### PR TITLE
fix(config): issues in preferred-display-locales implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,6 +902,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
+ "serde_with",
  "sqlx",
  "testcontainers-modules",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_qs = "1.1"
+serde_with.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting", "serde"] }
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }

--- a/README.md
+++ b/README.md
@@ -74,6 +74,18 @@ cd cloud-identity-wallet
 cargo run
 ```
 
+### Configuration
+
+The application is configured via environment variables prefixed with `APP_`, using `__` as the section separator. Key variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `APP_SERVER__HOST` | `127.0.0.1` | Bind address |
+| `APP_SERVER__PORT` | `3000` | Listen port |
+| `APP_OID4VCI__CLIENT_ID` | `cloud-identity-wallet` | OAuth2 client identifier |
+| `APP_OID4VCI__REDIRECT_URI` | `http://localhost:3000/api/v1/issuance/callback` | OAuth2 redirect URI |
+| `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES` | `en` | Comma-separated locale prefixes tried in priority order when selecting credential display metadata (e.g. `en,fr,de`) |
+
 ### Testing
 
 You can run the full test suite with:

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ cargo run
 
 The application is configured via environment variables prefixed with `APP_`, using `__` as the section separator. Key variables:
 
-| Variable | Default | Description |
-|---|---|---|
-| `APP_SERVER__HOST` | `127.0.0.1` | Bind address |
-| `APP_SERVER__PORT` | `3000` | Listen port |
-| `APP_OID4VCI__CLIENT_ID` | `cloud-identity-wallet` | OAuth2 client identifier |
-| `APP_OID4VCI__REDIRECT_URI` | `http://localhost:3000/api/v1/issuance/callback` | OAuth2 redirect URI |
-| `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES` | `en` | Comma-separated locale prefixes tried in priority order when selecting credential display metadata (e.g. `en,fr,de`) |
+| Variable                                 | Default                                          | Description                                                                                                          |
+| ---------------------------------------- | ------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `APP_SERVER__HOST`                       | `127.0.0.1`                                      | Bind address                                                                                                         |
+| `APP_SERVER__PORT`                       | `3000`                                           | Listen port                                                                                                          |
+| `APP_OID4VCI__CLIENT_ID`                 | `cloud-identity-wallet`                          | OAuth2 client identifier                                                                                             |
+| `APP_OID4VCI__REDIRECT_URI`              | `http://localhost:3000/api/v1/issuance/callback` | OAuth2 redirect URI                                                                                                  |
+| `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES` | `en`                                             | Comma-separated locale prefixes tried in priority order when selecting credential display metadata (e.g. `en,fr,de`) |
 
 ### Testing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt, time::Duration};
+use std::{collections::HashMap, time::Duration};
 
 use config::{Config as ConfigLib, ConfigBuilder, ConfigError, Environment, builder::DefaultState};
 use redis::{
@@ -6,10 +6,8 @@ use redis::{
     aio::{ConnectionManager, ConnectionManagerConfig},
 };
 use secrecy::{ExposeSecret, SecretString};
-use serde::{
-    Deserialize, Serialize,
-    de::{SeqAccess, Visitor},
-};
+use serde::{Deserialize, Serialize};
+use serde_with::{PickFirst, StringWithSeparator, formats::CommaSeparator, serde_as};
 use tokio::sync::mpsc::UnboundedReceiver;
 use url::Url;
 
@@ -37,6 +35,7 @@ pub struct DatabaseConfig {
     pub url: SecretString,
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
 pub struct Oid4vciConfig {
     pub client_id: String,
@@ -44,43 +43,8 @@ pub struct Oid4vciConfig {
     pub use_system_proxy: bool,
     /// Locale prefixes tried in order when selecting a credential display entry.
     /// Configurable via `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES=en,fr,de`.
-    #[serde(deserialize_with = "deserialize_string_or_seq")]
+    #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, Vec<_>)>")]
     pub preferred_display_locales: Vec<String>,
-}
-
-/// Deserialize a `Vec<String>` from either a JSON array or a comma-separated
-/// string (e.g. the value of an environment variable like `en,fr,de`).
-fn deserialize_string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    struct StringOrSeq;
-
-    impl<'de> Visitor<'de> for StringOrSeq {
-        type Value = Vec<String>;
-
-        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.write_str("a sequence or a comma-separated string")
-        }
-
-        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Vec<String>, E> {
-            Ok(v.split(',')
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_owned)
-                .collect())
-        }
-
-        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<String>, A::Error> {
-            let mut items = Vec::new();
-            while let Some(s) = seq.next_element::<String>()? {
-                items.push(s);
-            }
-            Ok(items)
-        }
-    }
-
-    deserializer.deserialize_any(StringOrSeq)
 }
 
 impl RedisConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, fmt, time::Duration};
 
 use config::{Config as ConfigLib, ConfigBuilder, ConfigError, Environment, builder::DefaultState};
 use redis::{
@@ -6,7 +6,10 @@ use redis::{
     aio::{ConnectionManager, ConnectionManagerConfig},
 };
 use secrecy::{ExposeSecret, SecretString};
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Serialize,
+    de::{SeqAccess, Visitor},
+};
 use tokio::sync::mpsc::UnboundedReceiver;
 use url::Url;
 
