### PR TITLE
feat: enrich issuance start response with issuer and credential displ…

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -116,9 +116,11 @@ paths:
                     session_id: ses_7f3kQ2mXpLnVwRtYbHsD9cAeUjZo1Ni
                     expires_at: "2026-04-08T14:35:00Z"
                     issuer:
-                      credential_issuer: https://issuer.example.eu
-                      display_name: Example EU Identity Authority
-                      logo_uri: null
+                      - name: Example EU Identity Authority
+                        locale: en-US
+                        logo:
+                          uri: https://issuer.example.eu/assets/logo.svg
+                          alt_text: Example Issuer Logo
                     credential_types:
                       - credential_configuration_id: eu.europa.ec.eudi.pid.1
                         format: vc+sd-jwt
@@ -139,9 +141,8 @@ paths:
                     session_id: ses_9aKpR1xWqNmLvYcZbTsE4dBfUhOo2Gj
                     expires_at: "2026-04-08T14:35:00Z"
                     issuer:
-                      credential_issuer: https://issuer.example.eu
-                      display_name: Example EU Identity Authority
-                      logo_uri: null
+                      - name: Example EU Identity Authority
+                        locale: en-US
                     credential_types:
                       - credential_configuration_id: eu.europa.ec.eudi.lpid.1
                         format: vc+sd-jwt
@@ -150,7 +151,6 @@ paths:
                           description: Official EU legal entity identity credential
                           background_color: "#1a4f2e"
                           text_color: "#ffffff"
-                          logo: null
                     flow: pre_authorized_code
                     tx_code_required: true
                     tx_code:
@@ -913,7 +913,14 @@ components:
             is reached.
           example: "2026-04-08T14:35:00Z"
         issuer:
-          $ref: "#/components/schemas/IssuerSummary"
+          type: array
+          description: |
+            Display properties for the Credential Issuer per OpenID4VCI spec.
+            Contains one or more display objects for different locales.
+            Fallback: if no display metadata in issuer metadata, returns a single
+            entry with `name` set to the credential_issuer URL.
+          items:
+            $ref: "#/components/schemas/IssuerDisplay"
         credential_types:
           type: array
           description: |
@@ -944,36 +951,39 @@ components:
             - $ref: "#/components/schemas/TxCodeSpec"
             - type: "null"
 
-    IssuerSummary:
+    IssuerDisplay:
+      type: object
+      description: |
+        Display properties for a Credential Issuer per OpenID4VCI spec §12.2.4.
+        When issuer metadata lacks display info, a fallback object is created
+        with `name` set to the credential_issuer URL.
+      properties:
+        name:
+          type: string
+          description: Human-readable display name of the Credential Issuer.
+          example: Example EU Identity Authority
+        locale:
+          type: string
+          description: BCP47 language tag (e.g. "en-US").
+          example: en-US
+        logo:
+          $ref: "#/components/schemas/Logo"
+
+    Logo:
       type: object
       required:
-        - credential_issuer
-        - display_name
-        - logo_uri
-      description: Resolved issuer metadata summary returned by `/start`.
+        - uri
+      description: Logo information for display objects.
       properties:
-        credential_issuer:
+        uri:
           type: string
           format: uri
-          description: Issuer identifier URL.
-          example: https://issuer.example.eu
-        display_name:
-          description: |
-            Human-readable issuer name from issuer metadata `display[0].name`.
-            `null` if not present in the issuer metadata.
-          oneOf:
-            - type: string
-            - type: "null"
-          example: Example EU Identity Authority
-        logo_uri:
-          description: |
-            Issuer logo URI from issuer metadata `display[0].logo.uri`.
-            `null` if not present.
-          oneOf:
-            - type: string
-              format: uri
-            - type: "null"
-          example: null
+          description: URI where the logo image can be obtained.
+          example: https://issuer.example.eu/assets/logo.svg
+        alt_text:
+          type: string
+          description: Alternative text for accessibility.
+          example: EU Issuer Logo
 
     CredentialTypeDisplay:
       type: object
@@ -1025,24 +1035,8 @@ components:
         logo:
           description: Logo image metadata. `null` if no logo is available.
           oneOf:
-            - $ref: "#/components/schemas/CredentialLogo"
+            - $ref: "#/components/schemas/Logo"
             - type: "null"
