### PR TITLE
Feat/background issuance task token exchange credential request deferred polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,12 +617,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -697,7 +691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
  "async-stream",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "bollard-buildkit-proto",
  "bollard-stubs",
@@ -754,7 +748,7 @@ version = "1.52.1-rc.29.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bollard-buildkit-proto",
  "bytes",
  "prost",
@@ -863,17 +857,18 @@ dependencies = [
 name = "cloud-identity-wallet"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "cloud-wallet-crypto",
  "cloud-wallet-kms",
  "cloud-wallet-openid4vc",
  "color-eyre",
  "config",
  "dashmap",
+ "futures",
  "jsonwebtoken",
- "postcard",
  "rand 0.10.1",
  "redis",
  "reqwest",
@@ -942,7 +937,7 @@ dependencies = [
 name = "cloud-wallet-openid4vc"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "cloud-wallet-crypto",
  "color-eyre",
  "csscolorparser",
@@ -978,15 +973,6 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
-name = "cobs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
-dependencies = [
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "color-eyre"
@@ -1382,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1414,11 +1400,11 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
  "serde_json",
 ]
@@ -1449,18 +1435,6 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "embedded-io"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
-
-[[package]]
-name = "embedded-io"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -1914,7 +1888,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2074,7 +2048,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2405,7 +2379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -2753,15 +2727,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2785,9 +2758,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -2883,7 +2856,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -3080,18 +3053,6 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "postcard"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
-dependencies = [
- "cobs",
- "embedded-io 0.4.0",
- "embedded-io 0.6.1",
- "serde",
-]
 
 [[package]]
 name = "potential_utf"
@@ -3345,9 +3306,9 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redis"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44e94c96d8870a387d88ce3de3fdd608cbfc0705f03cb343cdde91509d3e49a"
+checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3461,7 +3422,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3909,11 +3870,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3928,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -3974,7 +3935,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4048,9 +4009,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -4121,7 +4082,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -4196,7 +4157,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "byteorder",
  "bytes",
@@ -4238,7 +4199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "byteorder",
  "crc",
@@ -4682,7 +4643,7 @@ checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "h2",
  "http 1.4.0",
@@ -4937,7 +4898,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "log",
  "percent-encoding",
  "rustls",
@@ -4952,7 +4913,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http 1.4.0",
  "httparse",
  "log",
@@ -5619,7 +5580,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
 dependencies = [
  "assert-json-diff",
- "base64 0.22.1",
+ "base64",
  "deadpool",
  "futures",
  "http 1.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,6 +869,7 @@ dependencies = [
  "dashmap",
  "futures",
  "jsonwebtoken",
+ "parking_lot",
  "rand 0.10.1",
  "redis",
  "reqwest",
@@ -4959,6 +4960,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,9 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 # Async utilities
 async-trait = "0.1"
+futures = "0.3"
 tokio = "1"
+tokio-stream = "0.1"
 
 # Error handling
 color-eyre = "0.6"
@@ -61,6 +63,7 @@ broken_intra_doc_links = "deny"
 invalid_html_tags = "deny"
 
 [dependencies]
+async-stream = "0.3"
 async-trait.workspace = true
 axum = { version = "0.8", features = ["macros"] }
 base64.workspace = true
@@ -70,14 +73,14 @@ cloud-wallet-openid4vc = { path = "cloud-wallet-openid4vc" }
 color-eyre.workspace = true
 config = "0.15"
 dashmap.workspace = true
+futures.workspace = true
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
-postcard = { version = "1", default-features = false, features = ["alloc"] }
 rand.workspace = true
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
-time = { workspace = true, features = ["serde"] }
+time = { workspace = true, features = ["formatting", "serde"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ config = "0.15"
 dashmap.workspace = true
 futures.workspace = true
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
+parking_lot = "0.12"
 rand.workspace = true
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
@@ -86,7 +87,7 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 url.workspace = true
-uuid = { workspace = true, features = ["serde", "v4"] }
+uuid = { workspace = true, features = ["serde", "v4", "v5"] }
 
 [dependencies.redis]
 version = "1.2"

--- a/cloud-wallet-openid4vc/src/issuance/client/mod.rs
+++ b/cloud-wallet-openid4vc/src/issuance/client/mod.rs
@@ -218,7 +218,8 @@ impl Oid4vciClient {
         let mut inner_client_builder = reqwest::Client::builder()
             .timeout(config.timeout)
             .tls_backend_rustls()
-            .https_only(true);
+            .https_only(true)
+            .tls_danger_accept_invalid_hostnames(config.accept_untrusted_hosts);
 
         if config.accept_untrusted_hosts {
             inner_client_builder = inner_client_builder.tls_danger_accept_invalid_certs(true);

--- a/cloud-wallet-openid4vc/src/issuance/client/mod.rs
+++ b/cloud-wallet-openid4vc/src/issuance/client/mod.rs
@@ -5,6 +5,7 @@ mod tests;
 
 // Public Re-exports
 pub use error::ClientError;
+use serde::{Deserialize, Serialize};
 pub use signer::{
     Algorithm, Claims as ProofClaims, CryptoSigner, Header as ProofHeader, ProofSigner,
 };
@@ -54,7 +55,7 @@ const FORM_ENCODED_HEADER: &str = "application/x-www-form-urlencoded";
 const JSON_HEADER: &str = "application/json";
 
 /// Fully resolved context from a single credential offer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolvedOfferContext {
     pub offer: CredentialOffer,
     pub issuer_metadata: CredentialIssuerMetadata,
@@ -63,14 +64,14 @@ pub struct ResolvedOfferContext {
 }
 
 /// Which grant type the orchestrator should use.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum GrantType {
     AuthorizationCode,
     PreAuthorizedCode,
 }
 
 /// Chosen issuance flow data after offer resolution.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum IssuanceFlow {
     AuthorizationCode {
         issuer_state: Option<String>,
@@ -105,14 +106,14 @@ impl IssuanceFlow {
 }
 
 /// Result of building the authorization URL.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthorizationUrlResult {
     pub authz_url: Url,
     pub pkce_verifier: String,
 }
 
 /// Parsed authorization callback outcome.
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum AuthorizationCallback {
     Success(AuthorizationResponse),
     Error(Oid4vciError<AuthzErrorResponse>),

--- a/cloud-wallet-openid4vc/src/issuance/client/mod.rs
+++ b/cloud-wallet-openid4vc/src/issuance/client/mod.rs
@@ -132,6 +132,8 @@ pub struct Config {
     pub user_agent: Option<String>,
     /// Accept untrusted hosts (testing only).
     pub accept_untrusted_hosts: bool,
+    /// Use system proxy configuration discovered by the HTTP client.
+    pub use_system_proxy: bool,
 }
 
 impl Config {
@@ -148,6 +150,7 @@ impl Config {
             timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECS),
             user_agent: None,
             accept_untrusted_hosts: false,
+            use_system_proxy: true,
         }
     }
 
@@ -172,6 +175,17 @@ impl Config {
     pub fn accept_untrusted_hosts(self, accept_untrusted_hosts: bool) -> Self {
         Self {
             accept_untrusted_hosts,
+            ..self
+        }
+    }
+
+    /// Enables or disables system proxy discovery.
+    ///
+    /// Disabling this is useful in tests and restricted runtime environments
+    /// where reading host networking configuration may fail during client setup.
+    pub fn use_system_proxy(self, use_system_proxy: bool) -> Self {
+        Self {
+            use_system_proxy,
             ..self
         }
     }
@@ -204,16 +218,23 @@ impl Oid4vciClient {
         let mut inner_client_builder = reqwest::Client::builder()
             .timeout(config.timeout)
             .tls_backend_rustls()
-            .tls_danger_accept_invalid_hostnames(config.accept_untrusted_hosts)
             .https_only(true);
+
+        if config.accept_untrusted_hosts {
+            inner_client_builder = inner_client_builder.tls_danger_accept_invalid_certs(true);
+        }
+
+        if !config.use_system_proxy {
+            inner_client_builder = inner_client_builder.no_proxy();
+        }
 
         if let Some(ref user_agent) = config.user_agent {
             inner_client_builder = inner_client_builder.user_agent(user_agent);
         }
 
-        let inner_client = inner_client_builder
-            .build()
-            .map_err(|e| ClientError::configuration(format!("failed to build HTTP client: {e}")))?;
+        let inner_client = inner_client_builder.build().map_err(|e| {
+            ClientError::configuration(format!("failed to build HTTP client: {e:?}"))
+        })?;
 
         let http_client = ClientBuilder::new(inner_client)
             .with(RetryTransientMiddleware::new_with_policy(retry_policy))

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,12 +7,15 @@ use redis::{
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc::UnboundedReceiver;
+use url::Url;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     pub server: ServerConfig,
     pub redis: RedisConfig,
     pub database: DatabaseConfig,
+    pub oid4vci: Oid4vciConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -28,8 +31,13 @@ pub struct RedisConfig {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct DatabaseConfig {
-    /// Database URL
     pub url: SecretString,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Oid4vciConfig {
+    pub client_id: String,
+    pub redirect_uri: Url,
 }
 
 impl RedisConfig {
@@ -37,16 +45,25 @@ impl RedisConfig {
     ///
     /// - To enable TLS, the URI must use the `rediss://` scheme.
     /// - To enable insecure TLS, the URI must use the `rediss://` scheme and end with `/#insecure`.
+    /// - To enable RESP3 protocol, the URI must contains the `protocol=resp3` query parameter.
     ///
     /// # Errors
     /// Returns an error if the connection cannot be established.
-    pub async fn start(&self) -> RedisResult<ConnectionManager> {
+    pub async fn start(
+        &self,
+    ) -> RedisResult<(ConnectionManager, UnboundedReceiver<redis::PushInfo>)> {
         let client = RedisClient::open(self.uri.expose_secret())?;
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
         let config = ConnectionManagerConfig::new()
             .set_number_of_retries(3)
             .set_response_timeout(Some(Duration::from_secs(30)))
-            .set_connection_timeout(Some(Duration::from_secs(30)));
-        client.get_connection_manager_with_config(config).await
+            .set_connection_timeout(Some(Duration::from_secs(30)))
+            .set_push_sender(tx)
+            .set_automatic_resubscription();
+
+        let manager = client.get_connection_manager_with_config(config).await?;
+        Ok((manager, rx))
     }
 }
 
@@ -82,8 +99,10 @@ impl Config {
         ConfigLib::builder()
             .set_default("server.host", "127.0.0.1")?
             .set_default("server.port", 3000)?
-            .set_default("redis.uri", "redis://127.0.0.1:6379")?
-            .set_default("database.url", "sqlite::memory:")
+            .set_default("redis.uri", "redis://127.0.0.1:6379?protocol=resp3")?
+            .set_default("database.url", "sqlite::memory:")?
+            .set_default("oid4vci.client_id", "cloud-identity-wallet")?
+            .set_default("oid4vci.redirect_uri", "http://localhost:3000/callback")
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,7 @@ pub struct DatabaseConfig {
 pub struct Oid4vciConfig {
     pub client_id: String,
     pub redirect_uri: Url,
+    pub use_system_proxy: bool,
 }
 
 impl RedisConfig {
@@ -102,7 +103,8 @@ impl Config {
             .set_default("redis.uri", "redis://127.0.0.1:6379?protocol=resp3")?
             .set_default("database.url", "sqlite::memory:")?
             .set_default("oid4vci.client_id", "cloud-identity-wallet")?
-            .set_default("oid4vci.redirect_uri", "http://localhost:3000/callback")
+            .set_default("oid4vci.redirect_uri", "http://localhost:3000/callback")?
+            .set_default("oid4vci.use_system_proxy", true)
     }
 }
 
@@ -117,7 +119,10 @@ mod tests {
 
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
+        assert_eq!(
+            config.redis.uri.expose_secret(),
+            "redis://127.0.0.1:6379?protocol=resp3"
+        );
     }
 
     #[test]
@@ -130,7 +135,10 @@ mod tests {
 
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.port, 443);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
+        assert_eq!(
+            config.redis.uri.expose_secret(),
+            "redis://127.0.0.1:6379?protocol=resp3"
+        );
     }
 
     #[test]
@@ -144,6 +152,9 @@ mod tests {
         assert_eq!(config.server.host, "192.168.1.1");
         // The other values should use default
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
+        assert_eq!(
+            config.redis.uri.expose_secret(),
+            "redis://127.0.0.1:6379?protocol=resp3"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,7 +117,7 @@ mod tests {
 
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379");
+        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
     }
 
     #[test]
@@ -130,7 +130,7 @@ mod tests {
 
         assert_eq!(config.server.host, "0.0.0.0");
         assert_eq!(config.server.port, 443);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379");
+        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
     }
 
     #[test]
@@ -144,6 +144,6 @@ mod tests {
         assert_eq!(config.server.host, "192.168.1.1");
         // The other values should use default
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379");
+        assert_eq!(config.redis.uri.expose_secret(), "redis://127.0.0.1:6379?protocol=resp3");
     }
 }

--- a/src/domain/models.rs
+++ b/src/domain/models.rs
@@ -1,4 +1,3 @@
-//! Domain models for the wallet.
-
 pub mod credential;
+pub mod issuance;
 pub mod tenants;

--- a/src/domain/models/issuance/error.rs
+++ b/src/domain/models/issuance/error.rs
@@ -1,0 +1,328 @@
+use std::borrow::Cow;
+use std::error::Error as StdError;
+use std::fmt;
+
+use cloud_wallet_openid4vc::issuance::client::ClientError;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::models::credential::CredentialError;
+use crate::domain::models::issuance::events::IssuanceStep;
+use crate::domain::models::tenants::TenantError;
+use crate::session::SessionError;
+
+type DynError = Box<dyn StdError + Send + Sync>;
+
+/// Machine-readable error codes exposed by issuance APIs and SSE failures.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssuanceErrorCode {
+    InvalidCredentialOffer,
+    IssuerMetadataFetchFailed,
+    AuthServerMetadataFetchFailed,
+    SessionNotFound,
+    InvalidSessionState,
+    InvalidTxCode,
+    InvalidRequest,
+    CredentialNotFound,
+    InternalError,
+    Cancelled,
+    External(Cow<'static, str>),
+}
+
+impl IssuanceErrorCode {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::InvalidCredentialOffer => "invalid_credential_offer",
+            Self::IssuerMetadataFetchFailed => "issuer_metadata_fetch_failed",
+            Self::AuthServerMetadataFetchFailed => "auth_server_metadata_fetch_failed",
+            Self::SessionNotFound => "session_not_found",
+            Self::InvalidSessionState => "invalid_session_state",
+            Self::InvalidTxCode => "invalid_tx_code",
+            Self::InvalidRequest => "invalid_request",
+            Self::CredentialNotFound => "credential_not_found",
+            Self::InternalError => "internal_error",
+            Self::Cancelled => "cancelled",
+            Self::External(code) => code.as_ref(),
+        }
+    }
+}
+
+impl fmt::Display for IssuanceErrorCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Error that can occur during credential issuance orchestration.
+#[derive(Debug, thiserror::Error)]
+#[error("{error}: {error_description:?}")]
+pub struct IssuanceError {
+    pub error: IssuanceErrorCode,
+    pub error_description: Option<String>,
+    pub step: IssuanceStep,
+    #[source]
+    pub source: Option<DynError>,
+}
+
+impl IssuanceError {
+    /// Create a new issuance error.
+    pub fn new(
+        error: IssuanceErrorCode,
+        error_description: impl Into<Option<String>>,
+        step: IssuanceStep,
+    ) -> Self {
+        Self {
+            error,
+            error_description: error_description.into(),
+            step,
+            source: None,
+        }
+    }
+
+    /// Attach a source error to this issuance error.
+    pub fn with_source(self, source: impl StdError + Send + Sync + 'static) -> Self {
+        Self {
+            source: Some(Box::new(source)),
+            ..self
+        }
+    }
+
+    /// Create an external error.
+    pub fn external(
+        step: IssuanceStep,
+        error: impl Into<Cow<'static, str>>,
+        error_description: Option<String>,
+    ) -> Self {
+        Self::new(
+            IssuanceErrorCode::External(error.into()),
+            error_description,
+            step,
+        )
+    }
+
+    /// Create an internal error with the given source.
+    pub fn internal(source: impl StdError + Send + Sync + 'static) -> Self {
+        let message = source.to_string();
+        Self::internal_message(message).with_source(source)
+    }
+
+    /// Create an internal error with a message.
+    pub fn internal_message(message: impl fmt::Display) -> Self {
+        Self::new(
+            IssuanceErrorCode::InternalError,
+            Some(message.to_string()),
+            IssuanceStep::Internal,
+        )
+    }
+
+    /// Create a cancel error with the given reason.
+    pub fn cancelled(reason: impl fmt::Display) -> Self {
+        Self::new(
+            IssuanceErrorCode::Cancelled,
+            Some(reason.to_string()),
+            IssuanceStep::Internal,
+        )
+    }
+
+    /// Create an offer resolution error with the given description.
+    pub fn offer_resolution(description: impl fmt::Display) -> Self {
+        Self::new(
+            IssuanceErrorCode::InvalidCredentialOffer,
+            Some(description.to_string()),
+            IssuanceStep::OfferResolution,
+        )
+    }
+
+    /// Create a metadata error with the given description.
+    pub fn metadata(description: impl fmt::Display) -> Self {
+        Self::new(
+            IssuanceErrorCode::IssuerMetadataFetchFailed,
+            Some(description.to_string()),
+            IssuanceStep::Metadata,
+        )
+    }
+
+    /// Create an authorization error with the given description.
+    pub fn token(description: impl fmt::Display) -> Self {
+        Self::external(
+            IssuanceStep::Token,
+            "token_error",
+            Some(description.to_string()),
+        )
+    }
+
+    /// Create a credential request error with the given description.
+    pub fn credential_request(description: impl fmt::Display) -> Self {
+        Self::external(
+            IssuanceStep::CredentialRequest,
+            "credential_request_failed",
+            Some(description.to_string()),
+        )
+    }
+
+    /// Create a deferred credential error with the given description.
+    pub fn deferred_credential(description: impl fmt::Display) -> Self {
+        Self::external(
+            IssuanceStep::DeferredCredential,
+            "deferred_credential_failed",
+            Some(description.to_string()),
+        )
+    }
+
+    /// Returns the issuance step this error corresponds to.
+    pub fn step(&self) -> IssuanceStep {
+        self.step
+    }
+
+    /// Returns the machine-readable error code for this error.
+    pub fn error(&self) -> &str {
+        self.error.as_str()
+    }
+
+    /// Returns the human-readable error details if any.
+    pub fn error_description(&self) -> Option<&str> {
+        self.error_description.as_deref()
+    }
+}
+
+fn oid4vci_error_code<T: Serialize>(error: &T) -> String {
+    serde_json::to_string(error)
+        .ok()
+        .unwrap_or_else(|| "external_error".to_owned())
+}
+
+impl From<ClientError> for IssuanceError {
+    fn from(err: ClientError) -> Self {
+        match err {
+            ClientError::Authorization(e) => Self::external(
+                IssuanceStep::Authorization,
+                oid4vci_error_code(&e.error),
+                e.error_description,
+            ),
+            ClientError::Token(e) => Self::external(
+                IssuanceStep::Token,
+                oid4vci_error_code(&e.error),
+                e.error_description,
+            ),
+            ClientError::Credential(e) => Self::external(
+                IssuanceStep::CredentialRequest,
+                oid4vci_error_code(&e.error),
+                e.error_description,
+            ),
+            ClientError::DeferredCredential(e) => Self::external(
+                IssuanceStep::DeferredCredential,
+                oid4vci_error_code(&e.error),
+                e.error_description,
+            ),
+            ClientError::Notification(e) => Self::external(
+                IssuanceStep::Notification,
+                oid4vci_error_code(&e.error),
+                e.error_description,
+            ),
+            ClientError::Validation { message } => Self::offer_resolution(message),
+            ClientError::UnknownCredentialConfiguration { id } => Self::external(
+                IssuanceStep::CredentialRequest,
+                "unknown_credential_configuration",
+                Some(format!("unknown credential configuration: {id}")),
+            ),
+            ClientError::NoSupportedGrantType => Self::offer_resolution(
+                "no supported grant type found in credential offer or issuer metadata",
+            ),
+            ClientError::MetadataDiscovery { message } => Self::metadata(message),
+            ClientError::Http {
+                message,
+                status,
+                body,
+                source,
+            } => {
+                let description = message
+                    .map(|m| m.to_string())
+                    .or(body)
+                    .or_else(|| status.map(|s| format!("HTTP {s}")))
+                    .unwrap_or_else(|| "external HTTP request failed".into());
+                let mut error = Self::new(
+                    IssuanceErrorCode::InternalError,
+                    Some(description),
+                    IssuanceStep::Internal,
+                );
+                error.source = source;
+                error
+            }
+            ClientError::InvalidResponse { message } => Self::internal_message(message),
+            ClientError::Configuration { message } => Self::internal_message(message),
+            ClientError::Internal { message } => Self::internal_message(message),
+        }
+    }
+}
+
+impl From<CredentialError> for IssuanceError {
+    fn from(err: CredentialError) -> Self {
+        Self::internal_message(format!("error while storing credential: {err}")).with_source(err)
+    }
+}
+
+impl From<SessionError> for IssuanceError {
+    fn from(err: SessionError) -> Self {
+        Self::internal_message(format!("error storing session: {err}")).with_source(err)
+    }
+}
+
+impl From<serde_json::Error> for IssuanceError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::internal_message(format!("error serializing/deserializing: {err}")).with_source(err)
+    }
+}
+
+impl From<TenantError> for IssuanceError {
+    fn from(err: TenantError) -> Self {
+        Self::internal_message(format!("error handling tenant: {err}")).with_source(err)
+    }
+}
+
+impl From<tokio::task::JoinError> for IssuanceError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        Self::internal_message(format!("error executing task: {err}")).with_source(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cloud_wallet_openid4vc::issuance::error::{AuthzErrorResponse, Oid4vciError};
+
+    use super::*;
+
+    #[test]
+    fn step_display_matches_enum() {
+        assert_eq!(IssuanceStep::OfferResolution.as_str(), "offer_resolution");
+        assert_eq!(IssuanceStep::Metadata.as_str(), "metadata");
+        assert_eq!(IssuanceStep::Authorization.as_str(), "authorization");
+        assert_eq!(IssuanceStep::Token.as_str(), "token");
+        assert_eq!(
+            IssuanceStep::CredentialRequest.as_str(),
+            "credential_request"
+        );
+        assert_eq!(
+            IssuanceStep::DeferredCredential.as_str(),
+            "deferred_credential"
+        );
+        assert_eq!(IssuanceStep::Internal.as_str(), "internal");
+    }
+
+    #[test]
+    fn authorization_error_maps_to_external_error() {
+        let authz_error =
+            ClientError::Authorization(Oid4vciError::new(AuthzErrorResponse::InvalidRequest));
+        let err: IssuanceError = authz_error.into();
+        // check that it is an external error
+        assert!(matches!(err.error, IssuanceErrorCode::External(_)));
+        assert_eq!(err.error(), "invalid_request");
+        assert_eq!(err.step(), IssuanceStep::Authorization);
+    }
+
+    #[test]
+    fn storage_error_maps_to_internal_error() {
+        let err: IssuanceError = CredentialError::Other("disk full".into()).into();
+        assert_eq!(err.error(), "internal_error");
+        assert_eq!(err.step(), IssuanceStep::Internal);
+    }
+}

--- a/src/domain/models/issuance/error.rs
+++ b/src/domain/models/issuance/error.rs
@@ -186,8 +186,9 @@ impl IssuanceError {
 }
 
 fn oid4vci_error_code<T: Serialize>(error: &T) -> String {
-    serde_json::to_string(error)
+    serde_json::to_value(error)
         .ok()
+        .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_else(|| "external_error".to_owned())
 }
 

--- a/src/domain/models/issuance/events.rs
+++ b/src/domain/models/issuance/events.rs
@@ -1,0 +1,336 @@
+use std::borrow::Cow;
+
+use axum::response::sse::Event as SseEvent;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// Represents the step in the issuance flow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IssuanceStep {
+    OfferResolution,
+    Metadata,
+    Authorization,
+    Token,
+    CredentialRequest,
+    DeferredCredential,
+    Notification,
+    Internal,
+}
+
+impl IssuanceStep {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OfferResolution => "offer_resolution",
+            Self::Metadata => "metadata",
+            Self::Authorization => "authorization",
+            Self::Token => "token",
+            Self::CredentialRequest => "credential_request",
+            Self::DeferredCredential => "deferred_credential",
+            Self::Notification => "notification",
+            Self::Internal => "internal",
+        }
+    }
+}
+
+impl std::fmt::Display for IssuanceStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A processing event emitted while the server is performing back-channel
+/// operations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SseProcessingEvent {
+    pub session_id: String,
+    pub state: ProcessingState,
+    pub step: ProcessingStep,
+}
+
+impl SseProcessingEvent {
+    pub fn new(session_id: impl Into<String>, step: ProcessingStep) -> Self {
+        let session_id: String = session_id.into();
+        debug!(session_id = %session_id, ?step, "emitting processing event");
+        Self {
+            session_id,
+            state: ProcessingState::Processing,
+            step,
+        }
+    }
+
+    /// Convert to an SSE event frame.
+    pub fn to_sse_event(&self) -> Result<SseEvent, axum::Error> {
+        SseEvent::default().event("processing").json_data(self)
+    }
+}
+
+/// The specific back-channel operation in progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessingStep {
+    /// Exchanging authorization/pre-authorized code for an access token.
+    ExchangingToken,
+    /// Calling the issuer's credential endpoint.
+    RequestingCredential,
+    /// Credential issuance is deferred; backend is polling.
+    AwaitingDeferredCredential,
+}
+
+impl ProcessingStep {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ExchangingToken => "exchanging_token",
+            Self::RequestingCredential => "requesting_credential",
+            Self::AwaitingDeferredCredential => "awaiting_deferred_credential",
+        }
+    }
+}
+
+impl std::fmt::Display for ProcessingStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<IssuanceStep> for ProcessingStep {
+    fn from(step: IssuanceStep) -> Self {
+        match step {
+            IssuanceStep::Token => Self::ExchangingToken,
+            IssuanceStep::CredentialRequest => Self::RequestingCredential,
+            IssuanceStep::DeferredCredential => Self::AwaitingDeferredCredential,
+            _ => Self::ExchangingToken,
+        }
+    }
+}
+
+/// Always `"processing"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProcessingState {
+    Processing,
+}
+
+/// A completed event, terminal success. Credentials were issued and stored.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SseCompletedEvent {
+    pub session_id: String,
+    pub state: CompletedState,
+    /// Internal wallet credential IDs (UUID) for the issued credentials.
+    pub credential_ids: Vec<String>,
+    /// `credential_configuration_id` values of the issued credentials.
+    pub credential_types: Vec<String>,
+}
+
+impl SseCompletedEvent {
+    pub fn new(
+        session_id: impl Into<String>,
+        credential_ids: impl Into<Vec<String>>,
+        credential_types: impl Into<Vec<String>>,
+    ) -> Self {
+        let session_id: String = session_id.into();
+        Self {
+            session_id: session_id.clone(),
+            state: CompletedState::Completed,
+            credential_ids: credential_ids.into(),
+            credential_types: credential_types.into(),
+        }
+    }
+
+    /// Convert to an SSE event frame.
+    pub fn to_sse_event(&self) -> Result<SseEvent, axum::Error> {
+        SseEvent::default().event("completed").json_data(self)
+    }
+}
+
+/// Always `"completed"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletedState {
+    Completed,
+}
+
+/// A failed event, terminal error. The session is discarded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SseFailedEvent {
+    pub session_id: String,
+    pub state: FailedState,
+    pub error: Cow<'static, str>,
+    pub error_description: Option<String>,
+    /// The phase at which the failure occurred.
+    pub step: IssuanceStep,
+}
+
+impl SseFailedEvent {
+    pub fn new(
+        session_id: impl Into<String>,
+        error: impl Into<Cow<'static, str>>,
+        error_description: Option<String>,
+        step: IssuanceStep,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            state: FailedState::Failed,
+            error: error.into(),
+            error_description,
+            step,
+        }
+    }
+
+    /// Convert to an SSE event frame.
+    pub fn to_sse_event(&self) -> Result<SseEvent, axum::Error> {
+        SseEvent::default().event("failed").json_data(self)
+    }
+}
+
+/// Always `"failed"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailedState {
+    Failed,
+}
+
+/// SSE events. Used as the payload sent through the SSE event dispatcher.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event_type", rename_all = "snake_case")]
+pub enum IssuanceEvent {
+    Processing(SseProcessingEvent),
+    Completed(SseCompletedEvent),
+    Failed(SseFailedEvent),
+}
+
+impl IssuanceEvent {
+    /// Returns the session ID for this event.
+    pub fn session_id(&self) -> &str {
+        match self {
+            Self::Processing(e) => &e.session_id,
+            Self::Completed(e) => &e.session_id,
+            Self::Failed(e) => &e.session_id,
+        }
+    }
+
+    /// Returns `true` if this is a terminal event (completed or failed).
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Completed(_) | Self::Failed(_))
+    }
+
+    /// Convert to an SSE event frame.
+    pub fn to_sse_event(&self) -> Result<SseEvent, axum::Error> {
+        match self {
+            Self::Processing(e) => e.to_sse_event(),
+            Self::Completed(e) => e.to_sse_event(),
+            Self::Failed(e) => e.to_sse_event(),
+        }
+    }
+
+    /// Serialize to a JSON vector for transport.
+    pub fn to_json(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize from a JSON vector.
+    pub fn from_json(json: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processing_event_serializes_correctly() {
+        let event = SseProcessingEvent::new("ses_test", ProcessingStep::ExchangingToken);
+        let json = serde_json::to_value(&event).unwrap();
+        let expected = serde_json::json!({
+            "session_id": "ses_test",
+            "state": "exchanging_token",
+            "step": "processing"
+        });
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn completed_event_serializes_correctly() {
+        let event = SseCompletedEvent::new(
+            "ses_test",
+            vec!["uuid-1".into()],
+            vec!["eu.europa.ec.eudi.pid.1".into()],
+        );
+        let json = serde_json::to_value(&event).unwrap();
+        let expected = serde_json::json!({
+            "session_id": "ses_test",
+            "state": "completed",
+            "credential_ids": ["uuid-1"],
+            "credential_types": ["eu.europa.ec.eudi.pid.1"]
+        });
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn failed_event_serializes_correctly() {
+        let event = SseFailedEvent::new(
+            "ses_test",
+            "access_denied",
+            Some("User denied authorization".into()),
+            IssuanceStep::Authorization,
+        );
+        let json = serde_json::to_value(&event).unwrap();
+        let expected = serde_json::json!({
+            "session_id": "ses_test",
+            "state": "failed",
+            "error": "access_denied",
+            "error_description": "User denied authorization",
+            "step": "authorization"
+        });
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn issuance_event_round_trip_json() {
+        let event = IssuanceEvent::Processing(SseProcessingEvent::new(
+            "ses_123",
+            ProcessingStep::RequestingCredential,
+        ));
+        let json = event.to_json().unwrap();
+        let parsed = IssuanceEvent::from_json(&json).unwrap();
+        assert_eq!(parsed.session_id(), "ses_123");
+        assert!(matches!(parsed, IssuanceEvent::Processing(_)));
+    }
+
+    #[test]
+    fn terminal_event_detection() {
+        let processing = IssuanceEvent::Processing(SseProcessingEvent::new(
+            "ses",
+            ProcessingStep::ExchangingToken,
+        ));
+        assert!(!processing.is_terminal());
+
+        let completed = IssuanceEvent::Completed(SseCompletedEvent::new("ses", vec![], vec![]));
+        assert!(completed.is_terminal());
+
+        let failed = IssuanceEvent::Failed(SseFailedEvent::new(
+            "ses",
+            "err",
+            None,
+            IssuanceStep::Internal,
+        ));
+        assert!(failed.is_terminal());
+    }
+
+    #[test]
+    fn sse_event_frame_serialization() {
+        let event = SseProcessingEvent::new("ses", ProcessingStep::ExchangingToken);
+        let _axum_event = event.to_sse_event().unwrap();
+        let json = serde_json::to_value(&event).unwrap();
+        let expected = serde_json::json!({
+            "event": "processing",
+            "data": {
+                "session_id": "ses",
+                "state": "processing",
+                "step": "exchanging_token"
+            }
+        });
+        assert_eq!(json, expected);
+    }
+}

--- a/src/domain/models/issuance/events.rs
+++ b/src/domain/models/issuance/events.rs
@@ -244,8 +244,8 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
         let expected = serde_json::json!({
             "session_id": "ses_test",
-            "state": "exchanging_token",
-            "step": "processing"
+            "state": "processing",
+            "step": "exchanging_token"
         });
         assert_eq!(json, expected);
     }
@@ -321,15 +321,14 @@ mod tests {
     #[test]
     fn sse_event_frame_serialization() {
         let event = SseProcessingEvent::new("ses", ProcessingStep::ExchangingToken);
+        // Verify that to_sse_event produces a valid SSE event frame
         let _axum_event = event.to_sse_event().unwrap();
+        // Verify the struct itself serializes with correct fields
         let json = serde_json::to_value(&event).unwrap();
         let expected = serde_json::json!({
-            "event": "processing",
-            "data": {
-                "session_id": "ses",
-                "state": "processing",
-                "step": "exchanging_token"
-            }
+            "session_id": "ses",
+            "state": "processing",
+            "step": "exchanging_token"
         });
         assert_eq!(json, expected);
     }

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -4,13 +4,11 @@ mod task;
 
 pub use error::{IssuanceError, IssuanceErrorCode};
 pub use events::*;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 pub use task::{IssuanceTask, TaskResult};
 
-type Result<T> = std::result::Result<T, IssuanceError>;
-
-use std::sync::Arc;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use cloud_wallet_openid4vc::issuance::client::{CryptoSigner, Oid4vciClient, ResolvedOfferContext};
 use cloud_wallet_openid4vc::issuance::credential_response::{
@@ -25,9 +23,14 @@ use crate::domain::models::credential::{Credential, CredentialFormat, Credential
 use crate::domain::models::tenants::SignAlgorithm;
 use crate::domain::ports::{CredentialRepo, IssuanceEventPublisher, IssuanceTaskQueue, TenantRepo};
 use crate::session::{IssuanceSession, IssuanceState, SessionStore, transition};
+use tokio::{sync::Notify, task::JoinHandle};
+
+type Result<T> = std::result::Result<T, IssuanceError>;
 
 /// Maximum number of deferred credential polling attempts.
 const MAX_DEFERRED_RETRIES: u32 = 60;
+const DEFAULT_WORKER_IDLE_SLEEP: Duration = Duration::from_millis(250);
+const DEFAULT_WORKER_ERROR_SLEEP: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +49,8 @@ pub struct IssuanceEngine {
     pub event_publisher: Arc<dyn IssuanceEventPublisher>,
     pub credential_repo: Arc<dyn CredentialRepo>,
     pub tenant_repo: Arc<dyn TenantRepo>,
+    workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
+    worker_notify: Arc<Notify>,
 }
 
 impl Clone for IssuanceEngine {
@@ -56,6 +61,8 @@ impl Clone for IssuanceEngine {
             event_publisher: Arc::clone(&self.event_publisher),
             credential_repo: Arc::clone(&self.credential_repo),
             tenant_repo: Arc::clone(&self.tenant_repo),
+            workers: Arc::clone(&self.workers),
+            worker_notify: Arc::clone(&self.worker_notify),
         }
     }
 }
@@ -72,56 +79,160 @@ impl std::fmt::Debug for IssuanceEngine {
                 "event_publisher",
                 &std::any::type_name::<dyn IssuanceEventPublisher>(),
             )
+            .field("worker_count", &self.worker_count())
             .finish()
     }
 }
 
 impl IssuanceEngine {
-    /// Create a new orchestrator with all required dependencies.
-    pub fn new<Q, P, C, T>(
+    /// Create a new orchestrator with all required dependencies and default workers.
+    ///
+    /// The default worker count is the machine's available parallelism.
+    pub fn new<Q, P, C, T, S>(
         client: Oid4vciClient,
         task_queue: Q,
         event_publisher: P,
         credential_repo: C,
         tenant_repo: T,
+        session_store: &S,
     ) -> Self
     where
         Q: IssuanceTaskQueue,
         P: IssuanceEventPublisher,
         C: CredentialRepo,
         T: TenantRepo,
+        S: SessionStore + Clone,
     {
-        Self {
+        Self::with_worker_count(
+            client,
+            task_queue,
+            event_publisher,
+            credential_repo,
+            tenant_repo,
+            session_store,
+            default_worker_count(),
+        )
+    }
+
+    /// Create a new orchestrator and override how many background workers it starts.
+    pub fn with_worker_count<Q, P, C, T, S>(
+        client: Oid4vciClient,
+        task_queue: Q,
+        event_publisher: P,
+        credential_repo: C,
+        tenant_repo: T,
+        session_store: &S,
+        worker_count: usize,
+    ) -> Self
+    where
+        Q: IssuanceTaskQueue,
+        P: IssuanceEventPublisher,
+        C: CredentialRepo,
+        T: TenantRepo,
+        S: SessionStore + Clone,
+    {
+        let engine = Self {
             client: Arc::new(client),
             task_queue: Arc::new(task_queue),
             event_publisher: Arc::new(event_publisher),
             credential_repo: Arc::new(credential_repo),
             tenant_repo: Arc::new(tenant_repo),
+            workers: Arc::default(),
+            worker_notify: Arc::new(Notify::new()),
+        };
+
+        engine.start_worker_count(session_store.clone(), worker_count)
+    }
+
+    /// Return the number of worker currently attached to this engine.
+    pub fn worker_count(&self) -> usize {
+        self.workers.lock().len()
+    }
+
+    /// Enqueue a task for background issuance.
+    ///
+    /// Handlers should call this once the session has been moved to `processing`.
+    /// The task is later claimed by a worker that will execute it.
+    #[instrument(skip_all, fields(session_id = %task.session_id, tenant_id = %task.tenant_id))]
+    pub async fn enqueue(&self, task: &IssuanceTask) -> Result<()> {
+        self.task_queue.push(task).await?;
+        self.worker_notify.notify_one();
+        Ok(())
+    }
+
+    fn start_worker_count<S: SessionStore + Clone>(
+        self,
+        session_store: S,
+        worker_count: usize,
+    ) -> Self {
+        let existing_workers = self.worker_count();
+        if existing_workers > 0 {
+            return self;
+        }
+
+        let handles = (0..worker_count.max(1))
+            .map(|_| self.spawn_worker(session_store.clone()))
+            .collect::<Vec<_>>();
+        self.workers.lock().extend(handles);
+        self
+    }
+
+    /// Spawn a worker loop.
+    fn spawn_worker<S: SessionStore + Clone>(&self, session_store: S) -> JoinHandle<()> {
+        let engine = self.clone();
+        tokio::spawn(async move {
+            loop {
+                match engine.process_next_task(&session_store).await {
+                    Ok(true) => {}
+                    Ok(false) => engine.wait_for_work().await,
+                    Err(error) => {
+                        error!(%error, "issuance worker iteration failed");
+                        tokio::time::sleep(DEFAULT_WORKER_ERROR_SLEEP).await;
+                    }
+                }
+            }
+        })
+    }
+
+    async fn wait_for_work(&self) {
+        tokio::select! {
+            _ = self.worker_notify.notified() => {}
+            _ = tokio::time::sleep(DEFAULT_WORKER_IDLE_SLEEP) => {}
         }
     }
 
-    /// Enqueue a task and spawn its execution.
+    /// Claim and process the next available queued task.
     ///
-    /// This is the single entry point for handlers. It:
-    /// 1. Pushes the task onto the queue
-    /// 2. Spawns a task in a background worker to execute it.
-    #[instrument(skip_all, fields(session_id = %task.session_id, tenant_id = %task.tenant_id))]
-    pub async fn enqueue_and_spawn<S: SessionStore + Clone>(
+    /// Returns `Ok(false)` when the queue has no available task.
+    async fn process_next_task<S: SessionStore>(&self, session_store: &S) -> Result<bool> {
+        let Some(task) = self.task_queue.pop().await? else {
+            return Ok(false);
+        };
+
+        self.process_queued_task(task, session_store).await?;
+        Ok(true)
+    }
+
+    /// Execute a task that was claimed from the queue and acknowledge it when terminal.
+    async fn process_queued_task<S: SessionStore>(
         &self,
         task: IssuanceTask,
         session_store: &S,
     ) -> Result<()> {
-        self.task_queue.push(&task).await?;
+        let session_id = task.session_id.clone();
+        let result = self.execute(&task, session_store).await;
 
-        let engine = self.clone();
-        let sessions = session_store.clone();
-
-        tokio::spawn(async move {
-            if let Err(error) = engine.execute(&task, &sessions).await {
-                error!(%error, session_id = %task.session_id, "issuance task failed");
+        if let Err(ack_err) = self.task_queue.ack(&task).await {
+            warn!(
+                error = %ack_err,
+                session_id = %session_id,
+                "failed to acknowledge issuance task"
+            );
+            if result.is_ok() {
+                return Err(ack_err);
             }
-        });
-        Ok(())
+        }
+        result
     }
 
     /// Execute the full issuance flow for a task.
@@ -134,12 +245,7 @@ impl IssuanceEngine {
     /// 4. SSE event emission
     ///
     /// On failure, emits a `failed` SSE event and removes the session.
-    /// Always acknowledges the task on the queue when done.
-    pub async fn execute<S: SessionStore>(
-        &self,
-        task: &IssuanceTask,
-        session_store: &S,
-    ) -> Result<()> {
+    async fn execute<S: SessionStore>(&self, task: &IssuanceTask, session_store: &S) -> Result<()> {
         let session_id = &task.session_id;
         let session: IssuanceSession =
             session_store
@@ -174,10 +280,6 @@ impl IssuanceEngine {
 
             // Remove terminal failed session.
             self.terminate_session(session_store, session_id).await.ok();
-        }
-
-        if let Err(ack_err) = self.task_queue.ack(task).await {
-            warn!(error = %ack_err, "failed to acknowledge issuance task");
         }
         result
     }
@@ -528,4 +630,142 @@ pub async fn transition_session<S: SessionStore>(
     transition(&mut session, new_state)?;
     session_store.upsert(session_id, &session).await?;
     Ok(())
+}
+
+fn default_worker_count() -> usize {
+    std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get)
+}
+
+#[cfg(test)]
+mod tests {
+    use parking_lot::Mutex;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use async_trait::async_trait;
+    use cloud_wallet_openid4vc::issuance::client::Config as Oid4vciClientConfig;
+    use url::Url;
+
+    use super::*;
+    use crate::outbound::{MemoryCredentialRepo, MemoryEventPublisher, MemoryTenantRepo};
+    use crate::session::MemorySession;
+
+    #[derive(Debug, Clone, Default)]
+    struct RecordingTaskQueue {
+        state: Arc<Mutex<RecordingTaskQueueState>>,
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingTaskQueueState {
+        next_id: u64,
+        queued: VecDeque<IssuanceTask>,
+        acked: Vec<IssuanceTask>,
+    }
+
+    impl RecordingTaskQueue {
+        fn acked(&self) -> Vec<IssuanceTask> {
+            self.state.lock().acked.clone()
+        }
+
+        fn queued_len(&self) -> usize {
+            self.state.lock().queued.len()
+        }
+    }
+
+    #[async_trait]
+    impl IssuanceTaskQueue for RecordingTaskQueue {
+        async fn push(&self, task: &IssuanceTask) -> Result<()> {
+            self.state.lock().queued.push_back(task.clone());
+            Ok(())
+        }
+
+        async fn pop(&self) -> Result<Option<IssuanceTask>> {
+            let mut state = self.state.lock();
+            let Some(mut task) = state.queued.pop_front() else {
+                return Ok(None);
+            };
+
+            state.next_id += 1;
+            task.queue_id = Some(format!("queue-{}", state.next_id));
+            Ok(Some(task))
+        }
+
+        async fn ack(&self, task: &IssuanceTask) -> Result<()> {
+            self.state.lock().acked.push(task.clone());
+            Ok(())
+        }
+    }
+
+    fn make_engine(queue: RecordingTaskQueue) -> IssuanceEngine {
+        let client = Oid4vciClient::new(Oid4vciClientConfig::new(
+            "test-client",
+            Url::parse("https://wallet.example.com/callback").unwrap(),
+        ))
+        .unwrap();
+
+        let sessions = MemorySession::default();
+
+        IssuanceEngine::with_worker_count(
+            client,
+            queue,
+            MemoryEventPublisher::new(16),
+            MemoryCredentialRepo::new(),
+            MemoryTenantRepo::new(),
+            &sessions,
+            1,
+        )
+    }
+
+    fn make_task(session_id: &str) -> IssuanceTask {
+        IssuanceTask {
+            queue_id: None,
+            session_id: session_id.to_owned(),
+            tenant_id: Uuid::new_v4(),
+            flow: FlowType::PreAuthorizedCode,
+            authorization_code: None,
+            pkce_verifier: None,
+            pre_authorized_code: Some("pre-auth-code".to_owned()),
+            tx_code: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_persists_work_without_acknowledging_it() {
+        let queue = RecordingTaskQueue::default();
+        let engine = make_engine(queue.clone());
+
+        engine.enqueue(&make_task("ses_enqueue")).await.unwrap();
+
+        assert_eq!(queue.queued_len(), 1);
+        assert!(queue.acked().is_empty());
+    }
+
+    #[tokio::test]
+    async fn processing_next_task_claims_and_acks_the_popped_task() {
+        let queue = RecordingTaskQueue::default();
+        let engine = make_engine(queue.clone());
+        let sessions = MemorySession::default();
+
+        engine.enqueue(&make_task("ses_missing")).await.unwrap();
+        let result = engine.process_next_task(&sessions).await;
+
+        assert!(result.is_err(), "missing session should fail terminally");
+        assert_eq!(queue.queued_len(), 0);
+
+        let acked = queue.acked();
+        assert_eq!(acked.len(), 1);
+        assert_eq!(acked[0].session_id, "ses_missing");
+        assert_eq!(acked[0].queue_id.as_deref(), Some("queue-1"));
+    }
+
+    #[tokio::test]
+    async fn processing_empty_queue_reports_no_work() {
+        let queue = RecordingTaskQueue::default();
+        let engine = make_engine(queue);
+        let sessions = MemorySession::default();
+
+        let processed = engine.process_next_task(&sessions).await.unwrap();
+
+        assert!(!processed);
+    }
 }

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -1,0 +1,523 @@
+mod error;
+mod events;
+mod task;
+
+pub use error::{IssuanceError, IssuanceErrorCode};
+pub use events::*;
+pub use task::{IssuanceTask, TaskResult};
+
+type Result<T> = std::result::Result<T, IssuanceError>;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use cloud_wallet_openid4vc::issuance::client::{CryptoSigner, Oid4vciClient, ResolvedOfferContext};
+use cloud_wallet_openid4vc::issuance::credential_response::{
+    CredentialResponse, DeferredCredentialResult, ImmediateCredentialResponse,
+};
+use cloud_wallet_openid4vc::issuance::notification::{NotificationEvent, NotificationRequest};
+use cloud_wallet_openid4vc::issuance::token_response::TokenResponse;
+use tracing::{debug, error, info, instrument, warn};
+use uuid::Uuid;
+
+use crate::domain::models::credential::{Credential, CredentialFormat, CredentialStatus};
+use crate::domain::models::tenants::SignAlgorithm;
+use crate::domain::ports::{CredentialRepo, IssuanceEventPublisher, IssuanceTaskQueue, TenantRepo};
+use crate::session::{FlowType, IssuanceSession, IssuanceState, SessionStore, transition};
+
+/// Maximum number of deferred credential polling attempts.
+const MAX_DEFERRED_RETRIES: u32 = 60;
+
+/// The issuance engine.
+///
+/// Holds shared references to all internal services.
+/// Designed to be cheaply cloneable (all fields are `Arc`).
+pub struct IssuanceEngine {
+    pub client: Arc<Oid4vciClient>,
+    pub task_queue: Arc<dyn IssuanceTaskQueue>,
+    pub event_publisher: Arc<dyn IssuanceEventPublisher>,
+    pub credential_repo: Arc<dyn CredentialRepo>,
+    pub tenant_repo: Arc<dyn TenantRepo>,
+}
+
+impl Clone for IssuanceEngine {
+    fn clone(&self) -> Self {
+        Self {
+            client: Arc::clone(&self.client),
+            task_queue: Arc::clone(&self.task_queue),
+            event_publisher: Arc::clone(&self.event_publisher),
+            credential_repo: Arc::clone(&self.credential_repo),
+            tenant_repo: Arc::clone(&self.tenant_repo),
+        }
+    }
+}
+
+impl std::fmt::Debug for IssuanceEngine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IssuanceEngine")
+            .field("client", &self.client)
+            .field(
+                "task_queue",
+                &std::any::type_name::<dyn IssuanceTaskQueue>(),
+            )
+            .field(
+                "event_publisher",
+                &std::any::type_name::<dyn IssuanceEventPublisher>(),
+            )
+            .finish()
+    }
+}
+
+impl IssuanceEngine {
+    /// Create a new orchestrator with all required dependencies.
+    pub fn new<Q, P, C, T>(
+        client: Oid4vciClient,
+        task_queue: Q,
+        event_publisher: P,
+        credential_repo: C,
+        tenant_repo: T,
+    ) -> Self
+    where
+        Q: IssuanceTaskQueue,
+        P: IssuanceEventPublisher,
+        C: CredentialRepo,
+        T: TenantRepo,
+    {
+        Self {
+            client: Arc::new(client),
+            task_queue: Arc::new(task_queue),
+            event_publisher: Arc::new(event_publisher),
+            credential_repo: Arc::new(credential_repo),
+            tenant_repo: Arc::new(tenant_repo),
+        }
+    }
+
+    /// Enqueue a task and spawn its execution.
+    ///
+    /// This is the single entry point for handlers. It:
+    /// 1. Pushes the task onto the queue
+    /// 2. Spawns a task in a background worker to execute it.
+    #[instrument(skip_all, fields(session_id = %task.session_id, tenant_id = %task.tenant_id))]
+    pub async fn enqueue_and_spawn<S: SessionStore + Clone>(
+        &self,
+        task: IssuanceTask,
+        session_store: &S,
+    ) -> Result<()> {
+        self.task_queue.push(&task).await?;
+
+        let engine = self.clone();
+        let sessions = session_store.clone();
+
+        tokio::spawn(async move {
+            if let Err(error) = engine.execute(&task, &sessions).await {
+                error!(%error, session_id = %task.session_id, "issuance task failed");
+            }
+        });
+        Ok(())
+    }
+
+    /// Execute the full issuance flow for a task.
+    ///
+    /// Loads the session from the store to obtain the offer context
+    /// and user selected configuration ids, then drives:
+    /// 1. Token exchange
+    /// 2. Credential request (with deferred polling)
+    /// 3. Credential storage
+    /// 4. SSE event emission
+    ///
+    /// On failure, emits a `failed` SSE event and removes the session.
+    /// Always acknowledges the task on the queue when done.
+    pub async fn execute<S: SessionStore>(
+        &self,
+        task: &IssuanceTask,
+        session_store: &S,
+    ) -> Result<()> {
+        let session_id = &task.session_id;
+        let session: IssuanceSession =
+            session_store
+                .get(session_id.as_str())
+                .await?
+                .ok_or_else(|| {
+                    IssuanceError::internal_message(format!("session {session_id} not found"))
+                })?;
+
+        let result = self
+            .execute_inner(
+                task,
+                session_store,
+                &session.context,
+                &session.selected_config_ids,
+            )
+            .await;
+
+        if let Err(ref err) = result {
+            error!(error = %err, step = %err.step(), "issuance failed");
+
+            // Emit failed SSE event
+            let failed = IssuanceEvent::Failed(SseFailedEvent::new(
+                session_id,
+                err.step().as_str(),
+                Some(err.to_string()),
+                err.step(),
+            ));
+            if let Err(pub_err) = self.event_publisher.publish(&failed).await {
+                warn!(error = %pub_err, "failed to publish failure event");
+            }
+
+            // Remove terminal failed session.
+            self.terminate_session(session_store, session_id).await.ok();
+        }
+
+        if let Err(ack_err) = self.task_queue.ack(task).await {
+            warn!(error = %ack_err, "failed to acknowledge issuance task");
+        }
+        result
+    }
+
+    async fn execute_inner<S: SessionStore>(
+        &self,
+        task: &IssuanceTask,
+        session_store: &S,
+        context: &ResolvedOfferContext,
+        selected_config_ids: &[String],
+    ) -> Result<()> {
+        let session_id = &task.session_id;
+        self.emit_processing(session_id, ProcessingStep::ExchangingToken)
+            .await;
+
+        let token_response = match task.flow {
+            FlowType::AuthorizationCode => {
+                let code = task
+                    .authorization_code
+                    .as_deref()
+                    .ok_or(IssuanceError::token("missing authorization_code"))?;
+                let verifier = task
+                    .pkce_verifier
+                    .as_deref()
+                    .ok_or(IssuanceError::token("missing pkce_verifier"))?;
+
+                self.client
+                    .exchange_authorization_code(context, code, verifier, selected_config_ids)
+                    .await?
+            }
+            FlowType::PreAuthorizedCode => {
+                let pre_code = task
+                    .pre_authorized_code
+                    .as_deref()
+                    .ok_or(IssuanceError::token("missing pre_authorized_code"))?;
+
+                self.client
+                    .exchange_pre_authorized_code(
+                        context,
+                        pre_code,
+                        task.tx_code.as_deref(),
+                        selected_config_ids,
+                    )
+                    .await?
+            }
+        };
+        debug!(session_id, tenant_id = %task.tenant_id, "token exchange successful");
+
+        let (credential_ids, credential_types, notification_ids) = self
+            .request_and_store_credentials(session_id, &token_response, task, context)
+            .await?;
+
+        let completed = IssuanceEvent::Completed(SseCompletedEvent::new(
+            session_id,
+            credential_ids,
+            credential_types,
+        ));
+        self.event_publisher.publish(&completed).await?;
+        self.terminate_session(session_store, session_id).await?;
+
+        // Best-effort notification: must not fail the flow.
+        self.send_notifications(context, &token_response.access_token, notification_ids)
+            .await;
+
+        info!(session_id, tenant_id = %task.tenant_id, "issuance completed successfully");
+        Ok(())
+    }
+
+    async fn request_and_store_credentials(
+        &self,
+        session_id: &str,
+        token: &TokenResponse,
+        task: &IssuanceTask,
+        context: &ResolvedOfferContext,
+    ) -> Result<(Vec<String>, Vec<String>, Vec<String>)> {
+        let signer = self.build_signer(task.tenant_id).await?;
+        self.emit_processing(session_id, ProcessingStep::RequestingCredential)
+            .await;
+
+        let responses = self
+            .client
+            .request_credentials(context, token, &signer)
+            .await?;
+
+        debug!(
+            session_id,
+            count = responses.len(),
+            "credential responses received"
+        );
+
+        let mut credential_ids = Vec::with_capacity(responses.len());
+        let mut credential_types = Vec::with_capacity(responses.len());
+        let mut notification_ids = Vec::with_capacity(responses.len());
+
+        for (idx, response) in responses.into_iter().enumerate() {
+            let config_id = context
+                .offer
+                .credential_configuration_ids
+                .get(idx)
+                .cloned()
+                .ok_or_else(|| IssuanceError::offer_resolution("malformed credential offer"))?;
+
+            match response {
+                CredentialResponse::Immediate(immediate) => {
+                    debug!(session_id, config_id, "immediate credential received");
+                    let notify_id = self
+                        .store_credentials(
+                            task.tenant_id,
+                            context,
+                            &config_id,
+                            immediate,
+                            &mut credential_ids,
+                            &mut credential_types,
+                        )
+                        .await?;
+                    notification_ids.extend(notify_id);
+                }
+                CredentialResponse::Deferred(pending) => {
+                    debug!(
+                        session_id,
+                        transaction_id = %pending.transaction_id,
+                        interval = pending.interval_seconds(),
+                        "deferred credential, starting polling"
+                    );
+
+                    self.emit_processing(session_id, ProcessingStep::AwaitingDeferredCredential)
+                        .await;
+
+                    let token = &token.access_token;
+                    let tx_id = pending.transaction_id.clone();
+                    let interval = pending.interval_seconds();
+                    let immediate = self
+                        .poll_deferred(context, token, tx_id, interval, session_id)
+                        .await?;
+
+                    let notify_id = self
+                        .store_credentials(
+                            task.tenant_id,
+                            context,
+                            &config_id,
+                            immediate,
+                            &mut credential_ids,
+                            &mut credential_types,
+                        )
+                        .await?;
+                    notification_ids.extend(notify_id);
+                }
+            }
+        }
+        Ok((credential_ids, credential_types, notification_ids))
+    }
+
+    /// Store all credentials from an immediate response.
+    ///
+    /// Returns the `notification_id` from the response if present.
+    async fn store_credentials(
+        &self,
+        tenant_id: Uuid,
+        context: &ResolvedOfferContext,
+        config_id: &str,
+        immediate: ImmediateCredentialResponse,
+        credential_ids: &mut Vec<String>,
+        credential_types: &mut Vec<String>,
+    ) -> Result<Option<String>> {
+        let notification_id = immediate.notification_id;
+        let issuer = context.offer.credential_issuer.as_str();
+        for cred_obj in immediate.credentials {
+            let raw = match cred_obj.credential {
+                serde_json::Value::String(s) => s,
+                _ => {
+                    return Err(IssuanceError::credential_request(
+                        "the received credential is not a string",
+                    ));
+                }
+            };
+            let cred_id = self
+                .store_credential(tenant_id, issuer, config_id, raw)
+                .await?;
+
+            credential_ids.push(cred_id.to_string());
+            credential_types.push(config_id.to_owned());
+        }
+        Ok(notification_id)
+    }
+
+    /// Poll the deferred credential endpoint.
+    #[instrument(skip(self, context, access_token))]
+    async fn poll_deferred(
+        &self,
+        context: &ResolvedOfferContext,
+        access_token: &str,
+        initial_tx_id: String,
+        initial_interval: u64,
+        session_id: &str,
+    ) -> Result<ImmediateCredentialResponse> {
+        let mut tx_id = initial_tx_id;
+        let mut interval_secs = initial_interval;
+
+        for attempt in 1..=MAX_DEFERRED_RETRIES {
+            let wait = Duration::from_secs(interval_secs);
+            debug!(
+                session_id,
+                attempt,
+                wait_secs = interval_secs,
+                transaction_id = %tx_id,
+                "waiting before deferred poll"
+            );
+            tokio::time::sleep(wait).await;
+
+            let result = self
+                .client
+                .poll_deferred_credential(context, access_token, &tx_id)
+                .await?;
+
+            match result {
+                DeferredCredentialResult::Ready(response) => {
+                    debug!(
+                        session_id,
+                        attempt,
+                        credentials = response.credentials.len(),
+                        "deferred credential ready"
+                    );
+                    return Ok(response);
+                }
+                DeferredCredentialResult::Pending(pending) => {
+                    debug!(
+                        session_id,
+                        attempt,
+                        new_transaction_id = %pending.transaction_id,
+                        new_interval = pending.interval_seconds(),
+                        "deferred credential still pending"
+                    );
+                    interval_secs = pending.interval_seconds();
+                    tx_id = pending.transaction_id;
+                }
+            }
+        }
+        Err(IssuanceError::deferred_credential(format!(
+            "credential not ready after {MAX_DEFERRED_RETRIES} polling attempts"
+        )))
+    }
+
+    /// Build a `CryptoSigner` from the tenant's stored key material.
+    #[instrument(skip(self))]
+    async fn build_signer(&self, tenant_id: Uuid) -> Result<CryptoSigner> {
+        let key = self.tenant_repo.find_key(tenant_id).await?;
+
+        let signer = tokio::task::spawn_blocking(move || {
+            let der = key.der_bytes.expose();
+            match key.algorithm {
+                SignAlgorithm::Ecdsa => CryptoSigner::from_ecdsa_der(der),
+                SignAlgorithm::EdDsa => CryptoSigner::from_ed25519_der(der),
+                SignAlgorithm::Rsa => CryptoSigner::from_rsa_der(der),
+            }
+        })
+        .await??;
+        Ok(signer)
+    }
+
+    /// Store a raw credential string.
+    #[instrument(skip(self, raw_credential))]
+    async fn store_credential(
+        &self,
+        tenant_id: Uuid,
+        issuer: &str,
+        credential_config_id: &str,
+        raw_credential: String,
+    ) -> Result<Uuid> {
+        // TODO : Parse the raw credential to extract the fields
+        let credential = Credential {
+            id: Uuid::new_v4(),
+            tenant_id,
+            issuer: issuer.to_owned(),
+            subject: None,
+            credential_types: vec![credential_config_id.to_owned()],
+            format: CredentialFormat::SdJwtVc,
+            external_id: None,
+            status: CredentialStatus::Active,
+            issued_at: time::UtcDateTime::now(),
+            valid_until: None,
+            is_revoked: false,
+            status_location: None,
+            status_index: None,
+            raw_credential,
+        };
+
+        let id = self.credential_repo.upsert(credential).await?;
+        info!(credential_id = %id, "credential stored successfully");
+        Ok(id)
+    }
+
+    /// Emit a processing SSE event (best-effort, non-fatal on failure).
+    async fn emit_processing(&self, session_id: &str, step: ProcessingStep) {
+        let event = IssuanceEvent::Processing(SseProcessingEvent::new(session_id, step));
+        if let Err(e) = self.event_publisher.publish(&event).await {
+            warn!(error = %e, "failed to publish processing event");
+        }
+    }
+
+    /// Send issuer notifications for accepted credentials (best-effort).
+    ///
+    /// If the issuer's metadata declares a `notification_endpoint`, this sends
+    /// a `credential_accepted` notification for each `notification_id` received
+    /// in the credential responses.
+    async fn send_notifications(
+        &self,
+        context: &ResolvedOfferContext,
+        access_token: &str,
+        notification_ids: Vec<String>,
+    ) {
+        let Some(endpoint) = context.issuer_metadata.notification_endpoint.as_ref() else {
+            return;
+        };
+        for id in notification_ids {
+            let req = NotificationRequest::new(id, NotificationEvent::CredentialAccepted);
+            if let Err(e) = self
+                .client
+                .send_notification(endpoint, access_token, &req)
+                .await
+            {
+                warn!(error = %e, "notification to issuer failed");
+            }
+        }
+    }
+
+    /// Remove a session from the session store.
+    #[inline]
+    async fn terminate_session<S: SessionStore>(
+        &self,
+        session_store: &S,
+        session_id: &str,
+    ) -> Result<()> {
+        session_store.remove(session_id).await?;
+        Ok(())
+    }
+}
+
+/// Transition a session's state.
+pub async fn transition_session<S: SessionStore>(
+    session_store: &S,
+    session_id: &str,
+    new_state: IssuanceState,
+) -> Result<()> {
+    let mut session: IssuanceSession = session_store.get(session_id).await?.ok_or_else(|| {
+        IssuanceError::internal_message(format!("session {session_id} not found"))
+    })?;
+
+    transition(&mut session, new_state)?;
+    session_store.upsert(session_id, &session).await?;
+    Ok(())
+}

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -4,6 +4,7 @@ mod task;
 
 pub use error::{IssuanceError, IssuanceErrorCode};
 pub use events::*;
+use serde::{Deserialize, Serialize};
 pub use task::{IssuanceTask, TaskResult};
 
 type Result<T> = std::result::Result<T, IssuanceError>;
@@ -23,10 +24,17 @@ use uuid::Uuid;
 use crate::domain::models::credential::{Credential, CredentialFormat, CredentialStatus};
 use crate::domain::models::tenants::SignAlgorithm;
 use crate::domain::ports::{CredentialRepo, IssuanceEventPublisher, IssuanceTaskQueue, TenantRepo};
-use crate::session::{FlowType, IssuanceSession, IssuanceState, SessionStore, transition};
+use crate::session::{IssuanceSession, IssuanceState, SessionStore, transition};
 
 /// Maximum number of deferred credential polling attempts.
 const MAX_DEFERRED_RETRIES: u32 = 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlowType {
+    AuthorizationCode,
+    PreAuthorizedCode,
+}
 
 /// The issuance engine.
 ///

--- a/src/domain/models/issuance/task.rs
+++ b/src/domain/models/issuance/task.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 use uuid::Uuid;
 
-use crate::domain::models::issuance::events::IssuanceStep;
-use crate::session::{FlowType, IssuanceSession};
+use crate::domain::models::issuance::{FlowType, events::IssuanceStep};
+use crate::session::IssuanceSession;
 
 /// A task representing a credential issuance job.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/domain/models/issuance/task.rs
+++ b/src/domain/models/issuance/task.rs
@@ -1,0 +1,177 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use uuid::Uuid;
+
+use crate::domain::models::issuance::events::IssuanceStep;
+use crate::session::{FlowType, IssuanceSession};
+
+/// A task representing a credential issuance job.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssuanceTask {
+    /// Adapter-owned queue entry ID, set when the task is popped from Redis Streams.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_id: Option<String>,
+    /// The session ID this task belongs to.
+    pub session_id: String,
+    /// The tenant ID requesting the credential.
+    pub tenant_id: Uuid,
+    /// The flow type (auth code or pre-auth code).
+    pub flow: FlowType,
+    /// Authorization code (for auth code flow).
+    pub authorization_code: Option<String>,
+    /// PKCE code verifier (for auth code flow).
+    pub pkce_verifier: Option<String>,
+    /// Pre-authorized code (for pre-auth flow).
+    pub pre_authorized_code: Option<String>,
+    /// Transaction code (for pre-auth flow, if required).
+    pub tx_code: Option<String>,
+}
+
+impl IssuanceTask {
+    /// Create a new issuance task for the authorization code flow.
+    pub fn new_authz_code(
+        session: &IssuanceSession,
+        authorization_code: impl Into<String>,
+        pkce_verifier: impl Into<String>,
+    ) -> Self {
+        info!(
+            session_id = %session.id,
+            tenant_id = %session.tenant_id,
+            "creating auth code issuance task"
+        );
+        Self {
+            queue_id: None,
+            session_id: session.id.clone(),
+            tenant_id: session.tenant_id,
+            flow: FlowType::AuthorizationCode,
+            authorization_code: Some(authorization_code.into()),
+            pkce_verifier: Some(pkce_verifier.into()),
+            pre_authorized_code: None,
+            tx_code: None,
+        }
+    }
+
+    /// Create a new issuance task for the pre-authorized code flow.
+    pub fn new_pre_authz_code(
+        session: &IssuanceSession,
+        pre_authorized_code: impl Into<String>,
+        tx_code: Option<String>,
+    ) -> Self {
+        info!(
+            session_id = %session.id,
+            tenant_id = %session.tenant_id,
+            "creating pre-auth issuance task"
+        );
+        Self {
+            queue_id: None,
+            session_id: session.id.clone(),
+            tenant_id: session.tenant_id,
+            flow: FlowType::PreAuthorizedCode,
+            authorization_code: None,
+            pkce_verifier: None,
+            pre_authorized_code: Some(pre_authorized_code.into()),
+            tx_code,
+        }
+    }
+
+    /// Create a new issuance task for pre-auth flow without tx_code (consent given).
+    pub fn new_pre_auth_no_tx_code(session: &IssuanceSession) -> Self {
+        info!(
+            session_id = %session.id,
+            tenant_id = %session.tenant_id,
+            "creating pre-auth issuance task (no tx_code)"
+        );
+        let offer = &session.context.offer;
+        let pre_auth = offer
+            .grants
+            .as_ref()
+            .and_then(|g| g.pre_authorized_code.as_ref());
+        let pre_authorized_code = pre_auth
+            .map(|g| g.pre_authorized_code.clone())
+            .unwrap_or_default();
+
+        Self {
+            queue_id: None,
+            session_id: session.id.clone(),
+            tenant_id: session.tenant_id,
+            flow: FlowType::PreAuthorizedCode,
+            authorization_code: None,
+            pkce_verifier: None,
+            pre_authorized_code: Some(pre_authorized_code),
+            tx_code: None,
+        }
+    }
+
+    /// Serialize the task to a JSON vector for storage.
+    pub fn to_json(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize a task from a JSON vector.
+    pub fn from_json(json: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(json)
+    }
+}
+
+/// Result of processing an issuance task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskResult {
+    /// Whether the task completed successfully.
+    pub success: bool,
+    /// The session ID this result belongs to.
+    pub session_id: String,
+    /// Credential IDs that were issued (if successful).
+    pub credential_ids: Vec<String>,
+    /// Credential types that were issued (if successful).
+    pub credential_types: Vec<String>,
+    /// Error message (if failed).
+    pub error: Option<Cow<'static, str>>,
+    /// Error step (if failed).
+    pub error_step: Option<Cow<'static, str>>,
+}
+
+impl TaskResult {
+    /// Create a successful task result.
+    pub fn success(
+        session_id: impl Into<String>,
+        credential_ids: Vec<String>,
+        credential_types: Vec<String>,
+    ) -> Self {
+        Self {
+            success: true,
+            session_id: session_id.into(),
+            credential_ids,
+            credential_types,
+            error: None,
+            error_step: None,
+        }
+    }
+
+    /// Create a failed task result.
+    pub fn failure(
+        session_id: impl Into<String>,
+        error: impl Into<Cow<'static, str>>,
+        step: IssuanceStep,
+    ) -> Self {
+        Self {
+            success: false,
+            session_id: session_id.into(),
+            credential_ids: vec![],
+            credential_types: vec![],
+            error: Some(error.into()),
+            error_step: Some(step.as_str().into()),
+        }
+    }
+
+    /// Serialize to JSON.
+    pub fn to_json(&self) -> Result<Vec<u8>, serde_json::Error> {
+        serde_json::to_vec(self)
+    }
+
+    /// Deserialize from JSON.
+    pub fn from_json(json: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(json)
+    }
+}

--- a/src/domain/ports.rs
+++ b/src/domain/ports.rs
@@ -49,19 +49,22 @@ pub type IssuanceEventStream = Pin<Box<dyn Stream<Item = IssuanceEvent> + Send>>
 
 /// An issuance task queue for background task processing.
 ///
-/// Implementations handle the internal mechanics of locking and crash resilience.
+/// Implementations handle the internal mechanics of locking, leasing, stale
+/// reclaim, and crash resilience.
 #[async_trait]
 pub trait IssuanceTaskQueue: Send + Sync + 'static {
     /// Push an issuance task onto the queue for background processing.
     async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError>;
 
-    /// Pop the next available task from the queue.
+    /// Claim the next available task from the queue.
     ///
-    /// Returns `None` if the queue is empty or the next task is already
-    /// locked by another worker.
+    /// Returned tasks are owned by the caller until they are acknowledged or
+    /// become stale according to the backend's reclaim policy. Returns `None`
+    /// if no task is currently available.
     async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError>;
 
-    /// Mark a previously popped task as processed and remove it from the queue.
+    /// Mark a previously claimed task as terminally processed and remove it
+    /// from the queue.
     ///
     /// Queue implementations should make this idempotent enough that calling it
     /// for a task that was not popped from that backend is a no-op.

--- a/src/domain/ports.rs
+++ b/src/domain/ports.rs
@@ -1,10 +1,14 @@
 /*
    This module specifies the API by which external modules interact with the wallet domain.
 */
+use std::pin::Pin;
+
 use async_trait::async_trait;
+use futures::stream::Stream;
 use uuid::Uuid;
 
 use crate::domain::models::credential::{Credential, CredentialError, CredentialFilter};
+use crate::domain::models::issuance::{IssuanceError, IssuanceEvent, IssuanceTask};
 use crate::domain::models::tenants::{
     RegisterTenantRequest, TenantError, TenantKey, TenantResponse,
 };
@@ -38,4 +42,45 @@ pub trait CredentialRepo: Send + Sync + 'static {
 
     /// Deletes a Credential by its ID and tenant ID.
     async fn delete(&self, id: Uuid, tenant_id: Uuid) -> Result<(), CredentialError>;
+}
+
+/// A pinned async stream of [`IssuanceEvent`] items.
+pub type IssuanceEventStream = Pin<Box<dyn Stream<Item = IssuanceEvent> + Send>>;
+
+/// An issuance task queue for background task processing.
+///
+/// Implementations handle the internal mechanics of locking and crash resilience.
+#[async_trait]
+pub trait IssuanceTaskQueue: Send + Sync + 'static {
+    /// Push an issuance task onto the queue for background processing.
+    async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError>;
+
+    /// Pop the next available task from the queue.
+    ///
+    /// Returns `None` if the queue is empty or the next task is already
+    /// locked by another worker.
+    async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError>;
+
+    /// Mark a previously popped task as processed and remove it from the queue.
+    ///
+    /// Queue implementations should make this idempotent enough that calling it
+    /// for a task that was not popped from that backend is a no-op.
+    async fn ack(&self, task: &IssuanceTask) -> Result<(), IssuanceError>;
+}
+
+/// An event publisher for issuance events.
+#[async_trait]
+pub trait IssuanceEventPublisher: Send + Sync + 'static {
+    /// Publish an issuance event for a session.
+    async fn publish(&self, event: &IssuanceEvent) -> Result<(), IssuanceError>;
+}
+
+/// A subscriber for issuance events.
+#[async_trait]
+pub trait IssuanceEventSubscriber: Send + Sync + 'static {
+    /// Subscribe to events for a specific session.
+    ///
+    /// Returns a stream that yields events as they are published.
+    /// The stream should auto-terminate after a terminal event.
+    async fn subscribe(&self, session_id: &str) -> Result<IssuanceEventStream, IssuanceError>;
 }

--- a/src/domain/service.rs
+++ b/src/domain/service.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::domain::models::issuance::IssuanceEngine;
 use crate::domain::ports::TenantRepo;
 use crate::session::SessionStore;
 
@@ -7,16 +8,15 @@ use crate::session::SessionStore;
 pub struct Service<S> {
     pub session: S,
     pub tenant_repo: Arc<dyn TenantRepo>,
+    pub issuance_engine: IssuanceEngine,
 }
 
-impl<S: SessionStore> Service<S>
-where
-    S: SessionStore,
-{
-    pub fn new<R: TenantRepo>(session: S, tenant_repo: R) -> Self {
+impl<S: SessionStore + Clone> Service<S> {
+    pub fn new<R: TenantRepo>(session: S, tenant_repo: R, issuance_engine: IssuanceEngine) -> Self {
         Self {
             session,
             tenant_repo: Arc::new(tenant_repo),
+            issuance_engine,
         }
     }
 }
@@ -26,6 +26,7 @@ impl<S> std::fmt::Debug for Service<S> {
         f.debug_struct("Service")
             .field("session", &std::any::type_name::<S>())
             .field("tenant_repo", &std::any::type_name::<dyn TenantRepo>())
+            .field("issuance_engine", &self.issuance_engine)
             .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,5 +3,6 @@ pub mod domain;
 pub mod outbound;
 pub mod server;
 pub mod session;
+pub mod setup;
 pub mod telemetry;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use cloud_identity_wallet::config::Config;
-use cloud_identity_wallet::domain::service::Service;
 use cloud_identity_wallet::outbound::MemoryTenantRepo;
 use cloud_identity_wallet::server::Server;
 use cloud_identity_wallet::session::MemorySession;
+use cloud_identity_wallet::setup;
 use cloud_identity_wallet::telemetry;
 
 #[cfg(not(target_env = "msvc"))]
@@ -18,14 +18,11 @@ async fn main() -> color_eyre::Result<()> {
     let config = Config::load()?;
     tracing::info!("Loaded configuration: {:?}", config);
 
-    // TODO: Replace with Redis session store when ready
+    // TODO: Replace these later on
     let session_store = MemorySession::default();
-
-    // TODO: Replace with actual database repository when ready
     let tenant_repo = MemoryTenantRepo::new();
 
-    // Create service and server
-    let service = Service::new(session_store, tenant_repo);
+    let service = setup::build_service(session_store, tenant_repo, &config)?;
     let server = Server::new(&config, service).await?;
     server.run().await
 }

--- a/src/outbound/event_dispatch.rs
+++ b/src/outbound/event_dispatch.rs
@@ -273,7 +273,7 @@ impl IssuanceEventSubscriber for MemoryEventSubscriber {
 type SseStream =
     Sse<KeepAliveStream<Pin<Box<dyn Stream<Item = Result<SseEvent, axum::Error>> + Send>>>>;
 
-/// Converts an [`IssuanceEventStream`] into an [`Sse`](axum::response::sse::Sse) response.
+/// Converts an [`IssuanceEventStream`] into an [`Sse`] response.
 pub fn event_stream_to_sse(stream: IssuanceEventStream) -> SseStream {
     use futures::StreamExt;
 

--- a/src/outbound/event_dispatch.rs
+++ b/src/outbound/event_dispatch.rs
@@ -1,0 +1,344 @@
+use std::pin::Pin;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::response::sse::{Event as SseEvent, KeepAlive, KeepAliveStream, Sse};
+use dashmap::DashMap;
+use futures::stream::Stream;
+use redis::{AsyncCommands, PushKind, aio::ConnectionManager};
+use time::UtcDateTime;
+use tokio::sync::{broadcast, mpsc::UnboundedReceiver};
+use tracing::warn;
+
+use crate::domain::models::issuance::{IssuanceError, IssuanceEvent};
+use crate::domain::ports::{IssuanceEventPublisher, IssuanceEventStream, IssuanceEventSubscriber};
+
+/// Redis-backed event publisher.
+#[derive(Debug, Clone)]
+pub struct RedisEventPublisher {
+    conn: ConnectionManager,
+}
+
+impl RedisEventPublisher {
+    /// Create a new publisher backed by the given Redis connection.
+    pub fn new(conn: ConnectionManager) -> Self {
+        Self { conn }
+    }
+}
+
+#[async_trait]
+impl IssuanceEventPublisher for RedisEventPublisher {
+    async fn publish(&self, event: &IssuanceEvent) -> Result<(), IssuanceError> {
+        let channel = format!("issuance:events:{}", event.session_id());
+        let json = event.to_json()?;
+        let mut conn = self.conn.clone();
+        let _: () = conn.publish(&channel, &json).await.map_err(map_redis_err)?;
+        Ok(())
+    }
+}
+
+type Dispatcher = DashMap<String, broadcast::Sender<IssuanceEvent>>;
+
+/// Redis-backed event subscriber.
+///
+/// The returned stream after subscription auto-terminates on `completed` or `failed` events.
+#[derive(Debug, Clone)]
+pub struct RedisEventSubscriber {
+    conn: ConnectionManager,
+    dispatcher: Arc<Dispatcher>,
+}
+
+impl RedisEventSubscriber {
+    /// Build with an already-configured [RESP3] `ConnectionManager`.
+    ///
+    /// The `ConnectionManagerConfig` must have `set_push_sender` set before
+    /// the manager is created, otherwise push messages will not be received.
+    ///
+    /// ```no_run
+    /// use redis::{Client, aio::ConnectionManagerConfig};
+    ///
+    /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    /// let config = ConnectionManagerConfig::new().set_push_sender(tx);
+    /// let client = Client::open("redis://127.0.0.1/?protocol=resp3")?;
+    /// let conn = client.get_connection_manager_with_config(config).await?;
+    ///
+    /// let subscriber = RedisEventSubscriber::new(conn, rx);
+    /// ```
+    ///
+    /// [RESP3]: https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md
+    pub fn new(conn: ConnectionManager, push_rx: UnboundedReceiver<redis::PushInfo>) -> Self {
+        let dispatcher = Arc::new(DashMap::new());
+        Self::spawn_router(dispatcher.clone(), push_rx);
+        Self { conn, dispatcher }
+    }
+
+    fn spawn_router(dispatcher: Arc<Dispatcher>, mut push_rx: UnboundedReceiver<redis::PushInfo>) {
+        tokio::spawn(async move {
+            while let Some(mut push) = push_rx.recv().await {
+                if !matches!(push.kind, PushKind::Message | PushKind::SMessage) {
+                    continue;
+                }
+                // data[0] = channel name, data[1] = payload
+                if push.data.len() < 2 {
+                    continue;
+                }
+
+                let data = std::mem::take(&mut push.data[1]);
+                let payload: Vec<u8> = match redis::from_redis_value(data) {
+                    Ok(value) => value,
+                    Err(err) => {
+                        warn!("failed to decode push payload: {err}");
+                        continue;
+                    }
+                };
+                let event = match IssuanceEvent::from_json(&payload) {
+                    Ok(event) => event,
+                    Err(err) => {
+                        warn!("failed to deserialize IssuanceEvent: {err}");
+                        continue;
+                    }
+                };
+
+                let session_id = event.session_id().to_owned();
+                let terminal = event.is_terminal();
+
+                if let Some(tx) = dispatcher.get(&*session_id) {
+                    let _ = tx.send(event);
+                } else {
+                    warn!(session_id = %session_id, "received event for unknown session");
+                }
+
+                // Remove after the terminal event is broadcast.
+                if terminal {
+                    dispatcher.remove(&*session_id);
+                }
+            }
+        });
+    }
+
+    pub async fn subscribe(&self, session_id: &str) -> Result<IssuanceEventStream, IssuanceError> {
+        let channel = format!("issuance:events:{session_id}");
+        let rx = self
+            .dispatcher
+            .entry(session_id.to_owned())
+            .or_insert_with(|| {
+                let (tx, _) = broadcast::channel(32);
+                tx
+            })
+            .subscribe();
+
+        let mut conn = self.conn.clone();
+        conn.subscribe(channel).await.map_err(map_redis_err)?;
+        Ok(self.build_stream(session_id.to_owned(), rx, conn))
+    }
+
+    fn build_stream(
+        &self,
+        session_id: String,
+        mut rx: broadcast::Receiver<IssuanceEvent>,
+        mut conn: ConnectionManager,
+    ) -> IssuanceEventStream {
+        Box::pin(async_stream::stream! {
+            let channel = format!("issuance:events:{session_id}");
+
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        let terminal = event.is_terminal();
+                        yield event;
+                        if terminal { break; }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+
+            // Always UNSUBSCRIBE when the stream ends, regardless of reason.
+            // Prevents accumulation of dead subscriptions on the server.
+            if let Err(e) = conn.unsubscribe(channel).await {
+                warn!(session_id = %session_id, "UNSUBSCRIBE failed: {e}");
+            }
+        })
+    }
+}
+
+#[async_trait]
+impl IssuanceEventSubscriber for RedisEventSubscriber {
+    async fn subscribe(&self, session_id: &str) -> Result<IssuanceEventStream, IssuanceError> {
+        self.subscribe(session_id).await
+    }
+}
+
+/// Maps a `redis::RedisError` into an `IssuanceError`.
+fn map_redis_err(err: redis::RedisError) -> IssuanceError {
+    IssuanceError::internal(err)
+}
+
+/// In-process event publisher.
+///
+/// Events are broadcast to all subscribers on the same channel.
+/// Suitable for single-instance deployments and testing.
+#[derive(Debug, Clone)]
+pub struct MemoryEventPublisher {
+    tx: broadcast::Sender<IssuanceEvent>,
+}
+
+impl MemoryEventPublisher {
+    /// Create a new publisher with the given channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Create a publisher from an existing broadcast sender.
+    ///
+    /// Use this to share the channel with a [`MemoryEventSubscriber`].
+    pub fn from_sender(tx: broadcast::Sender<IssuanceEvent>) -> Self {
+        Self { tx }
+    }
+
+    /// Returns the underlying sender for sharing with a subscriber.
+    pub fn sender(&self) -> &broadcast::Sender<IssuanceEvent> {
+        &self.tx
+    }
+}
+
+#[async_trait]
+impl IssuanceEventPublisher for MemoryEventPublisher {
+    async fn publish(&self, event: &IssuanceEvent) -> Result<(), IssuanceError> {
+        let _ = self.tx.send(event.clone());
+        Ok(())
+    }
+}
+
+/// In-process event subscriber backed by `tokio::sync::broadcast`.
+///
+/// Subscribes to the shared broadcast channel and filters events by
+/// session ID. Auto-terminates on terminal events.
+#[derive(Debug, Clone)]
+pub struct MemoryEventSubscriber {
+    tx: broadcast::Sender<IssuanceEvent>,
+}
+
+impl MemoryEventSubscriber {
+    /// Create a new subscriber sharing the channel with the given publisher.
+    pub fn new(publisher: &MemoryEventPublisher) -> Self {
+        Self {
+            tx: publisher.sender().clone(),
+        }
+    }
+
+    /// Create a subscriber from an existing broadcast sender.
+    pub fn from_sender(tx: broadcast::Sender<IssuanceEvent>) -> Self {
+        Self { tx }
+    }
+}
+
+#[async_trait]
+impl IssuanceEventSubscriber for MemoryEventSubscriber {
+    async fn subscribe(&self, session_id: &str) -> Result<IssuanceEventStream, IssuanceError> {
+        let mut rx = self.tx.subscribe();
+        let session_id = session_id.to_owned();
+
+        let stream = async_stream::stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        // Only yield events for the requested session
+                        if event.session_id() != session_id {
+                            continue;
+                        }
+                        let is_terminal = event.is_terminal();
+                        yield event;
+                        if is_terminal {
+                            break;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(n, "SSE subscriber lagged, dropping events");
+                        continue;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+type SseStream =
+    Sse<KeepAliveStream<Pin<Box<dyn Stream<Item = Result<SseEvent, axum::Error>> + Send>>>>;
+
+/// Converts an [`IssuanceEventStream`] into an [`Sse`](axum::response::sse::Sse) response.
+pub fn event_stream_to_sse(stream: IssuanceEventStream) -> SseStream {
+    use futures::StreamExt;
+
+    let id = UtcDateTime::now().unix_timestamp_nanos();
+    let sse_stream = stream.map(move |event| event.to_sse_event().map(|e| e.id(id.to_string())));
+    let boxed_stream: Pin<Box<dyn Stream<Item = Result<SseEvent, axum::Error>> + Send>> =
+        Box::pin(sse_stream);
+    Sse::new(boxed_stream).keep_alive(KeepAlive::default())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::models::issuance::{ProcessingStep, SseCompletedEvent, SseProcessingEvent};
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn memory_publish_subscribe_round_trip() {
+        let publisher = MemoryEventPublisher::new(16);
+        let subscriber = MemoryEventSubscriber::new(&publisher);
+
+        let mut stream = subscriber.subscribe("ses_1").await.unwrap();
+
+        // Publish events
+        let processing = IssuanceEvent::Processing(SseProcessingEvent::new(
+            "ses_1",
+            ProcessingStep::ExchangingToken,
+        ));
+        let completed = IssuanceEvent::Completed(SseCompletedEvent::new(
+            "ses_1",
+            vec!["id1".into()],
+            vec!["type1".into()],
+        ));
+
+        publisher.publish(&processing).await.unwrap();
+        publisher.publish(&completed).await.unwrap();
+
+        // Read events from stream
+        let e1 = stream.next().await.unwrap();
+        assert!(matches!(e1, IssuanceEvent::Processing(_)));
+
+        let e2 = stream.next().await.unwrap();
+        assert!(matches!(e2, IssuanceEvent::Completed(_)));
+
+        // Stream should terminate after terminal event
+        assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_subscriber_filters_by_session() {
+        let publisher = MemoryEventPublisher::new(16);
+        let subscriber = MemoryEventSubscriber::new(&publisher);
+
+        let mut stream = subscriber.subscribe("ses_1").await.unwrap();
+
+        // Publish event for a different session
+        let other = IssuanceEvent::Processing(SseProcessingEvent::new(
+            "ses_OTHER",
+            ProcessingStep::ExchangingToken,
+        ));
+        publisher.publish(&other).await.unwrap();
+
+        // Publish terminal event for our session
+        let completed = IssuanceEvent::Completed(SseCompletedEvent::new("ses_1", vec![], vec![]));
+        publisher.publish(&completed).await.unwrap();
+
+        // Should only receive the completed event (not the other session's event)
+        let e1 = stream.next().await.unwrap();
+        assert!(matches!(e1, IssuanceEvent::Completed(_)));
+        assert_eq!(e1.session_id(), "ses_1");
+    }
+}

--- a/src/outbound/event_dispatch.rs
+++ b/src/outbound/event_dispatch.rs
@@ -55,6 +55,8 @@ impl RedisEventSubscriber {
     /// the manager is created, otherwise push messages will not be received.
     ///
     /// ```no_run
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    /// use cloud_identity_wallet::outbound::RedisEventSubscriber;
     /// use redis::{Client, aio::ConnectionManagerConfig};
     ///
     /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
@@ -62,7 +64,9 @@ impl RedisEventSubscriber {
     /// let client = Client::open("redis://127.0.0.1/?protocol=resp3")?;
     /// let conn = client.get_connection_manager_with_config(config).await?;
     ///
-    /// let subscriber = RedisEventSubscriber::new(conn, rx);
+    /// let _subscriber = RedisEventSubscriber::new(conn, rx);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [RESP3]: https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md

--- a/src/outbound/event_dispatch.rs
+++ b/src/outbound/event_dispatch.rs
@@ -277,8 +277,11 @@ type SseStream =
 pub fn event_stream_to_sse(stream: IssuanceEventStream) -> SseStream {
     use futures::StreamExt;
 
-    let id = UtcDateTime::now().unix_timestamp_nanos();
-    let sse_stream = stream.map(move |event| event.to_sse_event().map(|e| e.id(id.to_string())));
+    let sse_stream = stream.map(move |event| {
+        event
+            .to_sse_event()
+            .map(|e| e.id(UtcDateTime::now().unix_timestamp_nanos().to_string()))
+    });
     let boxed_stream: Pin<Box<dyn Stream<Item = Result<SseEvent, axum::Error>> + Send>> =
         Box::pin(sse_stream);
     Sse::new(boxed_stream).keep_alive(KeepAlive::default())

--- a/src/outbound/mod.rs
+++ b/src/outbound/mod.rs
@@ -4,9 +4,16 @@
 */
 
 mod credential;
+mod event_dispatch;
+mod task_queue;
 mod tenant;
 
 pub use credential::{MemoryCredentialRepo, SqlCredentialRepo};
+pub use event_dispatch::{
+    MemoryEventPublisher, MemoryEventSubscriber, RedisEventPublisher, RedisEventSubscriber,
+    event_stream_to_sse,
+};
+pub use task_queue::{MemoryTaskQueue, RedisTaskQueue};
 pub use tenant::{MemoryTenantRepo, SqlTenantRepo, TenantKeyAlg};
 
 mod cipher {

--- a/src/outbound/task_queue.rs
+++ b/src/outbound/task_queue.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -27,6 +28,7 @@ pub struct RedisTaskQueue {
     consumer: String,
     max_len: usize,
     claim_idle_timeout: Duration,
+    group_ready: Arc<AtomicBool>,
 }
 
 impl RedisTaskQueue {
@@ -38,6 +40,7 @@ impl RedisTaskQueue {
             consumer: default_consumer_name(),
             max_len: DEFAULT_STREAM_MAX_LEN,
             claim_idle_timeout: DEFAULT_CLAIM_IDLE_TIMEOUT,
+            group_ready: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -76,14 +79,24 @@ impl RedisTaskQueue {
 
     // Ensure the consumer group exists for the task stream
     async fn ensure_group(&self) -> Result<(), IssuanceError> {
+        if self.group_ready.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
         let mut conn = self.conn.clone();
         let result: redis::RedisResult<()> = conn
             .xgroup_create_mkstream(TASK_STREAM_KEY, self.group, "0")
             .await;
 
         match result {
-            Ok(()) => Ok(()),
-            Err(e) if e.code() == Some("BUSYGROUP") => Ok(()),
+            Ok(()) => {
+                self.group_ready.store(true, Ordering::Relaxed);
+                Ok(())
+            }
+            Err(e) if e.code() == Some("BUSYGROUP") => {
+                self.group_ready.store(true, Ordering::Relaxed);
+                Ok(())
+            }
             Err(e) => Err(map_redis_err(e)),
         }
     }

--- a/src/outbound/task_queue.rs
+++ b/src/outbound/task_queue.rs
@@ -1,0 +1,319 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use redis::streams::{
+    StreamAddOptions, StreamAutoClaimOptions, StreamId, StreamReadOptions, StreamReadReply,
+    StreamTrimStrategy, StreamTrimmingMode,
+};
+use redis::{AsyncCommands, Value, aio::ConnectionManager};
+
+use crate::domain::models::issuance::{IssuanceError, IssuanceTask};
+use crate::domain::ports::IssuanceTaskQueue;
+
+/// Key for the issuance task queue stream in Redis.
+const TASK_STREAM_KEY: &str = "issuance:task_stream";
+const TASK_STREAM_GROUP: &str = "issuance-workers";
+const TASK_STREAM_PAYLOAD_FIELD: &str = "payload";
+const DEFAULT_STREAM_MAX_LEN: usize = 10_000;
+const DEFAULT_CLAIM_IDLE_TIMEOUT: Duration = Duration::from_mins(5);
+
+/// Redis-backed distributed task queue.
+#[derive(Debug, Clone)]
+pub struct RedisTaskQueue {
+    conn: ConnectionManager,
+    group: &'static str,
+    consumer: String,
+    max_len: usize,
+    claim_idle_timeout: Duration,
+}
+
+impl RedisTaskQueue {
+    /// Create a new task queue with a Redis connection manager.
+    pub fn new(conn: ConnectionManager) -> Self {
+        Self {
+            conn,
+            group: TASK_STREAM_GROUP,
+            consumer: default_consumer_name(),
+            max_len: DEFAULT_STREAM_MAX_LEN,
+            claim_idle_timeout: DEFAULT_CLAIM_IDLE_TIMEOUT,
+        }
+    }
+
+    /// Override the Redis consumer group name.
+    ///
+    /// The default value is "issuance-workers"
+    pub fn with_group(self, group: &'static str) -> Self {
+        Self { group, ..self }
+    }
+
+    /// Override the Redis consumer name for this worker.
+    pub fn with_consumer(self, consumer: impl Into<String>) -> Self {
+        Self {
+            consumer: consumer.into(),
+            ..self
+        }
+    }
+
+    /// Cap the stream length during stream insertion.
+    pub fn with_max_len(self, max_len: usize) -> Self {
+        Self {
+            max_len: max_len.max(1),
+            ..self
+        }
+    }
+
+    /// Override how long a pending task must be idle before this worker may reclaim it.
+    ///
+    /// The default value is 5 minutes.
+    pub fn with_claim_idle_timeout(self, timeout: Duration) -> Self {
+        Self {
+            claim_idle_timeout: timeout,
+            ..self
+        }
+    }
+
+    // Ensure the consumer group exists for the task stream
+    async fn ensure_group(&self) -> Result<(), IssuanceError> {
+        let mut conn = self.conn.clone();
+        let result: redis::RedisResult<()> = conn
+            .xgroup_create_mkstream(TASK_STREAM_KEY, self.group, "0")
+            .await;
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(e) if e.code() == Some("BUSYGROUP") => Ok(()),
+            Err(e) => Err(map_redis_err(e)),
+        }
+    }
+
+    /// Claim any stale tasks that are still in the stream
+    async fn claim_stale_task(&self) -> Result<Option<IssuanceTask>, IssuanceError> {
+        let min_idle_ms = self.claim_idle_timeout.as_millis().min(usize::MAX as u128) as usize;
+        let options = StreamAutoClaimOptions::default().count(1);
+        let mut conn = self.conn.clone();
+        let reply: redis::streams::StreamAutoClaimReply = conn
+            .xautoclaim_options(
+                TASK_STREAM_KEY,
+                self.group,
+                self.consumer.as_str(),
+                min_idle_ms,
+                "0-0",
+                options,
+            )
+            .await
+            .map_err(map_redis_err)?;
+
+        let Some(entry) = reply.claimed.first() else {
+            return Ok(None);
+        };
+        Ok(Some(task_from_stream_entry(entry)?))
+    }
+}
+
+#[async_trait]
+impl IssuanceTaskQueue for RedisTaskQueue {
+    async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError> {
+        let json = task.to_json()?;
+
+        self.ensure_group().await?;
+        let mut conn = self.conn.clone();
+        let options = StreamAddOptions::default().trim(StreamTrimStrategy::maxlen(
+            StreamTrimmingMode::Approx,
+            self.max_len,
+        ));
+        let _: Option<String> = conn
+            .xadd_options(
+                TASK_STREAM_KEY,
+                "*",
+                &[(TASK_STREAM_PAYLOAD_FIELD, json)],
+                &options,
+            )
+            .await
+            .map_err(map_redis_err)?;
+        Ok(())
+    }
+
+    async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError> {
+        self.ensure_group().await?;
+
+        // First, try to claim any stale tasks that are still in the stream
+        if let Some(task) = self.claim_stale_task().await? {
+            return Ok(Some(task));
+        }
+
+        let mut conn = self.conn.clone();
+        let options = StreamReadOptions::default()
+            .group(self.group, self.consumer.as_str())
+            .count(1);
+
+        let reply: Option<StreamReadReply> = conn
+            .xread_options(&[TASK_STREAM_KEY], &[">"], &options)
+            .await
+            .map_err(map_redis_err)?;
+
+        let Some(reply) = reply else {
+            return Ok(None);
+        };
+        let Some(stream) = reply.keys.first() else {
+            return Ok(None);
+        };
+        let Some(entry) = stream.ids.first() else {
+            return Ok(None);
+        };
+        Ok(Some(task_from_stream_entry(entry)?))
+    }
+
+    async fn ack(&self, task: &IssuanceTask) -> Result<(), IssuanceError> {
+        let Some(queue_id) = task.queue_id.as_deref() else {
+            return Ok(());
+        };
+
+        let mut conn = self.conn.clone();
+        let _: usize = conn
+            .xack(TASK_STREAM_KEY, self.group, &[queue_id])
+            .await
+            .map_err(map_redis_err)?;
+        let _: usize = conn
+            .xdel(TASK_STREAM_KEY, &[queue_id])
+            .await
+            .map_err(map_redis_err)?;
+        Ok(())
+    }
+}
+
+fn default_consumer_name() -> String {
+    format!("worker-{}-{}", std::process::id(), uuid::Uuid::new_v4())
+}
+
+fn task_from_stream_entry(entry: &StreamId) -> Result<IssuanceTask, IssuanceError> {
+    let Some(payload) = entry.map.get(TASK_STREAM_PAYLOAD_FIELD) else {
+        return Err(IssuanceError::internal_message(
+            "Redis stream task entry is missing payload",
+        ));
+    };
+
+    let bytes = payload_bytes(payload)?;
+    let mut task = IssuanceTask::from_json(bytes)?;
+    task.queue_id = Some(entry.id.clone());
+    Ok(task)
+}
+
+fn payload_bytes(value: &Value) -> Result<&[u8], IssuanceError> {
+    match value {
+        Value::BulkString(bytes) => Ok(bytes),
+        Value::SimpleString(value) => Ok(value.as_bytes()),
+        other => Err(IssuanceError::internal_message(format!(
+            "Redis stream task payload has unexpected type: {other:?}"
+        ))),
+    }
+}
+
+/// Maps a `redis::RedisError` into an `IssuanceError`.
+fn map_redis_err(err: redis::RedisError) -> IssuanceError {
+    IssuanceError::internal(err)
+}
+
+/// In-memory task queue mainly designed for testing and development.
+#[derive(Debug)]
+pub struct MemoryTaskQueue {
+    queue: Mutex<VecDeque<IssuanceTask>>,
+}
+
+impl MemoryTaskQueue {
+    /// Create a new empty in-memory task queue.
+    pub fn new() -> Self {
+        Self {
+            queue: Mutex::new(VecDeque::new()),
+        }
+    }
+}
+
+impl Default for MemoryTaskQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl IssuanceTaskQueue for MemoryTaskQueue {
+    async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError> {
+        let mut queue = self.queue.lock().expect("lock poisoned");
+        queue.push_back(task.clone());
+        Ok(())
+    }
+
+    async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError> {
+        let task = {
+            let mut queue = self.queue.lock().expect("lock poisoned");
+            queue.pop_front()
+        };
+
+        let Some(task) = task else {
+            return Ok(None);
+        };
+        Ok(Some(task))
+    }
+
+    async fn ack(&self, _task: &IssuanceTask) -> Result<(), IssuanceError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::FlowType;
+    use uuid::Uuid;
+
+    fn make_task(session_id: &str) -> IssuanceTask {
+        IssuanceTask {
+            queue_id: None,
+            session_id: session_id.to_owned(),
+            tenant_id: Uuid::new_v4(),
+            flow: FlowType::PreAuthorizedCode,
+            authorization_code: None,
+            pkce_verifier: None,
+            pre_authorized_code: Some("pre_code".into()),
+            tx_code: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn memory_queue_push_pop_fifo() {
+        let queue = MemoryTaskQueue::new();
+        let t1 = make_task("ses_1");
+        let t2 = make_task("ses_2");
+
+        queue.push(&t1).await.unwrap();
+        queue.push(&t2).await.unwrap();
+
+        let popped1 = queue.pop().await.unwrap().unwrap();
+        assert_eq!(popped1.session_id, "ses_1");
+
+        let popped2 = queue.pop().await.unwrap().unwrap();
+        assert_eq!(popped2.session_id, "ses_2");
+
+        // Queue is now empty
+        assert!(queue.pop().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_queue_lock_prevents_duplicate() {
+        let queue = MemoryTaskQueue::new();
+        let t1 = make_task("ses_1");
+
+        // Push same session twice
+        queue.push(&t1).await.unwrap();
+        queue.push(&t1).await.unwrap();
+
+        // First pop acquires lock
+        let popped1 = queue.pop().await.unwrap();
+        assert!(popped1.is_some());
+
+        // Second pop sees lock and returns None
+        let popped2 = queue.pop().await.unwrap();
+        assert!(popped2.is_none());
+    }
+}

--- a/src/outbound/task_queue.rs
+++ b/src/outbound/task_queue.rs
@@ -300,7 +300,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn memory_queue_lock_prevents_duplicate() {
+    async fn memory_queue_push_twice_pops_twice() {
         let queue = MemoryTaskQueue::new();
         let t1 = make_task("ses_1");
 
@@ -308,12 +308,14 @@ mod tests {
         queue.push(&t1).await.unwrap();
         queue.push(&t1).await.unwrap();
 
-        // First pop acquires lock
+        // Both copies are popped
         let popped1 = queue.pop().await.unwrap();
         assert!(popped1.is_some());
 
-        // Second pop sees lock and returns None
         let popped2 = queue.pop().await.unwrap();
-        assert!(popped2.is_none());
+        assert!(popped2.is_some());
+
+        // Queue is now empty
+        assert!(queue.pop().await.unwrap().is_none());
     }
 }

--- a/src/outbound/task_queue.rs
+++ b/src/outbound/task_queue.rs
@@ -277,7 +277,7 @@ impl IssuanceTaskQueue for MemoryTaskQueue {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::session::FlowType;
+    use crate::domain::models::issuance::FlowType;
     use uuid::Uuid;
 
     fn make_task(session_id: &str) -> IssuanceTask {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,5 +1,5 @@
 mod auth;
-mod error;
+pub(crate) mod error;
 mod handlers;
 mod responses;
 
@@ -7,12 +7,13 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::domain::service::Service;
+use crate::server::auth::auth;
 use crate::server::handlers::{health_check, home, register_tenant};
 use crate::session::SessionStore;
 
 use axum::http::Method;
 use axum::{
-    Router,
+    Router, middleware,
     routing::{get, post},
 };
 use color_eyre::eyre::{Context, Result};
@@ -24,7 +25,7 @@ use tower_http::{
 
 #[derive(Debug)]
 /// The global application state shared between all request handlers.
-struct AppState<S: SessionStore> {
+pub(crate) struct AppState<S: SessionStore> {
     service: Arc<Service<S>>,
 }
 
@@ -44,7 +45,10 @@ pub struct Server {
 
 impl Server {
     /// Creates a new HTTPS server.
-    pub async fn new<S: SessionStore>(config: &Config, service: Service<S>) -> Result<Self> {
+    pub async fn new<S: SessionStore + Clone>(
+        config: &Config,
+        service: Service<S>,
+    ) -> Result<Self> {
         let trace_layer =
             TraceLayer::new_for_http().make_span_with(|request: &'_ axum::extract::Request<_>| {
                 let uri = request.uri().to_string();
@@ -94,6 +98,10 @@ impl Server {
     }
 }
 
-fn api_routes<S: SessionStore>() -> Router<AppState<S>> {
-    Router::new().route("/tenants", post(register_tenant))
+fn api_routes<S: SessionStore + Clone>() -> Router<AppState<S>> {
+    let protected = Router::new().route_layer(middleware::from_fn(auth));
+
+    Router::new()
+        .route("/tenants", post(register_tenant))
+        .merge(protected)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,13 +7,12 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::domain::service::Service;
-use crate::server::auth::auth;
 use crate::server::handlers::{health_check, home, register_tenant};
 use crate::session::SessionStore;
 
 use axum::http::Method;
 use axum::{
-    Router, middleware,
+    Router,
     routing::{get, post},
 };
 use color_eyre::eyre::{Context, Result};
@@ -99,9 +98,5 @@ impl Server {
 }
 
 fn api_routes<S: SessionStore + Clone>() -> Router<AppState<S>> {
-    let protected = Router::new().route_layer(middleware::from_fn(auth));
-
-    Router::new()
-        .route("/tenants", post(register_tenant))
-        .merge(protected)
+    Router::new().route("/tenants", post(register_tenant))
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use axum::{
     Json,
     http::StatusCode,
@@ -5,6 +7,7 @@ use axum::{
 };
 use serde::Serialize;
 
+use crate::domain::models::issuance::{IssuanceError, IssuanceErrorCode};
 use crate::domain::models::tenants::TenantError;
 
 /// The unified error type used by all HTTP handlers.
@@ -22,7 +25,7 @@ pub struct ApiError {
     /// HTTP status code.
     pub status: StatusCode,
     /// Machine-readable error code (snake_case ASCII).
-    pub error: &'static str,
+    pub error: Cow<'static, str>,
     /// Optional human-readable description. Omitted from JSON when None.
     pub error_description: Option<String>,
 }
@@ -33,7 +36,7 @@ impl ApiError {
         tracing::error!(error = %source, "internal server error");
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,
-            error: "internal_error",
+            error: Cow::Borrowed("internal_error"),
             error_description: Some("The server encountered an unexpected error.".into()),
         }
     }
@@ -49,7 +52,7 @@ impl IntoResponse for ApiError {
         }
 
         let body = Body {
-            error: self.error,
+            error: self.error.as_ref(),
             error_description: self.error_description.as_deref(),
         };
 
@@ -75,17 +78,41 @@ impl IntoApiError for TenantError {
         match self {
             TenantError::InvalidName(msg) => ApiError {
                 status: StatusCode::BAD_REQUEST,
-                error: "invalid_request",
+                error: Cow::Borrowed("invalid_request"),
                 error_description: Some(msg),
             },
             TenantError::NotFound { .. } => ApiError {
                 status: StatusCode::NOT_FOUND,
-                error: "not_found",
+                error: Cow::Borrowed("not_found"),
                 error_description: Some("Tenant not found.".into()),
             },
             TenantError::InvalidData(msg) => ApiError::internal(msg),
             TenantError::Backend(src) => ApiError::internal(src),
             TenantError::Encryption(src) => ApiError::internal(src),
+        }
+    }
+}
+
+impl IntoApiError for IssuanceError {
+    fn into_api_error(self) -> ApiError {
+        let status = match &self.error {
+            IssuanceErrorCode::InvalidCredentialOffer => StatusCode::BAD_REQUEST,
+            IssuanceErrorCode::IssuerMetadataFetchFailed => StatusCode::BAD_GATEWAY,
+            IssuanceErrorCode::AuthServerMetadataFetchFailed => StatusCode::BAD_GATEWAY,
+            IssuanceErrorCode::SessionNotFound => StatusCode::NOT_FOUND,
+            IssuanceErrorCode::InvalidSessionState => StatusCode::CONFLICT,
+            IssuanceErrorCode::InvalidTxCode => StatusCode::BAD_REQUEST,
+            IssuanceErrorCode::InvalidRequest => StatusCode::BAD_REQUEST,
+            IssuanceErrorCode::CredentialNotFound => StatusCode::NOT_FOUND,
+            IssuanceErrorCode::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
+            IssuanceErrorCode::Cancelled => StatusCode::CONFLICT,
+            IssuanceErrorCode::External(_) => StatusCode::BAD_GATEWAY,
+        };
+
+        ApiError {
+            status,
+            error: self.error.to_string().into(),
+            error_description: self.error_description,
         }
     }
 }

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -98,18 +98,41 @@ mod tests {
     use super::*;
 
     fn mock_session(flow: FlowType) -> IssuanceSession {
-        let offer = serde_json::from_value(serde_json::json!({
-            "credential_issuer": "https://issuer.example.com",
-            "credential_configuration_ids": ["test_id"],
-            "grants": {
-                "authorization_code": {
+        let context = serde_json::from_value(serde_json::json!({
+            "offer": {
+                "credential_issuer": "https://issuer.example.com",
+                "credential_configuration_ids": ["test_id"],
+                "grants": {
+                    "authorization_code": {
+                        "issuer_state": "test_state"
+                    }
+                }
+            },
+            "issuer_metadata": {
+                "credential_issuer": "https://issuer.example.com",
+                "credential_endpoint": "https://issuer.example.com/credential",
+                "credential_configurations_supported": {
+                    "test_id": {
+                        "format": "dc+sd-jwt",
+                        "vct": "https://credentials.example.com/test"
+                    }
+                }
+            },
+            "as_metadata": {
+                "issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://issuer.example.com/authorize",
+                "token_endpoint": "https://issuer.example.com/token",
+                "response_types_supported": ["code"]
+            },
+            "flow": {
+                "AuthorizationCode": {
                     "issuer_state": "test_state"
                 }
-            }
+            },
         }))
         .unwrap();
 
-        IssuanceSession::new(Uuid::new_v4(), offer, flow)
+        IssuanceSession::new(Uuid::new_v4(), context, flow)
     }
 
     #[test]

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -1,4 +1,4 @@
-use cloud_wallet_openid4vc::issuance::credential_offer::CredentialOffer;
+use cloud_wallet_openid4vc::issuance::client::ResolvedOfferContext;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -11,10 +11,13 @@ pub struct IssuanceSession {
     pub id: String,
     pub tenant_id: Uuid,
     pub state: IssuanceState,
-    pub offer: ParsedOffer,
+    pub context: ResolvedOfferContext,
+    /// Selected configuration IDs for issuance.
+    /// Empty by default, should be overridden
+    /// after user consent.
+    pub selected_config_ids: Vec<String>,
     pub flow: FlowType,
     pub code_verifier: Option<String>,
-    pub issuer_state: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,18 +44,16 @@ impl IssuanceState {
     }
 }
 
-pub type ParsedOffer = CredentialOffer;
-
 impl IssuanceSession {
-    pub fn new(tenant_id: Uuid, offer: ParsedOffer, flow: FlowType) -> Self {
+    pub fn new(tenant_id: Uuid, context: ResolvedOfferContext, flow: FlowType) -> Self {
         Self {
             id: utils::generate_session_id(),
             tenant_id,
             state: IssuanceState::AwaitingConsent,
-            offer,
+            context,
+            selected_config_ids: vec![],
             flow,
             code_verifier: None,
-            issuer_state: None,
         }
     }
 }

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -2,6 +2,7 @@ use cloud_wallet_openid4vc::issuance::client::ResolvedOfferContext;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::domain::models::issuance::FlowType;
 use crate::session::Result;
 use crate::session::SessionError;
 use crate::session::utils;
@@ -18,13 +19,6 @@ pub struct IssuanceSession {
     pub selected_config_ids: Vec<String>,
     pub flow: FlowType,
     pub code_verifier: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum FlowType {
-    AuthorizationCode,
-    PreAuthorizedCode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -7,7 +7,7 @@ pub enum Error {
     Store(#[source] Box<dyn std::error::Error + Send + Sync>),
 
     #[error("Encoding or decoding error: {0}")]
-    Encoding(#[from] postcard::Error),
+    Encoding(#[from] serde_json::Error),
 
     #[error("Invalid state transition from {0} to {1}")]
     InvalidStateTransition(Cow<'static, str>, Cow<'static, str>),

--- a/src/session/store/memory.rs
+++ b/src/session/store/memory.rs
@@ -63,7 +63,7 @@ impl SessionStore for MemorySession {
         V: serde::Serialize + Send + Sync,
     {
         let key = key.into();
-        let value_bytes = postcard::to_allocvec(value)?;
+        let value_bytes = serde_json::to_vec(value)?;
         let key_bytes: Box<[u8]> = key.as_bytes().into();
 
         match self.entries.entry(key_bytes) {
@@ -95,7 +95,7 @@ impl SessionStore for MemorySession {
                 self.entries.remove(key.as_bytes());
                 return Ok(None);
             }
-            let item: V = postcard::from_bytes(&entry.value)?;
+            let item: V = serde_json::from_slice(&entry.value)?;
             return Ok(Some(item));
         }
         Ok(None)
@@ -122,7 +122,7 @@ impl SessionStore for MemorySession {
         let key = key.into();
         match self.entries.remove(key.as_bytes()) {
             Some((_, entry)) if !Self::is_expired(&entry) => {
-                let item: V = postcard::from_bytes(&entry.value)?;
+                let item: V = serde_json::from_slice(&entry.value)?;
                 Ok(Some(item))
             }
             Some(_) | None => Ok(None),

--- a/src/session/store/redis.rs
+++ b/src/session/store/redis.rs
@@ -66,7 +66,7 @@ impl SessionStore for RedisSession {
         K: Into<Id> + Send + Sync,
         V: serde::Serialize + Send + Sync,
     {
-        let encoded_value = postcard::to_allocvec(value)?;
+        let encoded_value = serde_json::to_vec(value)?;
         let key = self.key(key.into().as_bytes());
         let ttl_ms = self.ttl.as_millis().try_into().unwrap_or(u64::MAX);
 
@@ -89,7 +89,7 @@ impl SessionStore for RedisSession {
         let value: Option<Vec<u8>> = conn.get(&key).await?;
 
         if let Some(v) = value {
-            Ok(Some(postcard::from_bytes(&v)?))
+            Ok(Some(serde_json::from_slice(&v)?))
         } else {
             Ok(None)
         }
@@ -113,7 +113,7 @@ impl SessionStore for RedisSession {
         let value: Option<Vec<u8>> = conn.get_del(self.key(key.as_bytes())).await?;
 
         if let Some(v) = value {
-            Ok(Some(postcard::from_bytes(&v)?))
+            Ok(Some(serde_json::from_slice(&v)?))
         } else {
             Ok(None)
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -15,6 +15,7 @@ pub fn build_issuance_engine(
         config.oid4vci.client_id.clone(),
         config.oid4vci.redirect_uri.clone(),
     )
+    .use_system_proxy(config.oid4vci.use_system_proxy)
     // TODO : remove this later on - only for local testing
     .accept_untrusted_hosts(true);
     let client = Oid4vciClient::new(client_config)?;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,0 +1,39 @@
+use cloud_wallet_openid4vc::issuance::client::{Config as Oid4vciClientConfig, Oid4vciClient};
+
+use crate::config::Config;
+use crate::domain::models::issuance::IssuanceEngine;
+use crate::domain::ports::TenantRepo;
+use crate::domain::service::Service;
+use crate::outbound::{MemoryCredentialRepo, MemoryEventPublisher, MemoryTaskQueue};
+use crate::session::SessionStore;
+
+pub fn build_issuance_engine(
+    config: &Config,
+    tenant_repo: impl TenantRepo,
+) -> color_eyre::Result<IssuanceEngine> {
+    let client_config = Oid4vciClientConfig::new(
+        config.oid4vci.client_id.clone(),
+        config.oid4vci.redirect_uri.clone(),
+    )
+    // TODO : remove this later on - only for local testing
+    .accept_untrusted_hosts(true);
+    let client = Oid4vciClient::new(client_config)?;
+
+    // TODO: Replace with production adapters (Redis, SQL)
+    let task_queue = MemoryTaskQueue::new();
+    let publisher = MemoryEventPublisher::new(128);
+    let credential_repo = MemoryCredentialRepo::new();
+
+    let engine = IssuanceEngine::new(client, task_queue, publisher, credential_repo, tenant_repo);
+    Ok(engine)
+}
+
+/// Build a fully wired [`Service`] ready for use in the server.
+pub fn build_service<S: SessionStore + Clone>(
+    session_store: S,
+    tenant_repo: impl TenantRepo + Clone,
+    config: &Config,
+) -> color_eyre::Result<Service<S>> {
+    let engine = build_issuance_engine(config, tenant_repo.clone())?;
+    Ok(Service::new(session_store, tenant_repo, engine))
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -7,9 +7,10 @@ use crate::domain::service::Service;
 use crate::outbound::{MemoryCredentialRepo, MemoryEventPublisher, MemoryTaskQueue};
 use crate::session::SessionStore;
 
-pub fn build_issuance_engine(
+pub fn build_issuance_engine<S: SessionStore + Clone>(
     config: &Config,
     tenant_repo: impl TenantRepo,
+    session_store: &S,
 ) -> color_eyre::Result<IssuanceEngine> {
     let client_config = Oid4vciClientConfig::new(
         config.oid4vci.client_id.clone(),
@@ -25,7 +26,14 @@ pub fn build_issuance_engine(
     let publisher = MemoryEventPublisher::new(128);
     let credential_repo = MemoryCredentialRepo::new();
 
-    let engine = IssuanceEngine::new(client, task_queue, publisher, credential_repo, tenant_repo);
+    let engine = IssuanceEngine::new(
+        client,
+        task_queue,
+        publisher,
+        credential_repo,
+        tenant_repo,
+        session_store,
+    );
     Ok(engine)
 }
 
@@ -35,6 +43,6 @@ pub fn build_service<S: SessionStore + Clone>(
     tenant_repo: impl TenantRepo + Clone,
     config: &Config,
 ) -> color_eyre::Result<Service<S>> {
-    let engine = build_issuance_engine(config, tenant_repo.clone())?;
+    let engine = build_issuance_engine(config, tenant_repo.clone(), &session_store)?;
     Ok(Service::new(session_store, tenant_repo, engine))
 }

--- a/tests/redis_issuance.rs
+++ b/tests/redis_issuance.rs
@@ -8,12 +8,11 @@
 use std::time::Duration;
 
 use cloud_identity_wallet::domain::models::issuance::{
-    IssuanceEvent, ProcessingStep, SseCompletedEvent, SseFailedEvent, SseProcessingEvent,
+    FlowType, IssuanceEvent, ProcessingStep, SseCompletedEvent, SseFailedEvent, SseProcessingEvent,
 };
 use cloud_identity_wallet::domain::models::issuance::{IssuanceStep, IssuanceTask};
 use cloud_identity_wallet::domain::ports::{IssuanceEventPublisher, IssuanceTaskQueue};
 use cloud_identity_wallet::outbound::{RedisEventPublisher, RedisEventSubscriber, RedisTaskQueue};
-use cloud_identity_wallet::session::FlowType;
 use futures::StreamExt;
 use redis::aio::ConnectionManagerConfig;
 use redis::{Client as RedisClient, aio::ConnectionManager};

--- a/tests/redis_issuance.rs
+++ b/tests/redis_issuance.rs
@@ -24,8 +24,6 @@ use testcontainers_modules::{
 use tokio::sync::mpsc::UnboundedReceiver;
 use uuid::Uuid;
 
-// ── Helpers ──────────────────────────────────────────────────────────────────
-
 const REDIS_TAG: &str = "8-alpine";
 
 /// Start a Redis container and return a plain connection manager (no push channel).
@@ -92,8 +90,6 @@ fn make_task(session_id: &str) -> IssuanceTask {
         tx_code: None,
     }
 }
-
-// ── RedisTaskQueue ───────────────────────────────────────────────────────────
 
 #[tokio::test]
 async fn task_queue_push_pop_round_trip() {
@@ -242,8 +238,6 @@ async fn task_queue_concurrent_consumers_get_distinct_tasks() {
         "each consumer should get a distinct task"
     );
 }
-
-// ── RedisEventPublisher + RedisEventSubscriber ───────────────────────────────
 
 #[tokio::test]
 async fn event_publish_subscribe_round_trip() {

--- a/tests/redis_issuance.rs
+++ b/tests/redis_issuance.rs
@@ -1,0 +1,407 @@
+//! Integration tests for Redis-backed issuance infrastructure.
+//!
+//! Tests cover:
+//! - `RedisTaskQueue`: push/pop/ack, FIFO ordering, stale reclaim, concurrent consumers
+//! - `RedisEventPublisher` + `RedisEventSubscriber`: pub/sub round-trip, terminal events,
+//!   session filtering, late subscription
+
+use std::time::Duration;
+
+use cloud_identity_wallet::domain::models::issuance::{
+    IssuanceEvent, ProcessingStep, SseCompletedEvent, SseFailedEvent, SseProcessingEvent,
+};
+use cloud_identity_wallet::domain::models::issuance::{IssuanceStep, IssuanceTask};
+use cloud_identity_wallet::domain::ports::{IssuanceEventPublisher, IssuanceTaskQueue};
+use cloud_identity_wallet::outbound::{RedisEventPublisher, RedisEventSubscriber, RedisTaskQueue};
+use cloud_identity_wallet::session::FlowType;
+use futures::StreamExt;
+use redis::aio::ConnectionManagerConfig;
+use redis::{Client as RedisClient, aio::ConnectionManager};
+use testcontainers_modules::{
+    redis::{REDIS_PORT, Redis},
+    testcontainers::{ContainerAsync, ImageExt, runners::AsyncRunner},
+};
+use tokio::sync::mpsc::UnboundedReceiver;
+use uuid::Uuid;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const REDIS_TAG: &str = "8-alpine";
+
+/// Start a Redis container and return a plain connection manager (no push channel).
+async fn init_redis() -> (ConnectionManager, ContainerAsync<Redis>) {
+    let container = Redis::default()
+        .with_tag(REDIS_TAG)
+        .start()
+        .await
+        .expect("redis container failed to start");
+
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+    let url = format!("redis://{host}:{port}");
+
+    let client = RedisClient::open(url).expect("failed to create redis client");
+    let conn = client
+        .get_connection_manager()
+        .await
+        .expect("failed to get redis connection manager");
+
+    (conn, container)
+}
+
+/// Start a Redis container and return a RESP3 connection manager with push channel.
+async fn init_redis_resp3() -> (
+    ConnectionManager,
+    UnboundedReceiver<redis::PushInfo>,
+    ContainerAsync<Redis>,
+) {
+    let container = Redis::default()
+        .with_tag(REDIS_TAG)
+        .start()
+        .await
+        .expect("redis container failed to start");
+
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+    let url = format!("redis://{host}:{port}?protocol=resp3");
+
+    let client = RedisClient::open(url).expect("failed to create redis client");
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let config = ConnectionManagerConfig::new()
+        .set_push_sender(tx)
+        .set_automatic_resubscription();
+
+    let conn = client
+        .get_connection_manager_with_config(config)
+        .await
+        .expect("failed to get RESP3 connection manager");
+
+    (conn, rx, container)
+}
+
+fn make_task(session_id: &str) -> IssuanceTask {
+    IssuanceTask {
+        queue_id: None,
+        session_id: session_id.to_owned(),
+        tenant_id: Uuid::new_v4(),
+        flow: FlowType::PreAuthorizedCode,
+        authorization_code: None,
+        pkce_verifier: None,
+        pre_authorized_code: Some("pre_code_123".into()),
+        tx_code: None,
+    }
+}
+
+// ── RedisTaskQueue ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn task_queue_push_pop_round_trip() {
+    let (conn, _container) = init_redis().await;
+    let queue = RedisTaskQueue::new(conn);
+
+    let task = make_task("ses_round_trip");
+    queue.push(&task).await.unwrap();
+
+    let popped = queue
+        .pop()
+        .await
+        .unwrap()
+        .expect("queue should not be empty");
+    assert_eq!(popped.session_id, "ses_round_trip");
+    assert_eq!(popped.flow, FlowType::PreAuthorizedCode);
+    assert_eq!(popped.pre_authorized_code.as_deref(), Some("pre_code_123"));
+    assert!(popped.queue_id.is_some(), "queue_id must be set after pop");
+}
+
+#[tokio::test]
+async fn task_queue_pop_returns_none_on_empty() {
+    let (conn, _container) = init_redis().await;
+    let queue = RedisTaskQueue::new(conn);
+
+    let result = queue.pop().await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn task_queue_ack_removes_from_pending() {
+    let (conn, _container) = init_redis().await;
+    let queue = RedisTaskQueue::new(conn);
+
+    let task = make_task("ses_ack");
+    queue.push(&task).await.unwrap();
+
+    let popped = queue.pop().await.unwrap().unwrap();
+    queue.ack(&popped).await.unwrap();
+
+    // After ack, nothing should be available (no stale reclaim either)
+    let result = queue.pop().await.unwrap();
+    assert!(result.is_none());
+}
+
+#[tokio::test]
+async fn task_queue_fifo_ordering() {
+    let (conn, _container) = init_redis().await;
+    let queue = RedisTaskQueue::new(conn);
+
+    let t1 = make_task("ses_fifo_1");
+    let t2 = make_task("ses_fifo_2");
+    let t3 = make_task("ses_fifo_3");
+
+    queue.push(&t1).await.unwrap();
+    queue.push(&t2).await.unwrap();
+    queue.push(&t3).await.unwrap();
+
+    let p1 = queue.pop().await.unwrap().unwrap();
+    assert_eq!(p1.session_id, "ses_fifo_1");
+    queue.ack(&p1).await.unwrap();
+
+    let p2 = queue.pop().await.unwrap().unwrap();
+    assert_eq!(p2.session_id, "ses_fifo_2");
+    queue.ack(&p2).await.unwrap();
+
+    let p3 = queue.pop().await.unwrap().unwrap();
+    assert_eq!(p3.session_id, "ses_fifo_3");
+    queue.ack(&p3).await.unwrap();
+
+    assert!(queue.pop().await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn task_queue_stale_task_reclaimed() {
+    let (conn, _container) = init_redis().await;
+
+    // Consumer A: short idle timeout so the task becomes reclaimable quickly
+    let queue_a = RedisTaskQueue::new(conn.clone())
+        .with_consumer("consumer-a")
+        .with_claim_idle_timeout(Duration::from_millis(200));
+
+    // Consumer B: will reclaim stale tasks
+    let queue_b = RedisTaskQueue::new(conn)
+        .with_consumer("consumer-b")
+        .with_claim_idle_timeout(Duration::from_millis(200));
+
+    let task = make_task("ses_stale");
+    queue_a.push(&task).await.unwrap();
+
+    // A pops but never acks
+    let popped_a = queue_a.pop().await.unwrap().unwrap();
+    assert_eq!(popped_a.session_id, "ses_stale");
+
+    // Wait for the idle timeout to expire
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    // B should be able to reclaim the stale task
+    let popped_b = queue_b
+        .pop()
+        .await
+        .unwrap()
+        .expect("stale task should be reclaimed");
+    assert_eq!(popped_b.session_id, "ses_stale");
+    queue_b.ack(&popped_b).await.unwrap();
+}
+
+#[tokio::test]
+async fn task_queue_concurrent_consumers_get_distinct_tasks() {
+    let (conn, _container) = init_redis().await;
+
+    // Push 4 tasks
+    let queue = RedisTaskQueue::new(conn.clone());
+    for i in 0..4 {
+        queue
+            .push(&make_task(&format!("ses_concurrent_{i}")))
+            .await
+            .unwrap();
+    }
+
+    // 4 consumers each pop one task
+    let mut handles = Vec::new();
+    for i in 0..4 {
+        let q = RedisTaskQueue::new(conn.clone()).with_consumer(format!("worker-{i}"));
+        handles.push(tokio::spawn(async move {
+            let task = q.pop().await.unwrap();
+            if let Some(t) = &task {
+                q.ack(t).await.unwrap();
+            }
+            task.map(|t| t.session_id)
+        }));
+    }
+
+    let mut session_ids: Vec<String> = Vec::new();
+    for handle in handles {
+        if let Some(id) = handle.await.unwrap() {
+            session_ids.push(id);
+        }
+    }
+
+    session_ids.sort();
+    session_ids.dedup();
+    assert_eq!(
+        session_ids.len(),
+        4,
+        "each consumer should get a distinct task"
+    );
+}
+
+// ── RedisEventPublisher + RedisEventSubscriber ───────────────────────────────
+
+#[tokio::test]
+async fn event_publish_subscribe_round_trip() {
+    let (conn, push_rx, _container) = init_redis_resp3().await;
+
+    let publisher = RedisEventPublisher::new(conn.clone());
+    let subscriber = RedisEventSubscriber::new(conn, push_rx);
+
+    let mut stream = subscriber.subscribe("ses_pubsub").await.unwrap();
+
+    // Small delay for subscription to settle
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let processing = IssuanceEvent::Processing(SseProcessingEvent::new(
+        "ses_pubsub",
+        ProcessingStep::ExchangingToken,
+    ));
+    publisher.publish(&processing).await.unwrap();
+
+    let completed = IssuanceEvent::Completed(SseCompletedEvent::new(
+        "ses_pubsub",
+        vec!["id1".into()],
+        vec!["type1".into()],
+    ));
+    publisher.publish(&completed).await.unwrap();
+
+    // Read events
+    let e1 = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout waiting for processing event")
+        .expect("stream ended prematurely");
+    assert!(matches!(e1, IssuanceEvent::Processing(_)));
+
+    let e2 = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout waiting for completed event")
+        .expect("stream ended prematurely");
+    assert!(matches!(e2, IssuanceEvent::Completed(_)));
+}
+
+#[tokio::test]
+async fn event_terminal_completed_closes_stream() {
+    let (conn, push_rx, _container) = init_redis_resp3().await;
+
+    let publisher = RedisEventPublisher::new(conn.clone());
+    let subscriber = RedisEventSubscriber::new(conn, push_rx);
+
+    let mut stream = subscriber.subscribe("ses_terminal").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let completed =
+        IssuanceEvent::Completed(SseCompletedEvent::new("ses_terminal", vec![], vec![]));
+    publisher.publish(&completed).await.unwrap();
+
+    // Should receive the completed event
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout")
+        .expect("stream ended prematurely");
+    assert!(matches!(event, IssuanceEvent::Completed(_)));
+
+    // Stream should terminate after terminal event
+    let next = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timeout waiting for stream end");
+    assert!(next.is_none(), "stream should close after terminal event");
+}
+
+#[tokio::test]
+async fn event_failed_terminates_stream() {
+    let (conn, push_rx, _container) = init_redis_resp3().await;
+
+    let publisher = RedisEventPublisher::new(conn.clone());
+    let subscriber = RedisEventSubscriber::new(conn, push_rx);
+
+    let mut stream = subscriber.subscribe("ses_fail").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let failed = IssuanceEvent::Failed(SseFailedEvent::new(
+        "ses_fail",
+        "access_denied",
+        Some("User denied".into()),
+        IssuanceStep::Authorization,
+    ));
+    publisher.publish(&failed).await.unwrap();
+
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout")
+        .expect("stream ended prematurely");
+    assert!(matches!(event, IssuanceEvent::Failed(_)));
+
+    let next = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timeout");
+    assert!(next.is_none(), "stream should close after failed event");
+}
+
+#[tokio::test]
+async fn event_subscriber_filters_by_session() {
+    let (conn, push_rx, _container) = init_redis_resp3().await;
+
+    let publisher = RedisEventPublisher::new(conn.clone());
+    let subscriber = RedisEventSubscriber::new(conn, push_rx);
+
+    // Subscribe to session A only
+    let mut stream_a = subscriber.subscribe("ses_A").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Publish event for session B (should not appear on stream_a)
+    let other = IssuanceEvent::Processing(SseProcessingEvent::new(
+        "ses_B",
+        ProcessingStep::ExchangingToken,
+    ));
+    publisher.publish(&other).await.unwrap();
+
+    // Publish terminal event for session A
+    let completed = IssuanceEvent::Completed(SseCompletedEvent::new("ses_A", vec![], vec![]));
+    publisher.publish(&completed).await.unwrap();
+
+    // stream_a should only receive ses_A's completed event
+    let event = tokio::time::timeout(Duration::from_secs(5), stream_a.next())
+        .await
+        .expect("timeout")
+        .expect("stream ended prematurely");
+    assert!(matches!(event, IssuanceEvent::Completed(_)));
+    assert_eq!(event.session_id(), "ses_A");
+}
+
+#[tokio::test]
+async fn event_late_subscriber_misses_earlier_events() {
+    let (conn, push_rx, _container) = init_redis_resp3().await;
+
+    let publisher = RedisEventPublisher::new(conn.clone());
+    let subscriber = RedisEventSubscriber::new(conn, push_rx);
+
+    // Publish before subscribing
+    let early = IssuanceEvent::Processing(SseProcessingEvent::new(
+        "ses_late",
+        ProcessingStep::ExchangingToken,
+    ));
+    publisher.publish(&early).await.unwrap();
+
+    // Now subscribe
+    let mut stream = subscriber.subscribe("ses_late").await.unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Publish a terminal event so the stream can complete
+    let completed = IssuanceEvent::Completed(SseCompletedEvent::new("ses_late", vec![], vec![]));
+    publisher.publish(&completed).await.unwrap();
+
+    // The first event received should be the completed event, not the early one
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("timeout")
+        .expect("stream ended prematurely");
+    assert!(
+        matches!(event, IssuanceEvent::Completed(_)),
+        "late subscriber should not receive events published before subscription"
+    );
+}

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -2,13 +2,11 @@
 
 use cloud_identity_wallet::{
     config::Config,
-    domain::{
-        models::credential::{Credential, CredentialFormat, CredentialStatus},
-        service::Service,
-    },
+    domain::models::credential::{Credential, CredentialFormat, CredentialStatus},
     outbound::MemoryTenantRepo,
     server::Server,
     session::MemorySession,
+    setup,
 };
 use sqlx::{AnyPool, ConnectOptions};
 use time::UtcDateTime;
@@ -24,8 +22,7 @@ pub async fn spawn_server() -> String {
     };
     let session_store = MemorySession::default();
     let tenant_repo = MemoryTenantRepo::new();
-
-    let service = Service::new(session_store, tenant_repo);
+    let service = setup::build_service(session_store, tenant_repo, &config).unwrap();
     let server = Server::new(&config, service).await.unwrap();
 
     let port = server.port();

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -18,6 +18,7 @@ pub async fn spawn_server() -> String {
         let mut config = Config::load().unwrap();
         config.server.host = "localhost".to_string();
         config.server.port = 0;
+        config.oid4vci.use_system_proxy = false;
         config
     };
     let session_store = MemorySession::default();


### PR DESCRIPTION
After consent (pre-auth flow without tx_code) or after the authorization callback (authorization code flow), the backend executes the OID4VCI back-channel steps entirely server-side. The frontend is notified exclusively via SSE events. This ticket covers token exchange, credential request, deferred credential polling, credential storage and issuance engine integration.
 
## Acceptance criteria
 
- Authorization code flow: token exchange succeeds with valid `code` and `code_verifier`, credential is stored, `completed` SSE event emitted.
- Pre-auth flow: token exchange succeeds with pre-authorized code, credential stored, `completed` SSE event emitted.
- Deferred issuance: `processing` event emitted, polling runs, `completed` emitted on eventual success.
- Any unrecoverable error emits a `failed` SSE event with the correct `step`.
- The background task does not leak on panic.