@@ -39,6 +42,45 @@ pub struct Oid4vciConfig {
     pub client_id: String,
     pub redirect_uri: Url,
     pub use_system_proxy: bool,
+    /// Locale prefixes tried in order when selecting a credential display entry.
+    /// Configurable via `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES=en,fr,de`.
+    #[serde(deserialize_with = "deserialize_string_or_seq")]
+    pub preferred_display_locales: Vec<String>,
+}
+
+/// Deserialize a `Vec<String>` from either a JSON array or a comma-separated
+/// string (e.g. the value of an environment variable like `en,fr,de`).
+fn deserialize_string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct StringOrSeq;
+
+    impl<'de> Visitor<'de> for StringOrSeq {
+        type Value = Vec<String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("a sequence or a comma-separated string")
+        }
+
+        fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Vec<String>, E> {
+            Ok(v.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect())
+        }
+
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Vec<String>, A::Error> {
+            let mut items = Vec::new();
+            while let Some(s) = seq.next_element::<String>()? {
+                items.push(s);
+            }
+            Ok(items)
+        }
+    }
+
+    deserializer.deserialize_any(StringOrSeq)
 }
 
 impl RedisConfig {
@@ -107,7 +149,8 @@ impl Config {
                 "oid4vci.redirect_uri",
                 "http://localhost:3000/api/v1/issuance/callback",
             )?
-            .set_default("oid4vci.use_system_proxy", true)
+            .set_default("oid4vci.use_system_proxy", true)?
+            .set_default("oid4vci.preferred_display_locales", vec!["en"])
     }
 }
 
@@ -125,6 +168,23 @@ mod tests {
         assert_eq!(
             config.redis.uri.expose_secret(),
             "redis://127.0.0.1:6379?protocol=resp3"
+        );
+        assert_eq!(config.oid4vci.preferred_display_locales, vec!["en"]);
+    }
+
+    #[test]
+    fn test_preferred_display_locales_csv_string_override() {
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            "oid4vci.preferred_display_locales".to_string(),
+            "fr,de,en".to_string(),
+        );
+
+        let config = Config::load_with_sources(Some(env_vars)).expect("Failed to load config");
+
+        assert_eq!(
+            config.oid4vci.preferred_display_locales,
+            vec!["fr", "de", "en"]
         );
     }
 

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -44,10 +44,6 @@ const MAX_DEFERRED_RETRIES: u32 = 60;
 const DEFAULT_WORKER_IDLE_SLEEP: Duration = Duration::from_millis(250);
 const DEFAULT_WORKER_ERROR_SLEEP: Duration = Duration::from_secs(1);
 
-/// Locale prefixes tried in order when selecting a display entry.
-/// TODO: make this configurable
-const PREFERRED_DISPLAY_LOCALES: &[&str] = &["en", "de"];
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum FlowType {
@@ -68,6 +64,7 @@ pub struct IssuanceEngine {
     pub tenant_repo: Arc<dyn TenantRepo>,
     workers: Arc<Mutex<Vec<JoinHandle<()>>>>,
     worker_notify: Arc<Notify>,
+    preferred_display_locales: Arc<Vec<String>>,
 }
 
 impl Clone for IssuanceEngine {
@@ -81,6 +78,7 @@ impl Clone for IssuanceEngine {
             tenant_repo: Arc::clone(&self.tenant_repo),
             workers: Arc::clone(&self.workers),
             worker_notify: Arc::clone(&self.worker_notify),
+            preferred_display_locales: Arc::clone(&self.preferred_display_locales),
         }
     }
 }
@@ -102,6 +100,7 @@ impl std::fmt::Debug for IssuanceEngine {
                 &std::any::type_name::<dyn IssuanceEventSubscriber>(),
             )
             .field("worker_count", &self.worker_count())
+            .field("preferred_display_locales", &self.preferred_display_locales)
             .finish()
     }
 }
