### PR TITLE
Feat/get api v1 issuance callback

### DIFF
--- a/cloud-wallet-openid4vc/src/issuance/client/mod.rs
+++ b/cloud-wallet-openid4vc/src/issuance/client/mod.rs
@@ -40,6 +40,7 @@ use crate::issuance::error::{
 };
 use crate::issuance::issuer_metadata::CredentialIssuerMetadata;
 use crate::issuance::notification::NotificationRequest;
+use crate::issuance::query_params::QueryParams;
 use crate::issuance::token_request::{
     AuthorizationCodeRequest, PreAuthorizedCodeRequest, TokenRequest,
 };
@@ -112,11 +113,28 @@ pub struct AuthorizationUrlResult {
     pub pkce_verifier: String,
 }
 
+/// Parsed OAuth authorization error callback.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthorizationErrorCallback {
+    pub error: Oid4vciError<AuthzErrorResponse>,
+    pub state: Option<String>,
+}
+
 /// Parsed authorization callback outcome.
 #[derive(Debug, Serialize, Deserialize)]
 pub enum AuthorizationCallback {
     Success(AuthorizationResponse),
-    Error(Oid4vciError<AuthzErrorResponse>),
+    Error(AuthorizationErrorCallback),
+}
+
+impl AuthorizationCallback {
+    /// Return the callback `state` value, when present.
+    pub fn state(&self) -> Option<&str> {
+        match self {
+            Self::Success(response) => response.state.as_deref(),
+            Self::Error(response) => response.state.as_deref(),
+        }
+    }
 }
 
 /// Configuration for the OID4VCI client.
@@ -466,25 +484,37 @@ impl Oid4vciClient {
         })
     }
 
+    /// Parses authorization callback query parameters into success/error result.
+    pub fn parse_authorization_callback(query: &str) -> Result<AuthorizationCallback> {
+        const RECOGNIZED: &[&str] = &["code", "state", "error", "error_description"];
+        let params = QueryParams::parse(query, RECOGNIZED)?;
+
+        if let Some(error_code) = params.get("error") {
+            let error = serde_json::from_value(serde_json::Value::String(error_code.to_owned()))
+                .map_err(|e| ClientError::InvalidResponse {
+                    message: format!("failed to parse authorization error: {e}").into(),
+                })?;
+            let error = Oid4vciError {
+                error,
+                error_description: params.get("error_description").map(ToOwned::to_owned),
+            };
+            return Ok(AuthorizationCallback::Error(AuthorizationErrorCallback {
+                error,
+                state: params.get("state").map(ToOwned::to_owned),
+            }));
+        }
+
+        let response = AuthorizationResponse::from_query(query)?;
+        Ok(AuthorizationCallback::Success(response))
+    }
+
     /// Parses authorization callback from redirect URI into success/error result.
     pub fn parse_authz_callback(&self, redirect_uri: &str) -> Result<AuthorizationCallback> {
         let url = Url::parse(redirect_uri)
             .map_err(|e| ClientError::validation(format!("invalid redirect uri: {e}")))?;
         let query = url.query().unwrap_or_default();
 
-        if url.query_pairs().any(|(k, _)| k == "error") {
-            let error =
-                serde_urlencoded::from_str(query).map_err(|e| ClientError::InvalidResponse {
-                    message: format!("failed to parse authorization error: {e}").into(),
-                })?;
-            return Ok(AuthorizationCallback::Error(error));
-        }
-
-        let response =
-            serde_urlencoded::from_str(query).map_err(|e| ClientError::InvalidResponse {
-                message: format!("failed to parse authorization response: {e}").into(),
-            })?;
-        Ok(AuthorizationCallback::Success(response))
+        Self::parse_authorization_callback(query)
     }
 
     /// Exchange an authorization code for an access token (authorization code flow).

