### PR TITLE
Fix race condition in AWS provider for cloud wallet KMS

### DIFF
--- a/cloud-wallet-kms/src/provider/aws.rs
+++ b/cloud-wallet-kms/src/provider/aws.rs
@@ -142,10 +142,37 @@ impl<S: Storage> AwsProvider<S> {
                         })?;
                         let key_id = key_metadata.key_id().to_string();
 
-                        // Create alias
-                        let alias_op = inner.client.create_alias().alias_name(&inner.master_alias);
-                        alias_op.target_key_id(&key_id).send().await?;
-                        key_id
+                        // Create alias — handle concurrent creation race
+                        let alias_result = inner
+                            .client
+                            .create_alias()
+                            .alias_name(&inner.master_alias)
+                            .target_key_id(&key_id)
+                            .send()
+                            .await;
+
+                        match alias_result {
+                            Ok(_) => key_id,
+                            Err(SdkError::ServiceError(err))
+                                if err.err().is_already_exists_exception() =>
+                            {
+                                // Another caller created the alias concurrently.
+                                // Re-fetch the actual key ID behind the alias.
+                                let output = inner
+                                    .client
+                                    .describe_key()
+                                    .key_id(&inner.master_alias)
+                                    .send()
+                                    .await?;
+                                let key_metadata = output.key_metadata().ok_or_else(|| {
+                                    Error::Provider(eyre!(
+                                        "No master key metadata in describe response after alias race"
+                                    ))
+                                })?;
+                                key_metadata.key_id().to_string()
+                            }
+                            Err(err) => return Err(Error::Provider(err.into())),
+                        }
                     }
                     Err(err) => return Err(Error::Provider(err.into())),
                 };


### PR DESCRIPTION
This pull request improves the robustness of the AWS KMS alias creation logic in the `AwsProvider` by handling potential race conditions when creating a new alias. The update ensures that if another process creates the alias concurrently, the correct key ID is still retrieved.

**AWS KMS alias creation improvements:**

* Updated the `AwsProvider`'s alias creation code in `aws.rs` to handle concurrent alias creation races by catching the "already exists" exception. If the alias already exists, the code now re-fetches the key ID behind the alias to ensure the correct key is used.…r/aws.rs