### PR TITLE
feat(openid4vci): implement credential offer URI dereferencing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,10 +359,12 @@ version = "0.1.0"
 dependencies = [
  "color-eyre",
  "percent-encoding",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "time",
+ "tokio",
  "url",
  "uuid",
 ]

--- a/cloud-wallet-openid4vc/Cargo.toml
+++ b/cloud-wallet-openid4vc/Cargo.toml
@@ -13,3 +13,8 @@ uuid.workspace = true
 time.workspace = true
 url.workspace = true
 percent-encoding = "2"
+reqwest = { version = "0.13", features = ["json"] }
+tokio = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/cloud-wallet-openid4vc/src/errors.rs
+++ b/cloud-wallet-openid4vc/src/errors.rs
@@ -152,6 +152,10 @@ pub enum ErrorKind {
     #[error("Credential is revoked")]
     CredentialRevoked,
 
+    /// A network error occurred while fetching a resource.
+    #[error("Network error")]
+    NetworkError,
+
     /// An error that doesn't fit into any other category.
     #[error("Other error")]
     Other,

--- a/cloud-wallet-openid4vc/src/issuance/credential_offer.rs
+++ b/cloud-wallet-openid4vc/src/issuance/credential_offer.rs
@@ -346,6 +346,66 @@ impl CredentialOfferUri {
     pub fn from_query(query: &str) -> Result<Self, Error> {
         Self::from_offer_link(query)
     }
+
+    /// Resolves the credential offer, fetching it if passed by reference.
+    ///
+    /// - For `ByValue`, returns the contained `CredentialOffer` directly.
+    /// - For `ByReference`, fetches the JSON from the URI and parses it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The URI is not a valid HTTPS URL (for `ByReference`)
+    /// - The HTTP request fails (network error, non-success status)
+    /// - The response body is not valid JSON
+    /// - The JSON does not conform to the `CredentialOffer` structure
+    pub async fn resolve(&self) -> Result<CredentialOffer, Error> {
+        match &self.source {
+            CredentialOfferSource::ByValue(offer) => Ok(offer.clone()),
+            CredentialOfferSource::ByReference(uri) => {
+                // Validate URI scheme
+                let parsed_url = Url::parse(uri).map_err(|e| {
+                    Error::message(
+                        ErrorKind::InvalidCredentialOffer,
+                        format!("invalid credential_offer_uri: {e}"),
+                    )
+                })?;
+
+                if parsed_url.scheme() != "https" {
+                    return Err(Error::message(
+                        ErrorKind::InvalidCredentialOffer,
+                        "credential_offer_uri must use the https scheme",
+                    ));
+                }
+
+                // Fetch the credential offer from the URI
+                let response = reqwest::get(uri)
+                    .await
+                    .map_err(|e| Error::new(ErrorKind::NetworkError, e))?;
+
+                // Check for successful response
+                if !response.status().is_success() {
+                    return Err(Error::message(
+                        ErrorKind::NetworkError,
+                        format!(
+                            "failed to fetch credential offer: HTTP {}",
+                            response.status()
+                        ),
+                    ));
+                }
+
+                // Parse the JSON response
+                let offer = response.json::<CredentialOffer>().await.map_err(|e| {
+                    Error::message(
+                        ErrorKind::InvalidCredentialOffer,
+                        format!("failed to parse credential offer JSON: {e}"),
+                    )
+                })?;
+
+                Ok(offer)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -688,5 +748,53 @@ mod tests {
 
         let offer: CredentialOffer = serde_json::from_str(json).expect("Failed to deserialize");
         assert!(offer.validate().is_ok());
+    }
+
+    #[tokio::test]
+    async fn resolve_by_value_returns_offer() {
+        let offer = CredentialOffer {
+            credential_issuer: "https://issuer.example.com".to_string(),
+            credential_configuration_ids: vec!["MyCredential".to_string()],
+            grants: None,
+        };
+
+        let uri = CredentialOfferUri {
+            source: CredentialOfferSource::ByValue(offer.clone()),
+        };
+
+        let resolved = uri.resolve().await.expect("Failed to resolve");
+        assert_eq!(resolved.credential_issuer, offer.credential_issuer);
+        assert_eq!(
+            resolved.credential_configuration_ids,
+            offer.credential_configuration_ids
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_by_reference_rejects_http_uri() {
+        let uri = CredentialOfferUri {
+            source: CredentialOfferSource::ByReference(
+                "http://server.example.com/credential-offer/123".to_string(),
+            ),
+        };
+
+        let result = uri.resolve().await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidCredentialOffer);
+        assert!(err.to_string().contains("https scheme"));
+    }
+
+    #[tokio::test]
+    async fn resolve_by_reference_rejects_invalid_uri() {
+        let uri = CredentialOfferUri {
+            source: CredentialOfferSource::ByReference("not-a-valid-uri".to_string()),
+        };
+
+        let result = uri.resolve().await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidCredentialOffer);
+        assert!(err.to_string().contains("invalid credential_offer_uri"));
     }
 }


### PR DESCRIPTION
Add HTTP fetch capability to dereference credential_offer_uri URLs for credential offers passed by reference.

- Add reqwest dependency for async HTTP client
- Add NetworkError variant to ErrorKind
- Implement resolve() method on CredentialOfferUri
- Add tests for URI dereferencing

Closes #86