--- a/cloud-wallet-openid4vc/src/issuance/client/tests.rs
+++ b/cloud-wallet-openid4vc/src/issuance/client/tests.rs
@@ -30,6 +30,40 @@ fn create_client() -> Oid4vciClient {
     }
 }
 
+#[test]
+fn parse_authorization_callback_success_query() {
+    let callback =
+        Oid4vciClient::parse_authorization_callback("code=abc123&state=ses_123").unwrap();
+
+    match callback {
+        AuthorizationCallback::Success(response) => {
+            assert_eq!(response.code, "abc123");
+            assert_eq!(response.state.as_deref(), Some("ses_123"));
+        }
+        other => panic!("expected success callback, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_authorization_callback_error_query() {
+    let callback = Oid4vciClient::parse_authorization_callback(
+        "error=access_denied&error_description=User+cancelled&state=ses_123",
+    )
+    .unwrap();
+
+    match callback {
+        AuthorizationCallback::Error(response) => {
+            assert_eq!(response.error.error, AuthzErrorResponse::AccessDenied);
+            assert_eq!(
+                response.error.error_description.as_deref(),
+                Some("User cancelled")
+            );
+            assert_eq!(response.state.as_deref(), Some("ses_123"));
+        }
+        other => panic!("expected error callback, got {other:?}"),
+    }
+}
+
 fn get_ecdsa_signer() -> CryptoSigner {
     let keypair = EcdsaKeyPair::generate(Curve::P256).unwrap();
     let der = keypair.to_pkcs8_der().to_vec();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -390,19 +390,17 @@ paths:
 
         **On success:**
         1. Validate `state` → recover session.
-        2. Exchange `code` for token (back-channel, with PKCE `code_verifier`).
-        3. Request credential(s) from the issuer's credential endpoint.
-        4. Store credential(s) and mark session `completed`.
-        5. Push `completed` SSE event.
-        6. Redirect to `<app_deep_link>?session_id=<session_id>&result=success`.
+        2. Mark the session `processing`.
+        3. Enqueue background issuance using the authorization code and PKCE
+           `code_verifier`.
+        4. Return `200 OK`. Completion or failure is reported through
+           the session's SSE stream.
 
         **On error (AS returns `error`):**
         1. Validate `state` → recover session.
-        2. Mark session `failed`; push `failed` SSE event (`step: "authorization"`).
-        3. Redirect to `<app_deep_link>?session_id=<session_id>&result=error&error=<error_code>`.
-
-        The `app_deep_link` scheme is configured per deployment and is out of
-        scope for this specification.
+        2. Push a `failed` SSE event (`step: "authorization"`).
+        3. Remove the session.
+        4. Return `200 OK`.
       security: [] # Authenticated via `state` parameter — no bearer token
       tags:
         - Issuance
@@ -436,24 +434,15 @@ paths:
           schema:
             type: string
       responses:
-        "302":
+        "200":
           description: |
-            Redirect to the frontend's registered deep link URI.
-            - Success: `<app_deep_link>?session_id=<id>&result=success`
-            - Error:   `<app_deep_link>?session_id=<id>&result=error&error=<code>`
-          headers:
-            Location:
-              required: true
-              schema:
-                type: string
-                format: uri
-              examples:
-                success:
-                  value: "wallet://issuance/callback?session_id=ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni&result=success"
-                error:
-                  value: "wallet://issuance/callback?session_id=ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni&result=error&error=access_denied"
+            Callback accepted. The response body is empty; clients observe
+            issuance progress through the session's SSE stream.
         "400":
-          description: Missing or invalid `state` parameter.
+          description: |
+            Missing or invalid `state` parameter. This includes unknown,
+            expired, or non-`awaiting_authorization` sessions; these all return
+            `400` to avoid leaking session existence to unauthenticated callers.
           content:
             application/json:
               schema:
@@ -461,15 +450,6 @@ paths:
               example:
                 error: invalid_request
                 error_description: Missing required `state` query parameter.
-        "404":
-          description: No active session found matching the given `state`.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
-              example:
-                error: session_not_found
-                error_description: No active session found for the given state value.
 
   # -------------------------------------------------------------------------
   # 6. Submit Transaction Code

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,7 +103,10 @@ impl Config {
             .set_default("redis.uri", "redis://127.0.0.1:6379?protocol=resp3")?
             .set_default("database.url", "sqlite::memory:")?
             .set_default("oid4vci.client_id", "cloud-identity-wallet")?
-            .set_default("oid4vci.redirect_uri", "http://localhost:3000/callback")?
+            .set_default(
+                "oid4vci.redirect_uri",
+                "http://localhost:3000/api/v1/issuance/callback",
+            )?
             .set_default("oid4vci.use_system_proxy", true)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::domain::service::Service;
-use crate::server::handlers::{health_check, home, register_tenant};
+use crate::server::handlers::{authorization_callback, health_check, home, register_tenant};
 use crate::session::SessionStore;
 
 use axum::http::Method;
@@ -98,5 +98,7 @@ impl Server {
 }
 
 fn api_routes<S: SessionStore + Clone>() -> Router<AppState<S>> {
-    Router::new().route("/tenants", post(register_tenant))
+    Router::new()
+        .route("/tenants", post(register_tenant))
+        .route("/issuance/callback", get(authorization_callback))
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -116,3 +116,9 @@ impl IntoApiError for IssuanceError {
         }
     }
 }
+
+impl IntoApiError for crate::session::SessionError {
+    fn into_api_error(self) -> ApiError {
+        ApiError::internal(self)
+    }
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,8 +1,10 @@
 mod health;
+mod issuance;
 mod root;
 mod tenant;
 
 // Export handlers for use in the server
 pub use health::health_check;
+pub use issuance::authorization_callback;
 pub use root::home;
 pub use tenant::register_tenant;

--- a/src/server/handlers/issuance/callback.rs
+++ b/src/server/handlers/issuance/callback.rs
@@ -1,0 +1,107 @@
+use std::borrow::Cow;
+
+use axum::{
+    extract::{RawQuery, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use cloud_wallet_openid4vc::issuance::client::{AuthorizationCallback, ClientError, Oid4vciClient};
+use tracing::{debug, error, info, instrument, warn};
+
+use crate::domain::models::issuance::{
+    IssuanceError, IssuanceEvent, IssuanceTask, SseFailedEvent, transition_session,
+};
+use crate::server::{AppState, error::ApiError};
+use crate::session::{IssuanceSession, IssuanceState, SessionStore};
+
+/// OAuth 2.0 redirect URI invoked by the issuer authorization server.
+#[instrument(skip_all)]
+pub async fn authorization_callback<S: SessionStore + Clone>(
+    State(state): State<AppState<S>>,
+    RawQuery(query): RawQuery,
+) -> Result<Response, ApiError> {
+    let query = query.unwrap_or_default();
+    debug!(query = %query, "received authorization callback");
+
+    let callback = Oid4vciClient::parse_authorization_callback(&query).map_err(|err| {
+        warn!(error = %err, "invalid authorization callback query");
+        invalid_callback("Invalid authorization callback.")
+    })?;
+
+    let session_id = callback
+        .state()
+        .filter(|state| !state.trim().is_empty())
+        .ok_or_else(|| invalid_callback("Missing required state query parameter."))?
+        .to_owned();
+    tracing::Span::current().record("state", tracing::field::display(&session_id));
+
+    let session = load_awaiting_authorization(&state.service.session, &session_id).await?;
+
+    match callback {
+        AuthorizationCallback::Success(response) => {
+            let code_verifier = session
+                .code_verifier
+                .clone()
+                .ok_or_else(|| invalid_callback("Session is missing its PKCE verifier."))?;
+
+            transition_session(
+                &state.service.session,
+                session_id.as_str(),
+                IssuanceState::Processing,
+            )
+            .await?;
+
+            let task = IssuanceTask::new_authz_code(&session, response.code, code_verifier);
+            state.service.issuance_engine.enqueue(&task).await?;
+
+            info!(session_id = %session_id, "authorization callback accepted");
+            Ok(StatusCode::OK.into_response())
+        }
+        AuthorizationCallback::Error(error_callback) => {
+            let error = IssuanceError::from(ClientError::Authorization(error_callback.error));
+            let error_code = error.error;
+            let error_description = error.error_description;
+
+            let failed = IssuanceEvent::Failed(SseFailedEvent::new(
+                &session_id,
+                error_code.to_string(),
+                error_description,
+                error.step,
+            ));
+            let event_publisher = &state.service.issuance_engine.event_publisher;
+            let publish_result = event_publisher.publish(&failed).await;
+            if let Err(err) = &publish_result {
+                warn!(error = %err, session_id = %session_id, "failed to publish authorization failure event");
+            }
+
+            state.service.session.remove(session_id.as_str()).await?;
+            publish_result?;
+
+            error!(session_id = %session_id, error = %error_code, "authorization callback failed");
+            Ok(StatusCode::OK.into_response())
+        }
+    }
+}
+
+async fn load_awaiting_authorization<S: SessionStore>(
+    session_store: &S,
+    session_id: &str,
+) -> Result<IssuanceSession, ApiError> {
+    let session: Option<IssuanceSession> = session_store.get(session_id).await?;
+    let Some(session) = session else {
+        return Err(invalid_callback("Invalid authorization callback state."));
+    };
+
+    if session.state != IssuanceState::AwaitingAuthorization {
+        return Err(invalid_callback("Invalid authorization callback state."));
+    }
+    Ok(session)
+}
+
+fn invalid_callback(description: impl Into<String>) -> ApiError {
+    ApiError {
+        status: StatusCode::BAD_REQUEST,
+        error: Cow::Borrowed("invalid_request"),
+        error_description: Some(description.into()),
+    }
+}

--- a/src/server/handlers/issuance/mod.rs
+++ b/src/server/handlers/issuance/mod.rs
@@ -1,0 +1,3 @@
+mod callback;
+
+pub use callback::authorization_callback;

--- a/tests/issuance_callback.rs
+++ b/tests/issuance_callback.rs
@@ -1,0 +1,267 @@
+//! Integration tests for GET /api/v1/issuance/callback
+
+pub mod utils;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cloud_identity_wallet::{
+    config::Config,
+    domain::{
+        models::issuance::{
+            FlowType, IssuanceEngine, IssuanceError, IssuanceEvent, IssuanceStep, IssuanceTask,
+        },
+        ports::{IssuanceEventSubscriber, IssuanceTaskQueue},
+        service::Service,
+    },
+    outbound::{
+        MemoryCredentialRepo, MemoryEventPublisher, MemoryEventSubscriber, MemoryTenantRepo,
+    },
+    server::Server,
+    session::{IssuanceSession, IssuanceState, MemorySession, SessionStore},
+};
+use cloud_wallet_openid4vc::issuance::client::{Config as Oid4vciClientConfig, Oid4vciClient};
+use futures::StreamExt;
+use reqwest::Client;
+use url::Url;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Default)]
+struct RecordingTaskQueue {
+    pushed: Arc<Mutex<Vec<IssuanceTask>>>,
+}
+
+#[async_trait]
+impl IssuanceTaskQueue for RecordingTaskQueue {
+    async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError> {
+        self.pushed.lock().unwrap().push(task.clone());
+        Ok(())
+    }
+
+    async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError> {
+        Ok(None)
+    }
+
+    async fn ack(&self, _task: &IssuanceTask) -> Result<(), IssuanceError> {
+        Ok(())
+    }
+}
+
+struct CallbackTestApp {
+    base_url: String,
+    session_store: MemorySession,
+    pushed_tasks: Arc<Mutex<Vec<IssuanceTask>>>,
+    event_subscriber: MemoryEventSubscriber,
+}
+
+async fn spawn_callback_test_app(session_store: MemorySession) -> CallbackTestApp {
+    let mut config = Config::load().unwrap();
+    config.server.host = "localhost".to_owned();
+    config.server.port = 0;
+    config.oid4vci.use_system_proxy = false;
+
+    let queue = RecordingTaskQueue::default();
+    let pushed_tasks = queue.pushed.clone();
+    let publisher = MemoryEventPublisher::new(16);
+    let event_subscriber = MemoryEventSubscriber::new(&publisher);
+    let tenant_repo = MemoryTenantRepo::new();
+    let client_config = Oid4vciClientConfig::new(
+        "wallet-client",
+        Url::parse("https://wallet.example.com/api/v1/issuance/callback").unwrap(),
+    )
+    .timeout(Duration::from_secs(60))
+    .accept_untrusted_hosts(true);
+
+    let client = Oid4vciClient::new(client_config).unwrap();
+    let engine = IssuanceEngine::new(
+        client,
+        queue,
+        publisher,
+        MemoryCredentialRepo::new(),
+        tenant_repo.clone(),
+        &session_store,
+    );
+    let service = Service::new(session_store.clone(), tenant_repo, engine);
+    let server = Server::new(&config, service).await.unwrap();
+    let port = server.port();
+
+    tokio::spawn(server.run());
+
+    CallbackTestApp {
+        base_url: format!("http://{}:{port}", config.server.host),
+        session_store,
+        pushed_tasks,
+        event_subscriber,
+    }
+}
+
+fn mock_session(session_id: &str, state: IssuanceState) -> IssuanceSession {
+    let context = serde_json::from_value(serde_json::json!({
+        "offer": {
+            "credential_issuer": "https://issuer.example.com",
+            "credential_configuration_ids": ["test_id"],
+            "grants": {
+                "authorization_code": {
+                    "issuer_state": session_id
+                }
+            }
+        },
+        "issuer_metadata": {
+            "credential_issuer": "https://issuer.example.com",
+            "credential_endpoint": "https://issuer.example.com/credential",
+            "credential_configurations_supported": {
+                "test_id": {
+                    "format": "dc+sd-jwt",
+                    "vct": "https://credentials.example.com/test"
+                }
+            }
+        },
+        "as_metadata": {
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://10.255.255.1/token",
+            "response_types_supported": ["code"]
+        },
+        "flow": {
+            "AuthorizationCode": {
+                "issuer_state": session_id
+            }
+        },
+    }))
+    .unwrap();
+
+    let mut session = IssuanceSession::new(Uuid::new_v4(), context, FlowType::AuthorizationCode);
+    session.id = session_id.to_owned();
+    session.state = state;
+    session.selected_config_ids = vec!["test_id".to_owned()];
+    session.code_verifier = Some("pkce-verifier".to_owned());
+    session
+}
+
+#[tokio::test]
+async fn valid_callback_transitions_session_to_processing_and_enqueues_task() {
+    let session_id = "ses_callback_success";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingAuthorization);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_callback_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .get(format!(
+            "{}/api/v1/issuance/callback?code=auth-code&state={session_id}",
+            app.base_url
+        ))
+        .send()
+        .await
+        .expect("failed to send callback request");
+
+    assert_eq!(response.status(), 200);
+    assert!(response.bytes().await.unwrap().is_empty());
+
+    let session: IssuanceSession = app.session_store.get(session_id).await.unwrap().unwrap();
+    assert_eq!(session.state, IssuanceState::Processing);
+
+    let tasks = app.pushed_tasks.lock().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].session_id, session_id);
+    assert_eq!(tasks[0].authorization_code.as_deref(), Some("auth-code"));
+}
+
+#[tokio::test]
+async fn error_callback_fails_emits_event_and_discards_session() {
+    let session_id = "ses_callback_error";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingAuthorization);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_callback_test_app(session_store).await;
+    let mut stream = app.event_subscriber.subscribe(session_id).await.unwrap();
+    let client = Client::new();
+
+    let response = client
+        .get(format!(
+            "{}/api/v1/issuance/callback?error=access_denied&error_description=No+thanks&state={session_id}",
+            app.base_url
+        ))
+        .send()
+        .await
+        .expect("failed to send callback request");
+
+    assert_eq!(response.status(), 200);
+    assert!(response.bytes().await.unwrap().is_empty());
+
+    let event = tokio::time::timeout(Duration::from_secs(1), stream.next())
+        .await
+        .expect("timed out waiting for failed event")
+        .expect("event stream ended");
+    match event {
+        IssuanceEvent::Failed(failed) => {
+            assert_eq!(failed.session_id, session_id);
+            assert_eq!(failed.error, "access_denied");
+            assert_eq!(failed.error_description.as_deref(), Some("No thanks"));
+            assert_eq!(failed.step, IssuanceStep::Authorization);
+        }
+        other => panic!("expected failed event, got {other:?}"),
+    }
+
+    let session: Option<IssuanceSession> = app.session_store.get(session_id).await.unwrap();
+    assert!(session.is_none());
+}
+
+#[tokio::test]
+async fn expired_state_returns_bad_request() {
+    let session_id = "ses_expired_callback";
+    let session_store = MemorySession::new(Duration::from_millis(30));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingAuthorization);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    let app = spawn_callback_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .get(format!(
+            "{}/api/v1/issuance/callback?code=auth-code&state={session_id}",
+            app.base_url
+        ))
+        .send()
+        .await
+        .expect("failed to send callback request");
+
+    assert_eq!(response.status(), 400);
+}
+
+#[tokio::test]
+async fn non_authorization_state_returns_bad_request() {
+    let session_id = "ses_wrong_state_callback";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingConsent);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_callback_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .get(format!(
+            "{}/api/v1/issuance/callback?code=auth-code&state={session_id}",
+            app.base_url
+        ))
+        .send()
+        .await
+        .expect("failed to send callback request");
+
+    assert_eq!(response.status(), 400);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["error"], "invalid_request");
+}

