### PR TITLE
Fix/improve internal error tracing and structured observability across issuance flows

### DIFF
--- a/src/domain/models/issuance/consent.rs
+++ b/src/domain/models/issuance/consent.rs
@@ -33,9 +33,6 @@ pub enum ConsentError {
     #[error("Session is not in awaiting_consent state")]
     InvalidState,
 
-    #[error("Failed to build authorization URL: {0}")]
-    AuthorizationUrlFailed(String),
-
     #[error("Session storage error: {0}")]
     Storage(#[source] Box<dyn std::error::Error + Send + Sync>),
 

--- a/src/domain/models/issuance/error.rs
+++ b/src/domain/models/issuance/error.rs
@@ -55,13 +55,25 @@ impl fmt::Display for IssuanceErrorCode {
 
 /// Error that can occur during credential issuance orchestration.
 #[derive(Debug, thiserror::Error)]
-#[error("{error}: {error_description:?}")]
 pub struct IssuanceError {
     pub error: IssuanceErrorCode,
     pub error_description: Option<String>,
     pub step: IssuanceStep,
     #[source]
     pub source: Option<DynError>,
+}
+
+impl fmt::Display for IssuanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.error)?;
+        if let Some(desc) = &self.error_description {
+            write!(f, ": {desc}")?;
+        }
+        if let Some(source) = &self.source {
+            write!(f, "\n\ncaused by:\n\t{source}")?;
+        }
+        Ok(())
+    }
 }
 
 impl IssuanceError {
@@ -195,26 +207,37 @@ fn oid4vci_error_code<T: Serialize>(error: &T) -> String {
 impl From<ClientError> for IssuanceError {
     fn from(err: ClientError) -> Self {
         match err {
-            ClientError::Authorization(e) => Self::external(
-                IssuanceStep::Authorization,
-                oid4vci_error_code(&e.error),
-                e.error_description,
-            ),
-            ClientError::Token(e) => Self::external(
-                IssuanceStep::Token,
-                oid4vci_error_code(&e.error),
-                e.error_description,
-            ),
-            ClientError::Credential(e) => Self::external(
-                IssuanceStep::CredentialRequest,
-                oid4vci_error_code(&e.error),
-                e.error_description,
-            ),
-            ClientError::DeferredCredential(e) => Self::external(
-                IssuanceStep::DeferredCredential,
-                oid4vci_error_code(&e.error),
-                e.error_description,
-            ),
+            ClientError::Authorization(e) => {
+                let alt_description = Some(e.to_string());
+                Self::external(
+                    IssuanceStep::Authorization,
+                    oid4vci_error_code(&e.error),
+                    e.error_description.or(alt_description),
+                )
+            }
+            ClientError::Token(e) => {
+                let alt_description = Some(e.to_string());
+                Self::external(
+                    IssuanceStep::Token,
+                    oid4vci_error_code(&e.error),
+                    e.error_description.or(alt_description),
+                )
+            }
+            ClientError::Credential(e) => {
+                let alt_description = Some(e.to_string());
+                Self::external(
+                    IssuanceStep::CredentialRequest,
+                    oid4vci_error_code(&e.error),
+                    e.error_description.or(alt_description),
+                )
+            }
+            ClientError::DeferredCredential(e) => {
+                let alt_description = Some(e.to_string());
+                Self::external(
+                    IssuanceStep::DeferredCredential,
+                    oid4vci_error_code(&e.error),
+                    e.error_description.or(alt_description),
+            )},
             ClientError::Notification(e) => Self::external(
                 IssuanceStep::Notification,
                 oid4vci_error_code(&e.error),

--- a/src/domain/models/issuance/error.rs
+++ b/src/domain/models/issuance/error.rs
@@ -237,7 +237,8 @@ impl From<ClientError> for IssuanceError {
                     IssuanceStep::DeferredCredential,
                     oid4vci_error_code(&e.error),
                     e.error_description.or(alt_description),
-            )},
+                )
+            }
             ClientError::Notification(e) => Self::external(
                 IssuanceStep::Notification,
                 oid4vci_error_code(&e.error),

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -295,7 +295,7 @@ impl IssuanceEngine {
             .await;
 
         if let Err(ref err) = result {
-            error!(error = %err, step = %err.step(), "issuance failed");
+            error!(error = ?err, step = %err.step(), "issuance failed");
 
             // Emit failed SSE event
             let failed = IssuanceEvent::Failed(SseFailedEvent::new(

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -112,6 +112,23 @@ impl IntoApiError for IssuanceError {
             IssuanceErrorCode::External(_) => StatusCode::BAD_GATEWAY,
         };
 
+        if status == StatusCode::INTERNAL_SERVER_ERROR {
+            tracing::error!(
+                error = %self,
+                error.source = ?self.source,
+                step = %self.step,
+                "issuance internal error"
+            );
+        }
+        if status == StatusCode::BAD_GATEWAY {
+            tracing::warn!(
+                error = %self,
+                error.source = ?self.source,
+                step = %self.step,
+                "external system error during issuance"
+            );
+        }
+
         ApiError {
             status,
             error: self.error.to_string().into(),
@@ -126,28 +143,15 @@ impl IntoApiError for ConsentError {
             ConsentError::NotFound(session_id) => ApiError {
                 status: StatusCode::NOT_FOUND,
                 error: Cow::Borrowed("session_not_found"),
-                error_description: Some(format!("Session {} does not exist", session_id)),
+                error_description: Some(format!("Session {session_id} does not exist")),
             },
             ConsentError::InvalidState => ApiError {
                 status: StatusCode::CONFLICT,
                 error: Cow::Borrowed("invalid_session_state"),
                 error_description: Some("Session is not in awaiting_consent state".into()),
             },
-            ConsentError::AuthorizationUrlFailed(msg) => ApiError {
-                status: StatusCode::BAD_GATEWAY,
-                error: Cow::Borrowed("bad_gateway"),
-                error_description: Some(msg),
-            },
             ConsentError::Storage(err) => ApiError::internal(err),
-            ConsentError::EventPublishing(msg) => {
-                tracing::warn!("Event publishing failed: {}", msg);
-                // Event publishing failures are not critical, so we don't return an error to the client
-                ApiError {
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                    error: Cow::Borrowed("internal_error"),
-                    error_description: Some(msg),
-                }
-            }
+            ConsentError::EventPublishing(msg) => ApiError::internal(msg),
         }
     }
 }
@@ -160,10 +164,7 @@ impl IntoApiError for SessionError {
             SessionError::InvalidStateTransition(from, to) => ApiError {
                 status: StatusCode::CONFLICT,
                 error: Cow::Borrowed("invalid_state_transition"),
-                error_description: Some(format!(
-                    "Invalid state transition from {} to {}",
-                    from, to
-                )),
+                error_description: Some(format!("Invalid state transition from {from} to {to}")),
             },
             SessionError::Other(err) => ApiError::internal(err),
         }

--- a/src/server/handlers/issuance/consent.rs
+++ b/src/server/handlers/issuance/consent.rs
@@ -163,7 +163,7 @@ async fn load_awaiting_consent<S: SessionStore>(
         return Err(ApiError {
             status: StatusCode::NOT_FOUND,
             error: Cow::Borrowed("session_not_found"),
-            error_description: Some("session_id does not exist or has expired.".into()),
+            error_description: Some("Session does not exist or has expired.".into()),
         });
     };
 

--- a/src/server/handlers/issuance/events.rs
+++ b/src/server/handlers/issuance/events.rs
@@ -33,12 +33,7 @@ pub async fn get_session_events<S: SessionStore + Clone>(
         return Err(session_not_found());
     }
 
-    let stream = state
-        .service
-        .issuance_engine
-        .subscribe(&session_id)
-        .await
-        .map_err(ApiError::internal)?;
+    let stream = state.service.issuance_engine.subscribe(&session_id).await?;
 
     debug!(session_id = %session_id, "SSE stream established");
     Ok((event_stream_to_sse(stream)).into_response())

--- a/src/server/handlers/issuance/start.rs
+++ b/src/server/handlers/issuance/start.rs
@@ -4,7 +4,7 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
-use cloud_wallet_openid4vc::issuance::client::{IssuanceFlow, Oid4vciClient, ResolvedOfferContext};
+use cloud_wallet_openid4vc::issuance::client::{IssuanceFlow, Oid4vciClient};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -21,7 +21,7 @@ pub async fn start_issuance<S: SessionStore + Clone>(
     Extension(tenant_id): Extension<Uuid>,
     Json(payload): Json<StartIssuanceRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let (_, _, response) = start_issuance_session(
+    let response = start_issuance_session(
         &state.service.issuance_engine.client,
         &state.service.session,
         &payload.offer,
@@ -37,7 +37,7 @@ async fn start_issuance_session<S: SessionStore>(
     session_store: &S,
     offer: &str,
     tenant_id: Uuid,
-) -> Result<(ResolvedOfferContext, IssuanceSession, StartIssuanceResponse), IssuanceError> {
+) -> Result<StartIssuanceResponse, IssuanceError> {
     if offer.is_empty() {
         return Err(IssuanceError::new(
             IssuanceErrorCode::InvalidCredentialOffer,
@@ -48,10 +48,7 @@ async fn start_issuance_session<S: SessionStore>(
 
     debug!(offer = %offer, "resolving credential offer");
 
-    let context = client
-        .resolve_offer_with_metadata(offer, None)
-        .await
-        .map_err(Into::<IssuanceError>::into)?;
+    let context = client.resolve_offer_with_metadata(offer, None).await?;
 
     let flow_type = match &context.flow {
         IssuanceFlow::AuthorizationCode { .. } => FlowType::AuthorizationCode,
@@ -59,13 +56,9 @@ async fn start_issuance_session<S: SessionStore>(
     };
 
     let session = IssuanceSession::new(tenant_id, context.clone(), flow_type);
-
-    session_store
-        .upsert(session.id.clone(), &session)
-        .await
-        .map_err(Into::<IssuanceError>::into)?;
-
     let response = StartIssuanceResponse::from_context(&context, &session)?;
 
-    Ok((context, session, response))
+    session_store.upsert(session.id.clone(), &session).await?;
+
+    Ok(response)
 }


### PR DESCRIPTION
The current error handling and tracing strategy does not consistently log internal errors, external system failures, and operational failures with sufficient context for debugging and production observability.

At the moment, tracing is mostly visible around SSE event emission failures and user-facing issuance state updates. However:
- many internal errors are only propagated upward without structured tracing
- some external dependency failures lose their original context
- SSE-visible errors may contain generic/internal-safe messages while the underlying root cause is never logged
- operational failures occurring in background tasks may become difficult to debug in distributed environments

This ticket is introduced to address that issue.