### PR TITLE
Feat/post api v1 issuance session id tx code

### DIFF
--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -1,12 +1,14 @@
 mod error;
 mod events;
 mod task;
+mod tx_code;
 
 pub use error::{IssuanceError, IssuanceErrorCode};
 pub use events::*;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 pub use task::{IssuanceTask, TaskResult};
+pub use tx_code::{TxCodeError, TxCodeRequest, TxCodeResponse};
 
 use std::{sync::Arc, time::Duration};
 

--- a/src/domain/models/issuance/tx_code.rs
+++ b/src/domain/models/issuance/tx_code.rs
@@ -1,0 +1,113 @@
+use cloud_wallet_openid4vc::issuance::credential_offer::{InputMode, TxCode};
+use serde::{Deserialize, Serialize};
+
+use crate::session::{IssuanceState, SessionError};
+
+/// Request body for submitting a transaction code.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TxCodeRequest {
+    pub tx_code: String,
+}
+
+impl TxCodeRequest {
+    pub fn value(&self) -> Result<&str, TxCodeError> {
+        if self.tx_code.is_empty() {
+            return Err(TxCodeError::invalid_tx_code(
+                "Transaction code is required.",
+            ));
+        }
+        Ok(self.tx_code.as_str())
+    }
+
+    pub fn validate_against(&self, spec: &TxCode) -> Result<(), TxCodeError> {
+        let tx_code = self.value()?;
+        let numeric = spec.input_mode.unwrap_or_default() == InputMode::Numeric;
+        let expected_len = spec.length.map(|length| length as usize);
+
+        let has_invalid_chars = numeric && !tx_code.bytes().all(|byte| byte.is_ascii_digit());
+        let has_invalid_len = expected_len.is_some_and(|length| tx_code.chars().count() != length);
+
+        if has_invalid_chars || has_invalid_len {
+            return Err(TxCodeError::invalid_tx_code(tx_code_error_description(
+                numeric,
+                expected_len,
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Response body returned when a transaction code is accepted.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TxCodeResponse {
+    pub session_id: String,
+}
+
+/// Errors specific to transaction-code submission.
+#[derive(Debug, thiserror::Error)]
+pub enum TxCodeError {
+    #[error("{0}")]
+    InvalidTxCode(String),
+
+    #[error("No active session found for session_id {0}.")]
+    SessionNotFound(String),
+
+    #[error("{0}")]
+    InvalidSessionState(String),
+
+    #[error("error storing session: {0}")]
+    SessionStore(#[from] SessionError),
+}
+
+impl TxCodeError {
+    pub fn invalid_tx_code(description: impl Into<String>) -> Self {
+        Self::InvalidTxCode(description.into())
+    }
+
+    pub fn session_not_found(session_id: impl Into<String>) -> Self {
+        Self::SessionNotFound(session_id.into())
+    }
+
+    pub fn invalid_session_state(description: impl Into<String>) -> Self {
+        Self::InvalidSessionState(description.into())
+    }
+
+    pub fn not_awaiting_tx_code(state: IssuanceState) -> Self {
+        Self::invalid_session_state(format!(
+            "Session is not awaiting a transaction code (current state: {state:?}).",
+        ))
+    }
+
+    pub fn tx_code_not_required() -> Self {
+        Self::invalid_session_state("Session does not require a transaction code.")
+    }
+
+    pub fn not_pre_authorized_flow() -> Self {
+        Self::invalid_session_state("Session is not a pre-authorized code flow.")
+    }
+
+    pub fn error_description(&self) -> String {
+        match self {
+            Self::InvalidTxCode(description) | Self::InvalidSessionState(description) => {
+                description.clone()
+            }
+            Self::SessionNotFound(session_id) => {
+                format!("No active session found for session_id {session_id}.")
+            }
+            Self::SessionStore(error) => format!("error storing session: {error}"),
+        }
+    }
+}
+
+fn tx_code_error_description(numeric: bool, expected_len: Option<usize>) -> String {
+    match (numeric, expected_len) {
+        (true, Some(length)) => {
+            format!("Transaction code must be exactly {length} numeric digits.")
+        }
+        (true, None) => "Transaction code must contain only ASCII digits.".to_owned(),
+        (false, Some(length)) => {
+            format!("Transaction code must be exactly {length} characters.")
+        }
+        (false, None) => "Transaction code is invalid.".to_owned(),
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,10 +7,11 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::domain::service::Service;
-use crate::server::handlers::{health_check, home, register_tenant};
+use crate::server::handlers::{health_check, home, register_tenant, submit_transaction_code};
 use crate::session::SessionStore;
 
 use axum::http::Method;
+use axum::middleware;
 use axum::{
     Router,
     routing::{get, post},
@@ -43,7 +44,7 @@ pub struct Server {
 }
 
 impl Server {
-    /// Creates a new HTTPS server.
+    /// Creates a new HTTP server.
     pub async fn new<S: SessionStore + Clone>(
         config: &Config,
         service: Service<S>,
@@ -98,5 +99,14 @@ impl Server {
 }
 
 fn api_routes<S: SessionStore + Clone>() -> Router<AppState<S>> {
-    Router::new().route("/tenants", post(register_tenant))
+    let protected_routes = Router::new()
+        .route(
+            "/issuance/{session_id}/tx-code",
+            post(submit_transaction_code),
+        )
+        .route_layer(middleware::from_fn(auth::auth));
+
+    Router::new()
+        .route("/tenants", post(register_tenant))
+        .merge(protected_routes)
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -7,7 +7,7 @@ use axum::{
 };
 use serde::Serialize;
 
-use crate::domain::models::issuance::{IssuanceError, IssuanceErrorCode};
+use crate::domain::models::issuance::{IssuanceError, IssuanceErrorCode, TxCodeError};
 use crate::domain::models::tenants::TenantError;
 
 /// The unified error type used by all HTTP handlers.
@@ -113,6 +113,31 @@ impl IntoApiError for IssuanceError {
             status,
             error: self.error.to_string().into(),
             error_description: self.error_description,
+        }
+    }
+}
+
+impl IntoApiError for TxCodeError {
+    fn into_api_error(self) -> ApiError {
+        match self {
+            TxCodeError::InvalidTxCode(description) => ApiError {
+                status: StatusCode::BAD_REQUEST,
+                error: Cow::Borrowed("invalid_tx_code"),
+                error_description: Some(description),
+            },
+            TxCodeError::SessionNotFound(session_id) => ApiError {
+                status: StatusCode::NOT_FOUND,
+                error: Cow::Borrowed("session_not_found"),
+                error_description: Some(format!(
+                    "No active session found for session_id {session_id}."
+                )),
+            },
+            TxCodeError::InvalidSessionState(description) => ApiError {
+                status: StatusCode::CONFLICT,
+                error: Cow::Borrowed("invalid_session_state"),
+                error_description: Some(description),
+            },
+            TxCodeError::SessionStore(source) => ApiError::internal(source),
         }
     }
 }

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1,8 +1,10 @@
 mod health;
+mod issuance;
 mod root;
 mod tenant;
 
 // Export handlers for use in the server
 pub use health::health_check;
+pub use issuance::submit_transaction_code;
 pub use root::home;
 pub use tenant::register_tenant;

--- a/src/server/handlers/issuance/mod.rs
+++ b/src/server/handlers/issuance/mod.rs
@@ -1,0 +1,3 @@
+mod tx_code;
+
+pub use tx_code::submit_transaction_code;

--- a/src/server/handlers/issuance/tx_code.rs
+++ b/src/server/handlers/issuance/tx_code.rs
@@ -1,0 +1,77 @@
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use cloud_wallet_openid4vc::issuance::{client::IssuanceFlow, credential_offer::TxCode};
+use tracing::{info, instrument};
+
+use crate::domain::models::issuance::{
+    IssuanceTask, TxCodeError, TxCodeRequest, TxCodeResponse, transition_session,
+};
+use crate::server::{AppState, error::ApiError, responses::ResponseBody};
+use crate::session::{IssuanceSession, IssuanceState, SessionStore};
+
+/// Submit the transaction code required by a pre-authorized code issuance flow.
+#[instrument(skip_all, fields(session_id = %session_id))]
+pub async fn submit_transaction_code<S: SessionStore + Clone>(
+    State(state): State<AppState<S>>,
+    Path(session_id): Path<String>,
+    Json(payload): Json<TxCodeRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let session = load_awaiting_tx_code(&state.service.session, &session_id).await?;
+
+    payload.validate_against(tx_code_spec(&session)?)?;
+    let pre_authorized_code = pre_authorized_code(&session)?;
+
+    transition_session(
+        &state.service.session,
+        session_id.as_str(),
+        IssuanceState::Processing,
+    )
+    .await?;
+
+    let tx_code = Some(payload.tx_code);
+    let task = IssuanceTask::new_pre_authz_code(&session, pre_authorized_code, tx_code);
+    state.service.issuance_engine.enqueue(&task).await?;
+
+    info!(session_id = %session_id, "transaction code accepted");
+    Ok(ResponseBody::new(
+        StatusCode::ACCEPTED,
+        TxCodeResponse { session_id },
+    ))
+}
+
+async fn load_awaiting_tx_code<S: SessionStore>(
+    session_store: &S,
+    session_id: &str,
+) -> Result<IssuanceSession, TxCodeError> {
+    let session: Option<IssuanceSession> = session_store.get(session_id).await?;
+    let Some(session) = session else {
+        return Err(TxCodeError::session_not_found(session_id));
+    };
+
+    if session.state != IssuanceState::AwaitingTxCode {
+        return Err(TxCodeError::not_awaiting_tx_code(session.state));
+    }
+    Ok(session)
+}
+
+fn tx_code_spec(session: &IssuanceSession) -> Result<&TxCode, TxCodeError> {
+    session
+        .context
+        .flow
+        .tx_code_spec()
+        .ok_or_else(TxCodeError::tx_code_not_required)
+}
+
+fn pre_authorized_code(session: &IssuanceSession) -> Result<String, TxCodeError> {
+    match &session.context.flow {
+        IssuanceFlow::PreAuthorizedCode {
+            pre_authorized_code,
+            ..
+        } => Ok(pre_authorized_code.clone()),
+        IssuanceFlow::AuthorizationCode { .. } => Err(TxCodeError::not_pre_authorized_flow()),
+    }
+}

--- a/tests/issuance_tx_code.rs
+++ b/tests/issuance_tx_code.rs
@@ -1,0 +1,333 @@
+//! Integration tests for POST /api/v1/issuance/{session_id}/tx-code
+
+pub mod utils;
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use cloud_identity_wallet::{
+    config::Config,
+    domain::{
+        models::issuance::{FlowType, IssuanceEngine, IssuanceError, IssuanceTask},
+        ports::IssuanceTaskQueue,
+        service::Service,
+    },
+    outbound::{MemoryCredentialRepo, MemoryEventPublisher, MemoryTenantRepo},
+    server::Server,
+    session::{IssuanceSession, IssuanceState, MemorySession, SessionStore},
+};
+use cloud_wallet_openid4vc::issuance::client::{Config as Oid4vciClientConfig, Oid4vciClient};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use reqwest::Client;
+use time::OffsetDateTime;
+use url::Url;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Default)]
+struct RecordingTaskQueue {
+    pushed: Arc<Mutex<Vec<IssuanceTask>>>,
+}
+
+#[async_trait]
+impl IssuanceTaskQueue for RecordingTaskQueue {
+    async fn push(&self, task: &IssuanceTask) -> Result<(), IssuanceError> {
+        self.pushed.lock().unwrap().push(task.clone());
+        Ok(())
+    }
+
+    async fn pop(&self) -> Result<Option<IssuanceTask>, IssuanceError> {
+        Ok(None)
+    }
+
+    async fn ack(&self, _task: &IssuanceTask) -> Result<(), IssuanceError> {
+        Ok(())
+    }
+}
+
+struct TxCodeTestApp {
+    base_url: String,
+    session_store: MemorySession,
+    pushed_tasks: Arc<Mutex<Vec<IssuanceTask>>>,
+    auth_token: String,
+}
+
+async fn spawn_tx_code_test_app(session_store: MemorySession) -> TxCodeTestApp {
+    let mut config = Config::load().unwrap();
+    config.server.host = "localhost".to_owned();
+    config.server.port = 0;
+    config.oid4vci.use_system_proxy = false;
+
+    let queue = RecordingTaskQueue::default();
+    let pushed_tasks = queue.pushed.clone();
+    let tenant_repo = MemoryTenantRepo::new();
+    let client_config = Oid4vciClientConfig::new(
+        "wallet-client",
+        Url::parse("https://wallet.example.com/api/v1/issuance/callback").unwrap(),
+    )
+    .timeout(Duration::from_secs(60))
+    .accept_untrusted_hosts(true);
+
+    let client = Oid4vciClient::new(client_config).unwrap();
+    let engine = IssuanceEngine::new(
+        client,
+        queue,
+        MemoryEventPublisher::new(16),
+        MemoryCredentialRepo::new(),
+        tenant_repo.clone(),
+        &session_store,
+    );
+    let service = Service::new(session_store.clone(), tenant_repo, engine);
+    let server = Server::new(&config, service).await.unwrap();
+    let port = server.port();
+
+    tokio::spawn(server.run());
+
+    let auth_token = create_test_bearer_token(Uuid::new_v4());
+
+    TxCodeTestApp {
+        base_url: format!("http://{}:{port}", config.server.host),
+        session_store,
+        pushed_tasks,
+        auth_token,
+    }
+}
+
+fn create_test_keypair() -> (String, jsonwebtoken::jwk::Jwk) {
+    let private_key_pem = "-----BEGIN PRIVATE KEY-----
+        MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgsJyilHyjhzXDVU2A
+        5ud6kfXPktY7wx5d8CQFe1nMzK2hRANCAAQ17IW//Yvrs4SmU1smlHTYgWKzj+UV
+        b0diaF8Xk6vqb3gB9qnvD4NxkNvLsQPPqjQKncEP831drigLydrC6WPT
+        -----END PRIVATE KEY-----
+    "
+    .to_string();
+
+    let public_key: jsonwebtoken::jwk::Jwk = serde_json::from_str(
+        r#"{
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "NeyFv_2L67OEplNbJpR02IFis4_lFW9HYmhfF5Or6m8",
+            "y": "eAH2qe8Pg3GQ28uxA8-qNAqdwQ_zfV2uKAvJ2sLpY9M"
+        }"#,
+    )
+    .unwrap();
+
+    (private_key_pem, public_key)
+}
+
+fn create_test_bearer_token(tenant_id: Uuid) -> String {
+    let (private_pem, public_key) = create_test_keypair();
+    let encoding_key = EncodingKey::from_ec_pem(private_pem.as_bytes()).unwrap();
+
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+    let claims = serde_json::json!({
+        "sub": tenant_id,
+        "iat": now,
+        "exp": now + 3600,
+    });
+
+    let mut header = Header::new(Algorithm::ES256);
+    header.jwk = Some(public_key);
+
+    encode(&header, &claims, &encoding_key).unwrap()
+}
+
+fn mock_session(session_id: &str, state: IssuanceState) -> IssuanceSession {
+    let context = serde_json::from_value(serde_json::json!({
+        "offer": {
+            "credential_issuer": "https://issuer.example.com",
+            "credential_configuration_ids": ["test_id"],
+            "grants": {
+                "urn:ietf:params:oauth:grant-type:pre-authorized_code": {
+                    "pre-authorized_code": "pre-auth-code",
+                    "tx_code": {
+                        "input_mode": "numeric",
+                        "length": 6,
+                        "description": "Enter the one-time code."
+                    }
+                }
+            }
+        },
+        "issuer_metadata": {
+            "credential_issuer": "https://issuer.example.com",
+            "credential_endpoint": "https://issuer.example.com/credential",
+            "credential_configurations_supported": {
+                "test_id": {
+                    "format": "dc+sd-jwt",
+                    "vct": "https://credentials.example.com/test"
+                }
+            }
+        },
+        "as_metadata": {
+            "issuer": "https://issuer.example.com",
+            "authorization_endpoint": "https://issuer.example.com/authorize",
+            "token_endpoint": "https://10.255.255.1/token",
+            "response_types_supported": ["code"],
+            "grant_types_supported": ["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
+        },
+        "flow": {
+            "PreAuthorizedCode": {
+                "pre_authorized_code": "pre-auth-code",
+                "tx_code": {
+                    "input_mode": "numeric",
+                    "length": 6,
+                    "description": "Enter the one-time code."
+                }
+            }
+        }
+    }))
+    .unwrap();
+
+    let mut session = IssuanceSession::new(Uuid::new_v4(), context, FlowType::PreAuthorizedCode);
+    session.id = session_id.to_owned();
+    session.state = state;
+    session.selected_config_ids = vec!["test_id".to_owned()];
+    session
+}
+
+#[tokio::test]
+async fn valid_tx_code_transitions_session_to_processing_and_enqueues_task() {
+    let session_id = "ses_tx_code_success";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingTxCode);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_tx_code_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .post(format!(
+            "{}/api/v1/issuance/{session_id}/tx-code",
+            app.base_url
+        ))
+        .bearer_auth(&app.auth_token)
+        .json(&serde_json::json!({ "tx_code": "493821" }))
+        .send()
+        .await
+        .expect("failed to send tx-code request");
+
+    assert_eq!(response.status(), 202);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["session_id"], session_id);
+
+    let session: IssuanceSession = app.session_store.get(session_id).await.unwrap().unwrap();
+    assert_eq!(session.state, IssuanceState::Processing);
+
+    let tasks = app.pushed_tasks.lock().unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert_eq!(tasks[0].session_id, session_id);
+    assert_eq!(
+        tasks[0].pre_authorized_code.as_deref(),
+        Some("pre-auth-code")
+    );
+    assert_eq!(tasks[0].tx_code.as_deref(), Some("493821"));
+}
+
+#[tokio::test]
+async fn empty_tx_code_returns_400() {
+    let session_id = "ses_tx_code_empty";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingTxCode);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_tx_code_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .post(format!(
+            "{}/api/v1/issuance/{session_id}/tx-code",
+            app.base_url
+        ))
+        .bearer_auth(&app.auth_token)
+        .json(&serde_json::json!({ "tx_code": "" }))
+        .send()
+        .await
+        .expect("failed to send tx-code request");
+
+    assert_eq!(response.status(), 400);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["error"], "invalid_tx_code");
+    assert!(app.pushed_tasks.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn non_numeric_tx_code_returns_400() {
+    let session_id = "ses_tx_code_non_numeric";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::AwaitingTxCode);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_tx_code_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .post(format!(
+            "{}/api/v1/issuance/{session_id}/tx-code",
+            app.base_url
+        ))
+        .bearer_auth(&app.auth_token)
+        .json(&serde_json::json!({ "tx_code": "49A821" }))
+        .send()
+        .await
+        .expect("failed to send tx-code request");
+
+    assert_eq!(response.status(), 400);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["error"], "invalid_tx_code");
+}
+
+#[tokio::test]
+async fn wrong_session_state_returns_409() {
+    let session_id = "ses_tx_code_wrong_state";
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let mock_session = mock_session(session_id, IssuanceState::Processing);
+    session_store
+        .upsert(session_id, &mock_session)
+        .await
+        .unwrap();
+    let app = spawn_tx_code_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .post(format!(
+            "{}/api/v1/issuance/{session_id}/tx-code",
+            app.base_url
+        ))
+        .bearer_auth(&app.auth_token)
+        .json(&serde_json::json!({ "tx_code": "493821" }))
+        .send()
+        .await
+        .expect("failed to send tx-code request");
+
+    assert_eq!(response.status(), 409);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["error"], "invalid_session_state");
+}
+
+#[tokio::test]
+async fn unknown_session_returns_404() {
+    let session_store = MemorySession::new(Duration::from_secs(5));
+    let app = spawn_tx_code_test_app(session_store).await;
+    let client = Client::new();
+
+    let response = client
+        .post(format!(
+            "{}/api/v1/issuance/{}/tx-code",
+            app.base_url, "ses_tx_code_unknown"
+        ))
+        .bearer_auth(&app.auth_token)
+        .json(&serde_json::json!({ "tx_code": "493821" }))
+        .send()
+        .await
+        .expect("failed to send tx-code request");
+
+    assert_eq!(response.status(), 404);
+    let body: serde_json::Value = response.json().await.expect("failed to parse response");
+    assert_eq!(body["error"], "session_not_found");
+}


### PR DESCRIPTION
Submits the transaction code for pre-authorized code flows where the issuer requires one. The backend stores the code and immediately starts the token exchange.

### Implementation tasks
 
- [x] Retrieve session and validate it is in `awaiting_tx_code`.
- [x] Validate `tx_code` against `tx_code` stored in the session (length and `input_mode`). Return `400 invalid_tx_code` on mismatch.
- [x] Transition session to `processing`. Emit `processing` SSE event with `step: "exchanging_token"`.
- [x] enqueue task for background processing.
- [x] Respond `202`.
 
### Acceptance criteria
 
- [x] Valid numeric code for a `numeric` spec returns `202` and background task starts.
- [x] Non-numeric characters for a `numeric` spec return `400 invalid_tx_code`.
- [x] Code of wrong length returns `400 invalid_tx_code`.
- [x] Submitting to a session not in `awaiting_tx_code` returns `409`.

cc @Christiantyemele @ndefokou @martcpp