--- a/tests/issuance_callback.rs
+++ b/tests/issuance_callback.rs
@@ -78,6 +78,7 @@ async fn spawn_callback_test_app(session_store: MemorySession) -> CallbackTestAp
         client,
         queue,
         publisher,
+        event_subscriber.clone(),
         MemoryCredentialRepo::new(),
         tenant_repo.clone(),
         &session_store,


### PR DESCRIPTION
The OAuth 2.0 redirect URI. The issuer's authorization server redirects to this endpoint after the user authenticates. The backend validates the callback, exchanges the code for a token, and triggers credential issuance. The frontend is notified exclusively via the SSE stream. This endpoint is not called directly by the frontend app.
 
- [x] Register this URL (`{BASE_URL}/api/v1/issuance/callback`) as the OAuth redirect
  URI. It must be in the wallet's client configuration at the issuer AS.
- [x] Implement `parse_authorization_callback(query: &str)` using the form decode
  utilities to distinguish success from error responses.
- [x] Validate `state` is a known, non-expired session in `awaiting_authorization`. All other states return `400`, not `404` — to avoid leaking session existence to an unauthenticated caller.
- [x] On success, spawn the background credential issuance task.
- [x] On error, discard the session and emit `failed` SSE event.
 
## Acceptance criteria
 
- [x] Valid callback with `code` and matching `state` transitions session to `processing`.
- [x] Callback with `error=...` transitions session to `failed` and emits the correct SSE event.
- [x] Callback with a `state` that matches an expired session returns `400`.
- [x] Callback with a `state` that matches a session not in `awaiting_authorization` returns `400` (CSRF protection).

cc @IngridPuppet, @ndefokou, @Christiantyemele