-
-    CredentialLogo:
-      type: object
-      required:
-        - uri
-      description: Logo image for a credential type.
-      properties:
-        uri:
-          type: string
-          format: uri
-          description: URI of the logo image.
-          example: https://issuer.example.eu/assets/pid-logo.svg
-        alt_text:
-          type: string
-          description: Accessibility alt text for the logo image.
-          example: EU PID Logo
 
     TxCodeSpec:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -125,13 +125,13 @@ paths:
                       - credential_configuration_id: eu.europa.ec.eudi.pid.1
                         format: vc+sd-jwt
                         display:
-                          name: EU Personal ID
-                          description: Official EU personal identity document
-                          background_color: "#12107c"
-                          text_color: "#ffffff"
-                          logo:
-                            uri: https://issuer.example.eu/assets/pid-logo.svg
-                            alt_text: EU PID Logo
+                          - name: EU Personal ID
+                            description: Official EU personal identity document
+                            background_color: "#12107c"
+                            text_color: "#ffffff"
+                            logo:
+                              uri: https://issuer.example.eu/assets/pid-logo.svg
+                              alt_text: EU PID Logo
                     flow: authorization_code
                     tx_code_required: false
                     tx_code: null
@@ -147,10 +147,10 @@ paths:
                       - credential_configuration_id: eu.europa.ec.eudi.lpid.1
                         format: vc+sd-jwt
                         display:
-                          name: EU Legal Person ID
-                          description: Official EU legal entity identity credential
-                          background_color: "#1a4f2e"
-                          text_color: "#ffffff"
+                          - name: EU Legal Person ID
+                            description: Official EU legal entity identity credential
+                            background_color: "#1a4f2e"
+                            text_color: "#ffffff"
                     flow: pre_authorized_code
                     tx_code_required: true
                     tx_code:
@@ -993,9 +993,9 @@ components:
         - display
       description: |
         A single credential configuration being offered, enriched with display
-        metadata sourced from `credential_configurations_supported[id].display[0]`
-        for the best-matching locale (fallback to first entry if no locale
-        match).
+        metadata sourced from `credential_configurations_supported[id].display`
+        for all available locales (fallback to single entry with configuration
+        ID as name if no display metadata exists).
       properties:
         credential_configuration_id:
           type: string
@@ -1006,7 +1006,11 @@ components:
           description: Credential format (e.g. `vc+sd-jwt`, `mso_mdoc`).
           example: vc+sd-jwt
         display:
-          $ref: "#/components/schemas/CredentialDisplay"
+          type: array
+          description: Array of display metadata for different locales.
+          minItems: 1
+          items:
+            $ref: "#/components/schemas/CredentialDisplay"
 
     CredentialDisplay:
       type: object

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -10,7 +10,7 @@ pub use error::{IssuanceError, IssuanceErrorCode};
 pub use events::*;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
-pub use start::{CredentialTypeDisplay, IssuerInfo, StartIssuanceRequest, StartIssuanceResponse};
+pub use start::{CredentialTypeDisplay, StartIssuanceRequest, StartIssuanceResponse};
 pub use task::{IssuanceTask, TaskResult};
 pub use tx_code::{TxCodeError, TxCodeRequest, TxCodeResponse};
 