@@ -110,6 +109,7 @@ impl IssuanceEngine {
     /// Create a new orchestrator with all required dependencies and default workers.
     ///
     /// The default worker count is the machine's available parallelism.
+    #[allow(clippy::too_many_arguments)]
     pub fn new<Q, P, B, C, T, S>(
         client: Oid4vciClient,
         task_queue: Q,
@@ -118,6 +118,7 @@ impl IssuanceEngine {
         credential_repo: C,
         tenant_repo: T,
         session_store: &S,
+        preferred_display_locales: Vec<String>,
     ) -> Self
     where
         Q: IssuanceTaskQueue,
@@ -135,6 +136,7 @@ impl IssuanceEngine {
             credential_repo,
             tenant_repo,
             session_store,
+            preferred_display_locales,
             default_worker_count(),
         )
     }
@@ -149,6 +151,7 @@ impl IssuanceEngine {
         credential_repo: C,
         tenant_repo: T,
         session_store: &S,
+        preferred_display_locales: Vec<String>,
         worker_count: usize,
     ) -> Self
     where
@@ -168,6 +171,7 @@ impl IssuanceEngine {
             tenant_repo: Arc::new(tenant_repo),
             workers: Arc::default(),
             worker_notify: Arc::new(Notify::new()),
+            preferred_display_locales: Arc::new(preferred_display_locales),
         };
 
         engine.start_worker_count(session_store.clone(), worker_count)
@@ -483,7 +487,8 @@ impl IssuanceEngine {
     ) -> Result<Option<String>> {
         let notification_id = immediate.notification_id;
         let issuer = context.offer.credential_issuer.as_str();
-        let display_metadata = extract_display_metadata(context, config_id);
+        let display_metadata =
+            extract_display_metadata(context, config_id, &self.preferred_display_locales);
 
         for cred_obj in immediate.credentials {
             let raw = match cred_obj.credential {
@@ -685,14 +690,13 @@ fn default_worker_count() -> usize {
 fn extract_display_metadata(
     context: &ResolvedOfferContext,
     credential_config_id: &str,
+    preferred: &[String],
 ) -> CredentialDisplayMetadata {
     let issuer_name = context
         .issuer_metadata
         .display
         .as_deref()
-        .and_then(|displays| {
-            select_preferred(displays, |d| d.locale.as_deref(), PREFERRED_DISPLAY_LOCALES)
-        })
+        .and_then(|displays| select_preferred(displays, |d| d.locale.as_deref(), preferred))
         .and_then(|d| d.name.clone())
         .unwrap_or_else(|| context.offer.credential_issuer.to_string());
 
@@ -702,9 +706,7 @@ fn extract_display_metadata(
         .get(credential_config_id)
         .and_then(|config| config.credential_metadata.as_ref())
         .and_then(|meta| meta.display.as_deref())
-        .and_then(|displays| {
-            select_preferred(displays, |d| d.locale.as_deref(), PREFERRED_DISPLAY_LOCALES)
-        });
+        .and_then(|displays| select_preferred(displays, |d| d.locale.as_deref(), preferred));
 
     let display = match cred_display {
         Some(entry) => entry.clone(),
@@ -722,18 +724,19 @@ fn extract_display_metadata(
 }
 
 /// Selects the preferred display entry from a locale-tagged list.
-fn select_preferred<'a, T, F>(items: &'a [T], locale_fn: F, preferred: &[&str]) -> Option<&'a T>
+fn select_preferred<'a, T, F, S>(items: &'a [T], locale_fn: F, preferred: &[S]) -> Option<&'a T>
 where
     F: Fn(&T) -> Option<&str>,
+    S: AsRef<str>,
 {
     if items.is_empty() {
         return None;
     }
 
-    for &prefix in preferred {
+    for prefix in preferred {
         if let Some(entry) = items.iter().find(|item| {
             locale_fn(item)
-                .map(|l| l.starts_with(prefix))
+                .map(|l| l.starts_with(prefix.as_ref()))
                 .unwrap_or(false)
         }) {
             return Some(entry);
@@ -749,7 +752,10 @@ mod tests {
     use std::sync::Arc;
 
     use async_trait::async_trait;
-    use cloud_wallet_openid4vc::core::client::{Config as Oid4vciClientConfig, OidClient};
+    use cloud_wallet_openid4vc::{
+        core::client::{Config as Oid4vciClientConfig, OidClient},
+        oid4vci::metadata::CredentialDisplay,
+    };
     use url::Url;
 
     use super::*;
@@ -823,6 +829,7 @@ mod tests {
             MemoryCredentialRepo::new(),
             MemoryTenantRepo::new(),
             &sessions,
+            vec!["en".to_owned()],
             1,
         )
     }
@@ -878,5 +885,46 @@ mod tests {
         let processed = engine.process_next_task(&sessions).await.unwrap();
 
         assert!(!processed);
+    }
+
+    #[test]
+    fn select_preferred_chooses_locale_by_prefix() {
+        // Arrange: two display entries; French listed second.
+        let entries = vec![
+            CredentialDisplay {
+                name: "English".to_owned(),
+                locale: Some("en-US".to_owned()),
+                ..Default::default()
+            },
+            CredentialDisplay {
+                name: "French".to_owned(),
+                locale: Some("fr-FR".to_owned()),
+                ..Default::default()
+            },
+        ];
+        let preferred = vec!["fr".to_owned()];
+
+        // Act
+        let result = select_preferred(&entries, |d| d.locale.as_deref(), &preferred);
+
+        // Assert: the French entry is selected even though it is listed second.
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "French");
+    }
+
+    #[test]
+    fn select_preferred_falls_back_to_first_when_no_match() {
+        let entries = vec![CredentialDisplay {
+            name: "English".to_owned(),
+            locale: Some("en-US".to_owned()),
+            ..Default::default()
+        }];
+        let preferred = vec!["fr".to_owned()];
+
+        // Act: preferred locale not present — should fall back to first entry.
+        let result = select_preferred(&entries, |d| d.locale.as_deref(), &preferred);
+
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "English");
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -30,6 +30,7 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
     let publisher = MemoryEventPublisher::new(128);
     let subscriber = MemoryEventSubscriber::new(&publisher);
     let credential_repo = MemoryCredentialRepo::new();
+    let preferred_display_locales = config.oid4vci.preferred_display_locales.clone();
 
     let engine = IssuanceEngine::new(
         client,
@@ -39,6 +40,7 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
         credential_repo,
         tenant_repo,
         session_store,
+        preferred_display_locales,
     );
     Ok(engine)
 }

--- a/tests/issuance_callback.rs
+++ b/tests/issuance_callback.rs
@@ -83,6 +83,7 @@ async fn spawn_callback_test_app(session_store: MemorySession) -> CallbackTestAp
         MemoryCredentialRepo::new(),
         tenant_repo.clone(),
         &session_store,
+        config.oid4vci.preferred_display_locales.clone(),
     );
     let service = Service::new(session_store.clone(), tenant_repo, engine);
     let server = Server::new(&config, service).await.unwrap();

--- a/tests/issuance_tx_code.rs
+++ b/tests/issuance_tx_code.rs
@@ -80,6 +80,7 @@ async fn spawn_tx_code_test_app(session_store: MemorySession) -> TxCodeTestApp {
         MemoryCredentialRepo::new(),
         tenant_repo.clone(),
         &session_store,
+        config.oid4vci.preferred_display_locales.clone(),
     );
     let service = Service::new(session_store.clone(), tenant_repo, engine);
     let server = Server::new(&config, service).await.unwrap();

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -68,6 +68,7 @@ pub async fn spawn_server() -> TestServer<MemoryCredentialRepo> {
         credential_repo.clone(),
         tenant_repo.clone(),
         &session_store,
+        config.oid4vci.preferred_display_locales.clone(),
     );
     let service = Service::new(session_store, tenant_repo, engine);
     let server = Server::new(&config, service).await.unwrap();


### PR DESCRIPTION
`extract_display_metadata` in `src/domain/models/issuance/mod.rs` selects which
locale entry to use when storing credential display metadata at issuance time.
Issuers can provide display data in multiple languages; the wallet picks one to
persist.

## Problem

The locale preference list is hardcoded in two places:

```
rust
select_preferred(displays, |d| d.locale.as_deref(), &["en", "de"])
```
## Proposed Fix

1. Add `preferred_display_locales: Vec<String>` to `Oid4vciConfig` in
   `src/config.rs`, defaulting to `["en"]`.
2. Thread the value from `Config` → `IssuanceEngine` → `extract_display_metadata`.
3. Replace both hardcoded `&["en", "de"]` slices with the config value.
4. Document the env var (e.g. `OID4VCI__PREFERRED_DISPLAY_LOCALES=en,fr,de`) in
   the deployment docs / README.

## Acceptance Criteria
- [x] `preferred_display_locales` field added to `Oid4vciConfig`
- [x] Configurable via environment variable
- [x] Default value is `["en"]`
- [x] `extract_display_metadata` uses the config value, not a hardcoded slice
- [x] Both call sites use the same source — duplication eliminated
- [x] Unit test: verify correct locale is selected when config specifies `["fr"]`
  and issuer metadata contains `"fr-FR"` and `"en-US"` entries