--- a/src/domain/models/issuance/start.rs
+++ b/src/domain/models/issuance/start.rs
@@ -30,7 +30,7 @@ pub struct StartIssuanceResponse {
 pub struct CredentialTypeDisplay {
     pub credential_configuration_id: String,
     pub format: String,
-    pub display: CredentialDisplay,
+    pub display: Vec<CredentialDisplay>,
 }
 
 impl StartIssuanceResponse {
@@ -61,8 +61,9 @@ impl StartIssuanceResponse {
                     .credential_metadata
                     .as_ref()
                     .and_then(|m| m.display.as_ref())
-                    .and_then(|d| d.first().cloned())
-                    .unwrap_or_else(|| CredentialDisplay {
+                    .filter(|d| !d.is_empty())
+                    .cloned()
+                    .unwrap_or_else(|| vec![CredentialDisplay {
                         name: id.clone(),
                         locale: None,
                         logo: None,
@@ -70,7 +71,7 @@ impl StartIssuanceResponse {
                         background_image: None,
                         text_color: None,
                         description: None,
-                    });
+                    }]);
 
                 Some(CredentialTypeDisplay {
                     credential_configuration_id: id.clone(),

--- a/src/domain/models/issuance/start.rs
+++ b/src/domain/models/issuance/start.rs
@@ -1,9 +1,9 @@
 use cloud_wallet_openid4vc::issuance::client::{IssuanceFlow, ResolvedOfferContext};
 use cloud_wallet_openid4vc::issuance::credential_configuration::CredentialDisplay;
 use cloud_wallet_openid4vc::issuance::credential_offer::TxCode;
+use cloud_wallet_openid4vc::issuance::issuer_metadata::IssuerDisplay;
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime, format_description::well_known::Rfc3339};
-use url::Url;
 
 use super::IssuanceError;
 use crate::session::IssuanceSession;
@@ -19,7 +19,7 @@ pub struct StartIssuanceRequest {
 pub struct StartIssuanceResponse {
     pub session_id: String,
     pub expires_at: String,
-    pub issuer: IssuerInfo,
+    pub issuer: Vec<IssuerDisplay>,
     pub credential_types: Vec<CredentialTypeDisplay>,
     pub flow: String,
     pub tx_code_required: bool,
@@ -27,17 +27,10 @@ pub struct StartIssuanceResponse {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub struct IssuerInfo {
-    pub credential_issuer: Url,
-    pub display_name: Option<String>,
-    pub logo_uri: Option<Url>,
-}
-
-#[derive(Debug, Clone, Serialize)]
 pub struct CredentialTypeDisplay {
     pub credential_configuration_id: String,
     pub format: String,
-    pub display: Option<CredentialDisplay>,
+    pub display: CredentialDisplay,
 }
 
 impl StartIssuanceResponse {
@@ -45,21 +38,13 @@ impl StartIssuanceResponse {
         context: &ResolvedOfferContext,
         session: &IssuanceSession,
     ) -> Result<Self, IssuanceError> {
-        let issuer = IssuerInfo {
-            credential_issuer: context.offer.credential_issuer.clone(),
-            display_name: context
-                .issuer_metadata
-                .display
-                .as_ref()
-                .and_then(|d| d.first())
-                .and_then(|d| d.name.clone()),
-            logo_uri: context
-                .issuer_metadata
-                .display
-                .as_ref()
-                .and_then(|d| d.first())
-                .and_then(|d| d.logo.as_ref())
-                .map(|l| l.uri.clone()),
+        let issuer = match &context.issuer_metadata.display {
+            Some(d) if !d.is_empty() => d.clone(),
+            _ => vec![IssuerDisplay {
+                name: Some(context.offer.credential_issuer.to_string()),
+                locale: None,
+                logo: None,
+            }],
         };
 
         let credential_types: Vec<CredentialTypeDisplay> = context
@@ -76,8 +61,16 @@ impl StartIssuanceResponse {
                     .credential_metadata
                     .as_ref()
                     .and_then(|m| m.display.as_ref())
-                    .and_then(|d| d.first())
-                    .cloned();
+                    .and_then(|d| d.first().cloned())
+                    .unwrap_or_else(|| CredentialDisplay {
+                        name: id.clone(),
+                        locale: None,
+                        logo: None,
+                        background_color: None,
+                        background_image: None,
+                        text_color: None,
+                        description: None,
+                    });
 
                 Some(CredentialTypeDisplay {
                     credential_configuration_id: id.clone(),

--- a/src/domain/models/issuance/start.rs
+++ b/src/domain/models/issuance/start.rs
@@ -63,15 +63,17 @@ impl StartIssuanceResponse {
                     .and_then(|m| m.display.as_ref())
                     .filter(|d| !d.is_empty())
                     .cloned()
-                    .unwrap_or_else(|| vec![CredentialDisplay {
-                        name: id.clone(),
-                        locale: None,
-                        logo: None,
-                        background_color: None,
-                        background_image: None,
-                        text_color: None,
-                        description: None,
-                    }]);
+                    .unwrap_or_else(|| {
+                        vec![CredentialDisplay {
+                            name: id.clone(),
+                            locale: None,
+                            logo: None,
+                            background_color: None,
+                            background_image: None,
+                            text_color: None,
+                            description: None,
+                        }]
+                    });
 
                 Some(CredentialTypeDisplay {
                     credential_configuration_id: id.clone(),


### PR DESCRIPTION
…ay metadata

- Replace IssuerInfo struct with Vec<IssuerDisplay> array per OpenID4VCI spec
- Change CredentialTypeDisplay.display from Option to required with fallback
- Add fallback for issuer display: use credential_issuer URL as name
- Add fallback for credential display: use configuration_id as display name
- Update OpenAPI schemas to reflect new response structure
- Avoid unnecessary cloning of large metadata objects

Closes #195