### PR TITLE
Feat/implement sd jwt vc signature verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,6 +1014,8 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "rustls-pki-types",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -984,7 +1025,9 @@ dependencies = [
  "tokio",
  "url",
  "validator",
+ "webpki-roots 1.0.7",
  "wiremock",
+ "x509-parser",
 ]
 
 [[package]]
@@ -1344,6 +1387,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1370,6 +1419,20 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2762,6 +2825,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,6 +3693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -5751,6 +5832,23 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "xattr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1020,7 @@ dependencies = [
  "futures",
  "jsonwebtoken",
  "percent-encoding",
+ "rcgen",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -3417,6 +3427,19 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "aws-lc-rs",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
 
 [[package]]
 name = "redis"
@@ -5840,6 +5863,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -5881,6 +5905,16 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.0",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
 ]
 
 [[package]]

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -16,6 +16,7 @@ percent-encoding = "2"
 reqwest = { version = "0.13", features = ["form", "json", "rustls"] }
 reqwest-middleware = { version = "0.5", features = ["form", "json"] }
 reqwest-retry = "0.9"
+rustls-pki-types = "1.14"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_urlencoded = "0.7"
@@ -24,6 +25,9 @@ thiserror.workspace = true
 time.workspace = true
 url = { workspace = true, features = ["serde"] }
 validator = { version = "0.20", features = ["derive"] }
+webpki-roots = "1"
+webpki = { package = "rustls-webpki", version = "0.103", features = ["aws-lc-rs"] }
+x509-parser = "0.18"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -30,5 +30,6 @@ webpki = { package = "rustls-webpki", version = "0.103", features = ["aws-lc-rs"
 x509-parser = "0.18"
 
 [dev-dependencies]
+rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/error.rs
@@ -1,3 +1,5 @@
+use crate::formats::sd_jwt::verification::VerificationError;
+
 /// Errors returned while parsing an SD-JWT VC or one of its embedded parts.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -62,6 +64,10 @@ pub enum Error {
         /// Processing failure reason.
         reason: ProcessingError,
     },
+
+    /// SD-JWT verification failed.
+    #[error("verification failed: {0}")]
+    Verification(#[from] VerificationError),
 }
 
 /// Failures that can occur while parsing an individual Disclosure.

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/metadata.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/metadata.rs
@@ -1,0 +1,416 @@
+// TODO : Remove dead code allowance when metadata is used
+#![allow(dead_code)]
+
+use std::borrow::Cow;
+
+use cloud_wallet_crypto::jwk::{Jwk, JwkSet};
+use reqwest::StatusCode;
+use reqwest_middleware::ClientWithMiddleware;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use url::Url;
+
+use super::SdJwt;
+
+const JWT_VC_ISSUER_WELL_KNOWN: &str = "/.well-known/jwt-vc-issuer";
+
+/// Errors returned while resolving JWT VC Issuer Metadata.
+#[derive(Debug, thiserror::Error)]
+pub enum IssuerMetadataError {
+    /// The issuer identifier is invalid or cannot be used for metadata discovery.
+    #[error("invalid JWT VC issuer: {message}")]
+    InvalidIssuer { message: Cow<'static, str> },
+
+    /// The metadata document violates SD-JWT VC metadata requirements.
+    #[error("invalid JWT VC issuer metadata: {message}")]
+    InvalidMetadata { message: Cow<'static, str> },
+
+    /// HTTP transport or non-success response error.
+    #[error("JWT VC issuer metadata HTTP error")]
+    Http {
+        /// Human-readable context for the HTTP failure.
+        message: Option<Cow<'static, str>>,
+        /// HTTP status code, if a response was received.
+        status: Option<u16>,
+        /// Response body, if available.
+        body: Option<String>,
+        /// Underlying transport error, if any.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+
+    /// The metadata or JWKS response could not be parsed.
+    #[error("invalid JWT VC issuer metadata response: {message}")]
+    InvalidResponse {
+        /// Human-readable parse failure context.
+        message: Cow<'static, str>,
+        /// Underlying parse error.
+        #[source]
+        source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    },
+}
+
+/// JWT VC Issuer Metadata as defined by SD-JWT VC draft section 3.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(super) struct IssuerMetadata {
+    /// Issuer identifier. This must be identical to the issuer-signed JWT `iss`.
+    pub issuer: String,
+
+    /// URL of the issuer's JWK Set document.
+    pub jwks_uri: Option<Url>,
+
+    /// Issuer JWK Set embedded by value.
+    pub jwks: Option<JwkSet>,
+}
+
+impl IssuerMetadata {
+    /// Validates issuer metadata against the issuer value from the SD-JWT VC.
+    pub fn validate_for_issuer(&self, expected_issuer: &str) -> Result<(), IssuerMetadataError> {
+        if self.issuer != expected_issuer {
+            return Err(IssuerMetadataError::InvalidMetadata {
+                message: format!(
+                    "metadata issuer '{}' does not match expected issuer '{}'",
+                    self.issuer, expected_issuer
+                )
+                .into(),
+            });
+        }
+
+        match (&self.jwks_uri, &self.jwks) {
+            (Some(_), None) | (None, Some(_)) => Ok(()),
+            (None, None) => Err(IssuerMetadataError::InvalidMetadata {
+                message: "metadata must include either jwks_uri or jwks".into(),
+            }),
+            (Some(_), Some(_)) => Err(IssuerMetadataError::InvalidMetadata {
+                message: "metadata must not include both jwks_uri and jwks".into(),
+            }),
+        }
+    }
+}
+
+/// Finds a key by `kid` in the resolved JWK Set.
+pub fn key_by_id<'a>(jwks: &'a JwkSet, kid: &str) -> Option<&'a Jwk> {
+    jwks.keys
+        .iter()
+        .find(|key| key.prm.kid.as_deref() == Some(kid))
+}
+
+/// Resolves JWT VC issuer signing JWK Set.
+pub(super) async fn resolve(
+    sd_jwt: &SdJwt<'_>,
+    http_client: &ClientWithMiddleware,
+) -> Result<JwkSet, IssuerMetadataError> {
+    let issuer = sd_jwt
+        .jwt()
+        .claims()
+        .rfc7519
+        .iss
+        .as_deref()
+        .ok_or_else(|| IssuerMetadataError::InvalidIssuer {
+            message: "issuer-signed JWT is missing iss".into(),
+        })?;
+
+    resolve_issuer(http_client, issuer).await
+}
+
+/// Resolves metadata for an issuer identifier.
+async fn resolve_issuer(
+    http_client: &ClientWithMiddleware,
+    issuer: &str,
+) -> Result<JwkSet, IssuerMetadataError> {
+    let issuer_url = validate_issuer_url(issuer)?;
+    let metadata_url = jwt_vc_issuer_metadata_url(&issuer_url);
+    let metadata = fetch_metadata(http_client, &metadata_url).await?;
+    metadata.validate_for_issuer(issuer)?;
+    let jwks = resolve_jwks(http_client, metadata).await?;
+    Ok(jwks)
+}
+
+async fn fetch_metadata(
+    http_client: &ClientWithMiddleware,
+    url: &Url,
+) -> Result<IssuerMetadata, IssuerMetadataError> {
+    let response = http_client
+        .get(url.as_str())
+        .send()
+        .await
+        .map_err(|source| IssuerMetadataError::Http {
+            message: Some("failed to fetch JWT VC issuer metadata".into()),
+            status: None,
+            body: None,
+            source: Some(Box::new(source)),
+        })?;
+
+    if response.status() != StatusCode::OK {
+        return Err(http_error_response(
+            response,
+            "JWT VC issuer metadata endpoint returned an error",
+        )
+        .await);
+    }
+
+    response
+        .json::<IssuerMetadata>()
+        .await
+        .map_err(|source| IssuerMetadataError::InvalidResponse {
+            message: "failed to parse JWT VC issuer metadata".into(),
+            source: Some(Box::new(source)),
+        })
+}
+
+async fn resolve_jwks(
+    http_client: &ClientWithMiddleware,
+    metadata: IssuerMetadata,
+) -> Result<JwkSet, IssuerMetadataError> {
+    if let Some(jwks) = metadata.jwks {
+        return Ok(jwks);
+    }
+
+    // Safety: metadata validation ensures jwks_uri or jwks is present
+    let jwks_uri = metadata.jwks_uri.unwrap();
+
+    let response = http_client
+        .get(jwks_uri.as_str())
+        .send()
+        .await
+        .map_err(|source| IssuerMetadataError::Http {
+            message: Some("failed to fetch JWT VC issuer JWKS".into()),
+            status: None,
+            body: None,
+            source: Some(Box::new(source)),
+        })?;
+
+    if response.status() != StatusCode::OK {
+        return Err(
+            http_error_response(response, "JWT VC issuer JWKS endpoint returned an error").await,
+        );
+    }
+
+    response
+        .json::<JwkSet>()
+        .await
+        .map_err(|source| IssuerMetadataError::InvalidResponse {
+            message: "failed to parse JWT VC issuer JWKS".into(),
+            source: Some(Box::new(source)),
+        })
+}
+
+/// Builds the JWT VC Issuer Metadata well-known URL for an issuer.
+///
+/// The well-known suffix is inserted between the host component and the issuer
+/// path component, after removing any terminating slash from that path.
+fn jwt_vc_issuer_metadata_url(issuer: &Url) -> Url {
+    let mut url = issuer.clone();
+    let path = issuer.path().trim_end_matches('/');
+    url.set_path(&format!("{JWT_VC_ISSUER_WELL_KNOWN}{path}"));
+    url.set_query(None);
+    url.set_fragment(None);
+    url
+}
+
+fn validate_issuer_url(issuer: &str) -> Result<Url, IssuerMetadataError> {
+    let url = Url::parse(issuer).map_err(|source| IssuerMetadataError::InvalidIssuer {
+        message: format!("issuer is not a valid URL: {source}").into(),
+    })?;
+
+    if url.host().is_none() || url.scheme() != "https" {
+        return Err(IssuerMetadataError::InvalidIssuer {
+            message: "issuer must include a host and use https scheme".into(),
+        });
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        return Err(IssuerMetadataError::InvalidIssuer {
+            message: "issuer must not include query or fragment components".into(),
+        });
+    }
+    Ok(url)
+}
+
+async fn http_error_response(
+    response: reqwest::Response,
+    message: &'static str,
+) -> IssuerMetadataError {
+    let status = response.status().as_u16();
+    let body = response.text().await.unwrap_or_default();
+    IssuerMetadataError::Http {
+        message: Some(message.into()),
+        status: Some(status),
+        body: Some(body),
+        source: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest_middleware::ClientBuilder;
+    use serde_json::json;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn test_jwks() -> serde_json::Value {
+        json!({
+            "keys": [
+                {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": "WKn-ZIGevcwGIyyrzFoZNBdaq9_TsqzGl96oc0CWuis",
+                    "y": "y77t-RvAHRKTsSGdIYUfweuOvwrvDD-Q3Hv5J0fSKbE",
+                    "kid": "key-1"
+                }
+            ]
+        })
+    }
+
+    #[test]
+    fn builds_well_known_url_for_root_issuer() {
+        let issuer = Url::parse("https://example.com").unwrap();
+
+        assert_eq!(
+            jwt_vc_issuer_metadata_url(&issuer).as_str(),
+            "https://example.com/.well-known/jwt-vc-issuer"
+        );
+    }
+
+    #[test]
+    fn builds_well_known_url_for_path_issuer() {
+        let issuer = Url::parse("https://example.com/tenant/1234/").unwrap();
+
+        assert_eq!(
+            jwt_vc_issuer_metadata_url(&issuer).as_str(),
+            "https://example.com/.well-known/jwt-vc-issuer/tenant/1234"
+        );
+    }
+
+    #[test]
+    fn validates_exactly_one_jwk_source() {
+        let issuer = "https://example.com";
+        let missing = IssuerMetadata {
+            issuer: issuer.to_owned(),
+            jwks_uri: None,
+            jwks: None,
+        };
+        assert!(matches!(
+            missing.validate_for_issuer(issuer),
+            Err(IssuerMetadataError::InvalidMetadata { .. })
+        ));
+
+        let both = IssuerMetadata {
+            issuer: issuer.to_owned(),
+            jwks_uri: Some(Url::parse("https://example.com/jwks.json").unwrap()),
+            jwks: Some(serde_json::from_value(test_jwks()).unwrap()),
+        };
+        assert!(matches!(
+            both.validate_for_issuer(issuer),
+            Err(IssuerMetadataError::InvalidMetadata { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_metadata_issuer_matches_jwt_issuer() {
+        let metadata = IssuerMetadata {
+            issuer: "https://other.example.com".to_owned(),
+            jwks_uri: None,
+            jwks: Some(serde_json::from_value(test_jwks()).unwrap()),
+        };
+
+        assert!(matches!(
+            metadata.validate_for_issuer("https://example.com"),
+            Err(IssuerMetadataError::InvalidMetadata { .. })
+        ));
+    }
+
+    #[test]
+    fn validates_issuer_identifier_shape() {
+        assert!(matches!(
+            validate_issuer_url("http://example.com"),
+            Err(IssuerMetadataError::InvalidIssuer { .. })
+        ));
+        assert!(matches!(
+            validate_issuer_url("https://example.com?x=1"),
+            Err(IssuerMetadataError::InvalidIssuer { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn resolves_inline_jwks_metadata() {
+        let mock_server = MockServer::start().await;
+        let issuer = "https://issuer.example.com";
+        let metadata = json!({
+            "issuer": issuer,
+            "jwks": test_jwks()
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/jwt-vc-issuer"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+            .mount(&mock_server)
+            .await;
+
+        let metadata_url =
+            Url::parse(&format!("{}/.well-known/jwt-vc-issuer", mock_server.uri())).unwrap();
+        let metadata = fetch_metadata(
+            &ClientBuilder::new(reqwest::Client::new()).build(),
+            &metadata_url,
+        )
+        .await
+        .unwrap();
+        metadata.validate_for_issuer(issuer).unwrap();
+        let jwks = resolve_jwks(
+            &ClientBuilder::new(reqwest::Client::new()).build(),
+            metadata.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(metadata.issuer, issuer);
+        assert_eq!(jwks.keys.len(), 1);
+        assert_eq!(
+            jwks.keys
+                .iter()
+                .find(|key| key.prm.kid.as_deref() == Some("key-1"))
+                .and_then(|key| key.prm.kid.as_deref()),
+            Some("key-1")
+        );
+    }
+
+    #[tokio::test]
+    async fn resolves_jwks_uri_metadata() {
+        let mock_server = MockServer::start().await;
+        let issuer = "https://issuer.example.com";
+        let metadata = json!({
+            "issuer": issuer,
+            "jwks_uri": format!("{}/jwks.json", mock_server.uri())
+        });
+
+        Mock::given(method("GET"))
+            .and(path("/.well-known/jwt-vc-issuer"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/jwks.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(test_jwks()))
+            .mount(&mock_server)
+            .await;
+
+        let metadata_url =
+            Url::parse(&format!("{}/.well-known/jwt-vc-issuer", mock_server.uri())).unwrap();
+        let metadata = fetch_metadata(
+            &ClientBuilder::new(reqwest::Client::new()).build(),
+            &metadata_url,
+        )
+        .await
+        .unwrap();
+        metadata.validate_for_issuer(issuer).unwrap();
+        let jwks = resolve_jwks(
+            &ClientBuilder::new(reqwest::Client::new()).build(),
+            metadata,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(jwks.keys.len(), 1);
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/metadata.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/metadata.rs
@@ -1,6 +1,3 @@
-// TODO : Remove dead code allowance when metadata is used
-#![allow(dead_code)]
-
 use std::borrow::Cow;
 
 use cloud_wallet_crypto::jwk::{Jwk, JwkSet};

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
@@ -7,13 +7,16 @@ mod kb_jwt;
 mod metadata;
 #[cfg(test)]
 mod tests;
+mod verification;
 
 pub use disclosure::Disclosure;
 pub use error::{DisclosureError, Error, ProcessingError};
 pub use hash::IanaHashAlgorithm;
+use jsonwebtoken::Algorithm;
 pub use jwt::Jwt;
 pub use kb_jwt::{KeyBindingClaims, KeyBindingJwt};
 pub use metadata::IssuerMetadataError;
+pub use verification::VerificationError;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -131,6 +134,16 @@ impl<'a> SdJwt<'a> {
         let mut payload = self.to_disclosed_payload()?;
         remove_metadata(&mut payload);
         Ok(payload)
+    }
+
+    /// Establishes issuer trust and verifies the issuer-signed JWT signature.
+    ///
+    /// Returns the algorithm used for verification.
+    pub async fn verify_signature(
+        &self,
+        http_client: &reqwest_middleware::ClientWithMiddleware,
+    ) -> Result<Algorithm, VerificationError> {
+        verification::verify_issuer_signature(self, http_client).await
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod hash;
 mod jwt;
 mod kb_jwt;
+mod metadata;
 #[cfg(test)]
 mod tests;
 
@@ -12,6 +13,7 @@ pub use error::{DisclosureError, Error, ProcessingError};
 pub use hash::IanaHashAlgorithm;
 pub use jwt::Jwt;
 pub use kb_jwt::{KeyBindingClaims, KeyBindingJwt};
+pub use metadata::IssuerMetadataError;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
@@ -36,9 +36,11 @@ const TRANSITIONAL_SD_JWT_VC_TYP: &str = "vc+sd-jwt";
 const METADATA_CLAIMS: &[&str] = &[
     "iss",
     "sub",
+    "aud",
     "exp",
     "nbf",
     "iat",
+    "jti",
     "vct",
     "vct#integrity",
     "cnf",
@@ -144,8 +146,10 @@ impl<'a> SdJwt<'a> {
         &self,
         http_client: &ClientWithMiddleware,
         trust_anchors: X5cTrustAnchors<'_>,
-    ) -> Result<Algorithm, VerificationError> {
-        verification::verify_issuer_signature(self, http_client, trust_anchors).await
+    ) -> Result<Algorithm, Error> {
+        verification::verify_issuer_signature(self, http_client, trust_anchors)
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
@@ -12,12 +12,13 @@ mod verification;
 pub use disclosure::Disclosure;
 pub use error::{DisclosureError, Error, ProcessingError};
 pub use hash::IanaHashAlgorithm;
-use jsonwebtoken::Algorithm;
 pub use jwt::Jwt;
 pub use kb_jwt::{KeyBindingClaims, KeyBindingJwt};
 pub use metadata::IssuerMetadataError;
-pub use verification::VerificationError;
+pub use verification::{VerificationError, X5cTrustAnchors};
 
+use jsonwebtoken::Algorithm;
+use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use serde_with::skip_serializing_none;
@@ -141,9 +142,10 @@ impl<'a> SdJwt<'a> {
     /// Returns the algorithm used for verification.
     pub async fn verify_signature(
         &self,
-        http_client: &reqwest_middleware::ClientWithMiddleware,
+        http_client: &ClientWithMiddleware,
+        trust_anchors: X5cTrustAnchors<'_>,
     ) -> Result<Algorithm, VerificationError> {
-        verification::verify_issuer_signature(self, http_client).await
+        verification::verify_issuer_signature(self, http_client, trust_anchors).await
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
@@ -1,6 +1,13 @@
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use cloud_wallet_crypto::digest::HashAlg;
+use cloud_wallet_crypto::ecdsa::{Curve as EcdsaCurve, KeyPair as EcdsaKeyPair};
+use cloud_wallet_crypto::jwk::{
+    Algorithm as JwkAlgorithm, Jwk, JwkSet, KeyUse, Signing as JwkSigning,
+};
+use jsonwebtoken::{Algorithm as JwtAlgorithm, EncodingKey, Header};
 use serde_json::{Value, json};
+
+use crate::formats::sd_jwt::verification::{verify_with_jwks, verify_with_x5c};
 
 use super::*;
 
@@ -32,6 +39,32 @@ fn b64(value: Value) -> String {
 // Create a compact JWT from header and claims
 fn compact_jwt(header: Value, claims: Value) -> String {
     format!("{}.{}.sig", b64(header), b64(claims))
+}
+
+fn signed_sd_jwt() -> (String, JwkSet) {
+    let key_pair = EcdsaKeyPair::generate(EcdsaCurve::P256).expect("key generation should work");
+    let mut jwk = Jwk::try_from(&key_pair).expect("JWK conversion should work");
+    jwk.prm.kid = Some("issuer-key-1".to_string());
+    jwk.prm.alg = Some(JwkAlgorithm::Signing(JwkSigning::Es256));
+    jwk.prm.key_use = Some(KeyUse::Signing);
+
+    let mut header = Header::new(JwtAlgorithm::ES256);
+    header.typ = Some("dc+sd-jwt".to_string());
+    header.kid = Some("issuer-key-1".to_string());
+
+    let claims = json!({
+        "iss": "https://issuer.example.com",
+        "vct": "https://credentials.example.com/identity",
+        "given_name": "Ada"
+    });
+    let token = jsonwebtoken::encode(
+        &header,
+        &claims,
+        &EncodingKey::from_ec_der(key_pair.to_pkcs8_der()),
+    )
+    .expect("test JWT should sign");
+
+    (format!("{token}~"), JwkSet { keys: vec![jwk] })
 }
 
 // Create a disclosure from a value
@@ -592,4 +625,63 @@ fn renders_disclosed_claims_without_protocol_metadata() {
         })
     );
     assert_no_rendering_metadata(&rendered);
+}
+
+#[test]
+fn verifies_issuer_signature_with_trusted_jwks() {
+    let (raw, jwks) = signed_sd_jwt();
+    let sd_jwt = SdJwt::parse(&raw).expect("signed SD-JWT should parse");
+
+    let algorithm = verify_with_jwks(&sd_jwt, &jwks).expect("signature should verify");
+
+    assert_eq!(algorithm, JwtAlgorithm::ES256);
+}
+
+#[test]
+fn rejects_issuer_signature_when_trusted_jwk_algorithm_differs() {
+    let (raw, mut jwks) = signed_sd_jwt();
+    jwks.keys[0].prm.alg = Some(JwkAlgorithm::Signing(JwkSigning::Rs256));
+    let sd_jwt = SdJwt::parse(&raw).expect("signed SD-JWT should parse");
+
+    assert!(matches!(
+        verify_with_jwks(&sd_jwt, &jwks),
+        Err(VerificationError::InvalidKey { .. })
+    ));
+}
+
+#[test]
+fn rejects_tampered_issuer_signature() {
+    let (raw, jwks) = signed_sd_jwt();
+    let token = raw.strip_suffix('~').expect("issued SD-JWT has trailing ~");
+    let mut parts = token.split('.').collect::<Vec<_>>();
+    parts[2] = "AA";
+    let raw = format!("{}.{}.{}~", parts[0], parts[1], parts[2]);
+    let sd_jwt = SdJwt::parse(&raw).expect("tampered SD-JWT should still parse");
+
+    assert!(matches!(
+        verify_with_jwks(&sd_jwt, &jwks),
+        Err(VerificationError::Signature { .. })
+    ));
+}
+
+#[test]
+fn rejects_invalid_x5c_certificate_chain_before_signature_verification() {
+    let jwt = compact_jwt(
+        json!({
+            "alg": "ES256",
+            "typ": "dc+sd-jwt",
+            "x5c": ["not-base64!"]
+        }),
+        json!({
+            "iss": "https://issuer.example.com",
+            "vct": "https://credentials.example.com/identity"
+        }),
+    );
+    let raw = format!("{jwt}~");
+    let sd_jwt = SdJwt::parse(&raw).expect("SD-JWT with x5c header should parse");
+
+    assert!(matches!(
+        verify_with_x5c(&sd_jwt),
+        Err(VerificationError::X5c { .. })
+    ));
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
@@ -4,7 +4,7 @@ use cloud_wallet_crypto::ecdsa::{Curve as EcdsaCurve, KeyPair as EcdsaKeyPair};
 use cloud_wallet_crypto::jwk::{
     Algorithm as JwkAlgorithm, Jwk, JwkSet, KeyUse, Signing as JwkSigning,
 };
-use jsonwebtoken::{Algorithm as JwtAlgorithm, EncodingKey, Header};
+use jsonwebtoken::{Algorithm as JwtAlgorithm, EncodingKey, Header, get_current_timestamp};
 use serde_json::{Value, json};
 
 use crate::formats::sd_jwt::verification::{verify_with_jwks, verify_with_x5c};
@@ -42,6 +42,14 @@ fn compact_jwt(header: Value, claims: Value) -> String {
 }
 
 fn signed_sd_jwt() -> (String, JwkSet) {
+    signed_sd_jwt_with_claims(json!({
+        "iss": "https://issuer.example.com",
+        "vct": "https://credentials.example.com/identity",
+        "given_name": "Ada"
+    }))
+}
+
+fn signed_sd_jwt_with_claims(claims: Value) -> (String, JwkSet) {
     let key_pair = EcdsaKeyPair::generate(EcdsaCurve::P256).expect("key generation should work");
     let mut jwk = Jwk::try_from(&key_pair).expect("JWK conversion should work");
     jwk.prm.kid = Some("issuer-key-1".to_string());
@@ -52,11 +60,6 @@ fn signed_sd_jwt() -> (String, JwkSet) {
     header.typ = Some("dc+sd-jwt".to_string());
     header.kid = Some("issuer-key-1".to_string());
 
-    let claims = json!({
-        "iss": "https://issuer.example.com",
-        "vct": "https://credentials.example.com/identity",
-        "given_name": "Ada"
-    });
     let token = jsonwebtoken::encode(
         &header,
         &claims,
@@ -662,6 +665,36 @@ fn rejects_tampered_issuer_signature() {
         verify_with_jwks(&sd_jwt, &jwks),
         Err(VerificationError::Signature { .. })
     ));
+}
+
+#[test]
+fn rejects_expired_jwt_claims() {
+    let now = get_current_timestamp();
+    let (raw, jwks) = signed_sd_jwt_with_claims(json!({
+        "iss": "https://issuer.example.com",
+        "vct": "https://credentials.example.com/identity",
+        "exp": now.saturating_sub(120),
+    }));
+    let sd_jwt = SdJwt::parse(&raw).expect("signed SD-JWT should parse");
+
+    let result = verify_with_jwks(&sd_jwt, &jwks);
+    // Expired JWT should fail signature verification
+    assert!(matches!(result, Err(VerificationError::Signature(_))));
+}
+
+#[test]
+fn rejects_not_yet_valid_jwt_claims() {
+    let now = get_current_timestamp();
+    let (raw, jwks) = signed_sd_jwt_with_claims(json!({
+        "iss": "https://issuer.example.com",
+        "vct": "https://credentials.example.com/identity",
+        "nbf": now + 120,
+    }));
+    let sd_jwt = SdJwt::parse(&raw).expect("signed SD-JWT should parse");
+
+    let result = verify_with_jwks(&sd_jwt, &jwks);
+    // Future nbf (Not Before) should fail signature verification
+    assert!(matches!(result, Err(VerificationError::Signature(_))));
 }
 
 #[test]

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
@@ -215,9 +215,11 @@ fn assert_no_rendering_metadata(value: &Value) {
     for claim_name in [
         "iss",
         "sub",
+        "aud",
         "exp",
         "nbf",
         "iat",
+        "jti",
         "vct",
         "vct#integrity",
         "cnf",
@@ -874,7 +876,7 @@ async fn rejects_x5c_signature_with_untrusted_trust_anchor() {
         sd_jwt
             .verify_signature(&http_client, X5cTrustAnchors::Custom(&trust_anchors))
             .await,
-        Err(VerificationError::X5c { .. })
+        Err(Error::Verification(VerificationError::X5c { .. }))
     ));
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
@@ -1,11 +1,20 @@
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use base64::{
+    Engine,
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+};
 use cloud_wallet_crypto::digest::HashAlg;
 use cloud_wallet_crypto::ecdsa::{Curve as EcdsaCurve, KeyPair as EcdsaKeyPair};
 use cloud_wallet_crypto::jwk::{
     Algorithm as JwkAlgorithm, Jwk, JwkSet, KeyUse, Signing as JwkSigning,
 };
 use jsonwebtoken::{Algorithm as JwtAlgorithm, EncodingKey, Header, get_current_timestamp};
+use rcgen::{
+    BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
+    Issuer, KeyPair as CertKeyPair, KeyUsagePurpose,
+};
+use rustls_pki_types::TrustAnchor;
 use serde_json::{Value, json};
+use webpki::anchor_from_trusted_cert;
 
 use crate::formats::sd_jwt::verification::{verify_with_jwks, verify_with_x5c};
 
@@ -68,6 +77,80 @@ fn signed_sd_jwt_with_claims(claims: Value) -> (String, JwkSet) {
     .expect("test JWT should sign");
 
     (format!("{token}~"), JwkSet { keys: vec![jwk] })
+}
+
+struct X5cSdJwt {
+    raw: String,
+    trust_anchor: TrustAnchor<'static>,
+    untrusted_anchor: TrustAnchor<'static>,
+}
+
+fn signed_sd_jwt_with_custom_x5c() -> X5cSdJwt {
+    let root_key = CertKeyPair::generate().expect("root key generation should work");
+    let mut root_params = CertificateParams::default();
+    root_params.distinguished_name = DistinguishedName::new();
+    root_params
+        .distinguished_name
+        .push(DnType::CommonName, "Test Root CA");
+    root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    root_params.key_usages = vec![
+        KeyUsagePurpose::KeyCertSign,
+        KeyUsagePurpose::CrlSign,
+        KeyUsagePurpose::DigitalSignature,
+    ];
+    let root_cert = root_params
+        .self_signed(&root_key)
+        .expect("root certificate should sign");
+    let root_anchor = anchor_from_trusted_cert(root_cert.der())
+        .expect("root certificate should become trust anchor")
+        .to_owned();
+    let root_issuer = Issuer::new(root_params, root_key);
+
+    let leaf_key = CertKeyPair::generate().expect("leaf key generation should work");
+    let mut leaf_params = CertificateParams::new(["issuer.example.com".to_owned()])
+        .expect("leaf params should build");
+    leaf_params.distinguished_name = DistinguishedName::new();
+    leaf_params
+        .distinguished_name
+        .push(DnType::CommonName, "issuer.example.com");
+    leaf_params.is_ca = IsCa::NoCa;
+    leaf_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &root_issuer)
+        .expect("leaf certificate should sign");
+
+    let untrusted_key = CertKeyPair::generate().expect("untrusted root key should generate");
+    let mut untrusted_params = CertificateParams::default();
+    untrusted_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let untrusted_cert = untrusted_params
+        .self_signed(&untrusted_key)
+        .expect("untrusted root certificate should sign");
+    let untrusted_anchor = anchor_from_trusted_cert(untrusted_cert.der())
+        .expect("untrusted root certificate should become trust anchor")
+        .to_owned();
+
+    let mut header = Header::new(JwtAlgorithm::ES256);
+    header.typ = Some("dc+sd-jwt".to_owned());
+    header.x5c = Some(vec![STANDARD.encode(leaf_cert.der().as_ref())]);
+
+    let claims = json!({
+        "iss": "https://issuer.example.com",
+        "vct": "https://credentials.example.com/identity",
+        "given_name": "Ada"
+    });
+    let token = jsonwebtoken::encode(
+        &header,
+        &claims,
+        &EncodingKey::from_ec_der(&leaf_key.serialize_der()),
+    )
+    .expect("test JWT should sign with leaf key");
+
+    X5cSdJwt {
+        raw: format!("{token}~"),
+        trust_anchor: root_anchor,
+        untrusted_anchor,
+    }
 }
 
 // Create a disclosure from a value
@@ -697,6 +780,36 @@ fn rejects_not_yet_valid_jwt_claims() {
     assert!(matches!(result, Err(VerificationError::Signature(_))));
 }
 
+#[tokio::test]
+async fn verifies_x5c_signature_with_custom_trust_anchor() {
+    let fixture = signed_sd_jwt_with_custom_x5c();
+    let sd_jwt = SdJwt::parse(&fixture.raw).expect("x5c SD-JWT should parse");
+    let trust_anchors = [fixture.trust_anchor];
+    let http_client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+
+    let algorithm = sd_jwt
+        .verify_signature(&http_client, X5cTrustAnchors::Custom(&trust_anchors))
+        .await
+        .expect("x5c signature should verify with custom root");
+
+    assert_eq!(algorithm, JwtAlgorithm::ES256);
+}
+
+#[tokio::test]
+async fn rejects_x5c_signature_with_untrusted_trust_anchor() {
+    let fixture = signed_sd_jwt_with_custom_x5c();
+    let sd_jwt = SdJwt::parse(&fixture.raw).expect("x5c SD-JWT should parse");
+    let trust_anchors = [fixture.untrusted_anchor];
+    let http_client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build();
+
+    assert!(matches!(
+        sd_jwt
+            .verify_signature(&http_client, X5cTrustAnchors::Custom(&trust_anchors))
+            .await,
+        Err(VerificationError::X5c { .. })
+    ));
+}
+
 #[test]
 fn rejects_invalid_x5c_certificate_chain_before_signature_verification() {
     let jwt = compact_jwt(
@@ -714,7 +827,7 @@ fn rejects_invalid_x5c_certificate_chain_before_signature_verification() {
     let sd_jwt = SdJwt::parse(&raw).expect("SD-JWT with x5c header should parse");
 
     assert!(matches!(
-        verify_with_x5c(&sd_jwt),
+        verify_with_x5c(&sd_jwt, X5cTrustAnchors::default()),
         Err(VerificationError::X5c { .. })
     ));
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/tests.rs
@@ -86,6 +86,18 @@ struct X5cSdJwt {
 }
 
 fn signed_sd_jwt_with_custom_x5c() -> X5cSdJwt {
+    sd_jwt_with_custom_x5c(
+        JwtAlgorithm::ES256,
+        vec![KeyUsagePurpose::DigitalSignature],
+        true,
+    )
+}
+
+fn sd_jwt_with_custom_x5c(
+    jwt_algorithm: JwtAlgorithm,
+    leaf_key_usages: Vec<KeyUsagePurpose>,
+    sign_with_leaf_key: bool,
+) -> X5cSdJwt {
     let root_key = CertKeyPair::generate().expect("root key generation should work");
     let mut root_params = CertificateParams::default();
     root_params.distinguished_name = DistinguishedName::new();
@@ -114,7 +126,7 @@ fn signed_sd_jwt_with_custom_x5c() -> X5cSdJwt {
         .distinguished_name
         .push(DnType::CommonName, "issuer.example.com");
     leaf_params.is_ca = IsCa::NoCa;
-    leaf_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    leaf_params.key_usages = leaf_key_usages;
     leaf_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
     let leaf_cert = leaf_params
         .signed_by(&leaf_key, &root_issuer)
@@ -130,7 +142,7 @@ fn signed_sd_jwt_with_custom_x5c() -> X5cSdJwt {
         .expect("untrusted root certificate should become trust anchor")
         .to_owned();
 
-    let mut header = Header::new(JwtAlgorithm::ES256);
+    let mut header = Header::new(jwt_algorithm);
     header.typ = Some("dc+sd-jwt".to_owned());
     header.x5c = Some(vec![STANDARD.encode(leaf_cert.der().as_ref())]);
 
@@ -139,12 +151,19 @@ fn signed_sd_jwt_with_custom_x5c() -> X5cSdJwt {
         "vct": "https://credentials.example.com/identity",
         "given_name": "Ada"
     });
-    let token = jsonwebtoken::encode(
-        &header,
-        &claims,
-        &EncodingKey::from_ec_der(&leaf_key.serialize_der()),
-    )
-    .expect("test JWT should sign with leaf key");
+    let token = if sign_with_leaf_key {
+        jsonwebtoken::encode(
+            &header,
+            &claims,
+            &EncodingKey::from_ec_der(&leaf_key.serialize_der()),
+        )
+        .expect("test JWT should sign with leaf key")
+    } else {
+        compact_jwt(
+            serde_json::to_value(header).expect("test header should serialize"),
+            claims,
+        )
+    };
 
     X5cSdJwt {
         raw: format!("{token}~"),
@@ -899,5 +918,59 @@ fn rejects_invalid_x5c_certificate_chain_before_signature_verification() {
     assert!(matches!(
         verify_with_x5c(&sd_jwt, X5cTrustAnchors::default()),
         Err(VerificationError::X5c { .. })
+    ));
+}
+
+#[test]
+fn rejects_empty_x5c_certificate_chain() {
+    let jwt = compact_jwt(
+        json!({
+            "alg": "ES256",
+            "typ": "dc+sd-jwt",
+            "x5c": []
+        }),
+        json!({
+            "iss": "https://issuer.example.com",
+            "vct": "https://credentials.example.com/identity"
+        }),
+    );
+    let raw = format!("{jwt}~");
+    let sd_jwt = SdJwt::parse(&raw).expect("SD-JWT with x5c header should parse");
+
+    assert!(matches!(
+        verify_with_x5c(&sd_jwt, X5cTrustAnchors::default()),
+        Err(VerificationError::X5c { .. })
+    ));
+}
+
+#[test]
+fn rejects_x5c_leaf_without_digital_signature_key_usage() {
+    let fixture = sd_jwt_with_custom_x5c(
+        JwtAlgorithm::ES256,
+        vec![KeyUsagePurpose::KeyEncipherment],
+        true,
+    );
+    let sd_jwt = SdJwt::parse(&fixture.raw).expect("x5c SD-JWT should parse");
+    let trust_anchors = [fixture.trust_anchor];
+
+    assert!(matches!(
+        verify_with_x5c(&sd_jwt, X5cTrustAnchors::Custom(&trust_anchors)),
+        Err(VerificationError::InvalidKey { .. })
+    ));
+}
+
+#[test]
+fn rejects_x5c_leaf_public_key_type_that_does_not_match_algorithm() {
+    let fixture = sd_jwt_with_custom_x5c(
+        JwtAlgorithm::RS256,
+        vec![KeyUsagePurpose::DigitalSignature],
+        false,
+    );
+    let sd_jwt = SdJwt::parse(&fixture.raw).expect("x5c SD-JWT should parse");
+    let trust_anchors = [fixture.trust_anchor];
+
+    assert!(matches!(
+        verify_with_x5c(&sd_jwt, X5cTrustAnchors::Custom(&trust_anchors)),
+        Err(VerificationError::InvalidKey { .. })
     ));
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
@@ -125,8 +125,9 @@ fn verify_signature(
 ) -> Result<SdJwtClaims> {
     let mut validation = Validation::new(algorithm);
     validation.required_spec_claims.clear();
-    validation.validate_exp = false;
-    validation.validate_nbf = false;
+    validation.validate_exp = sd_jwt.jwt().claims().rfc7519.exp.is_some();
+    validation.validate_nbf = sd_jwt.jwt().claims().rfc7519.nbf.is_some();
+
     validation.validate_aud = false;
 
     decode_jwt::<SdJwtClaims>(sd_jwt.jwt().raw(), decoding_key, &validation)

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
@@ -9,7 +9,7 @@ use jsonwebtoken::{
     errors::Error as JwtError, jwk::Jwk as JwtJwk,
 };
 use reqwest_middleware::ClientWithMiddleware;
-use rustls_pki_types::{CertificateDer, UnixTime};
+use rustls_pki_types::{CertificateDer, TrustAnchor, UnixTime};
 use serde_json::Error as JsonError;
 use webpki::{EndEntityCert, Error as WebPkiError, KeyUsage};
 use x509_parser::{extensions::ParsedExtension, parse_x509_certificate, public_key::PublicKey};
@@ -19,6 +19,23 @@ use super::{SdJwt, SdJwtClaims, metadata};
 type Result<T> = std::result::Result<T, VerificationError>;
 
 const ED25519_OID: &str = "1.3.101.112";
+
+/// Trust anchors used to validate an issuer-signed JWT `x5c` certificate path.
+///
+/// Call `X5cTrustAnchors::default()` to use Mozilla's public WebPKI root certificate set.
+#[derive(Debug, Clone, Copy)]
+pub enum X5cTrustAnchors<'a> {
+    /// Mozilla's public WebPKI root certificate set.
+    Mozilla,
+    /// Caller-provided trust anchors.
+    Custom(&'a [TrustAnchor<'a>]),
+}
+
+impl Default for X5cTrustAnchors<'_> {
+    fn default() -> Self {
+        Self::Mozilla
+    }
+}
 
 /// Errors returned while establishing issuer trust or verifying the issuer signature.
 #[derive(Debug, thiserror::Error)]
@@ -55,14 +72,15 @@ pub enum VerificationError {
 /// Establishes issuer trust and verifies the issuer-signed JWT signature.
 ///
 /// If the JWT header contains `x5c`, the certificate chain is validated first
-/// against Mozilla's WebPKI trust anchors. Otherwise, the issuer's trusted JWKS
-/// is resolved from JWT VC Issuer Metadata before selecting a verification key.
+/// against the supplied trust anchors. Otherwise, the issuer's trusted JWKS is
+/// resolved from JWT VC Issuer Metadata before selecting a verification key.
 pub async fn verify_issuer_signature(
     sd_jwt: &SdJwt<'_>,
     http_client: &ClientWithMiddleware,
+    trust_anchors: X5cTrustAnchors<'_>,
 ) -> Result<JwtAlgorithm> {
     if sd_jwt.jwt().header().x5c.is_some() {
-        return verify_with_x5c(sd_jwt);
+        return verify_with_x5c(sd_jwt, trust_anchors);
     }
 
     let jwks = metadata::resolve(sd_jwt, http_client).await?;
@@ -83,7 +101,10 @@ pub(super) fn verify_with_jwks(sd_jwt: &SdJwt<'_>, jwks: &JwkSet) -> Result<JwtA
 ///
 /// The leaf certificate is only used for signature verification after the
 /// supplied certificate chain validates against a trust anchor.
-pub(super) fn verify_with_x5c(sd_jwt: &SdJwt<'_>) -> Result<JwtAlgorithm> {
+pub(super) fn verify_with_x5c(
+    sd_jwt: &SdJwt<'_>,
+    trust_anchors: X5cTrustAnchors<'_>,
+) -> Result<JwtAlgorithm> {
     let algorithm = supported_public_algorithm(sd_jwt.jwt().header().alg)?;
     let x5c = sd_jwt
         .jwt()
@@ -96,7 +117,7 @@ pub(super) fn verify_with_x5c(sd_jwt: &SdJwt<'_>) -> Result<JwtAlgorithm> {
         })?;
 
     let chain = decode_x5c_chain(x5c)?;
-    validate_x5c_chain(&chain)?;
+    validate_x5c_chain(&chain, trust_anchors)?;
     let spki = leaf_spki_for_algorithm(&chain[0], algorithm)?;
 
     let decoding_key = match algorithm {
@@ -263,7 +284,16 @@ fn decode_x5c_chain(x5c: &[String]) -> Result<Vec<Vec<u8>>> {
         .collect()
 }
 
-fn validate_x5c_chain(chain: &[Vec<u8>]) -> Result<()> {
+fn validate_x5c_chain(chain: &[Vec<u8>], trust_anchors: X5cTrustAnchors<'_>) -> Result<()> {
+    match trust_anchors {
+        X5cTrustAnchors::Mozilla => {
+            validate_with_trust_anchors(chain, webpki_roots::TLS_SERVER_ROOTS)
+        }
+        X5cTrustAnchors::Custom(trust_anchors) => validate_with_trust_anchors(chain, trust_anchors),
+    }
+}
+
+fn validate_with_trust_anchors(chain: &[Vec<u8>], trust_anchors: &[TrustAnchor<'_>]) -> Result<()> {
     let leaf = CertificateDer::from(chain[0].as_slice());
     let intermediates = chain[1..]
         .iter()
@@ -275,7 +305,7 @@ fn validate_x5c_chain(chain: &[Vec<u8>]) -> Result<()> {
     end_entity
         .verify_for_usage(
             webpki::ALL_VERIFICATION_ALGS,
-            webpki_roots::TLS_SERVER_ROOTS,
+            trust_anchors,
             &intermediates,
             UnixTime::now(),
             KeyUsage::server_auth(),

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
@@ -1,0 +1,350 @@
+use std::borrow::Cow;
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use cloud_wallet_crypto::jwk::{
+    Algorithm as JwkAlgorithm, Curve, Jwk, JwkSet, Key, KeyUse, OkpCurve, Operations, Signing,
+};
+use jsonwebtoken::{
+    Algorithm as JwtAlgorithm, DecodingKey, Validation, decode as decode_jwt,
+    errors::Error as JwtError, jwk::Jwk as JwtJwk,
+};
+use reqwest_middleware::ClientWithMiddleware;
+use rustls_pki_types::{CertificateDer, UnixTime};
+use serde_json::Error as JsonError;
+use webpki::{EndEntityCert, Error as WebPkiError, KeyUsage};
+use x509_parser::{extensions::ParsedExtension, parse_x509_certificate, public_key::PublicKey};
+
+use super::{SdJwt, SdJwtClaims, metadata};
+
+type Result<T> = std::result::Result<T, VerificationError>;
+
+const ED25519_OID: &str = "1.3.101.112";
+
+/// Errors returned while establishing issuer trust or verifying the issuer signature.
+#[derive(Debug, thiserror::Error)]
+pub enum VerificationError {
+    /// The trust material for the issuer could not be resolved.
+    #[error("failed to establish issuer trust")]
+    Trust(#[from] metadata::IssuerMetadataError),
+
+    /// The trusted key set does not contain an unambiguous signing key.
+    #[error("trusted issuer signing key not found: {message}")]
+    KeySelection { message: Cow<'static, str> },
+
+    /// The JOSE algorithm or the trusted key parameters are not acceptable.
+    #[error("invalid issuer signing key: {message}")]
+    InvalidKey { message: Cow<'static, str> },
+
+    /// The trusted key could not be converted for verification.
+    #[error("failed to prepare issuer verification key")]
+    KeyMaterial {
+        /// Underlying conversion/parsing failure.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The issuer-signed JWT signature is invalid.
+    #[error("issuer-signed JWT signature verification failed")]
+    Signature(#[from] JwtError),
+
+    /// The `x5c` trust path could not be validated.
+    #[error("failed to validate issuer x5c trust chain: {message}")]
+    X5c { message: Cow<'static, str> },
+}
+
+/// Establishes issuer trust and verifies the issuer-signed JWT signature.
+///
+/// If the JWT header contains `x5c`, the certificate chain is validated first
+/// against Mozilla's WebPKI trust anchors. Otherwise, the issuer's trusted JWKS
+/// is resolved from JWT VC Issuer Metadata before selecting a verification key.
+pub async fn verify_issuer_signature(
+    sd_jwt: &SdJwt<'_>,
+    http_client: &ClientWithMiddleware,
+) -> Result<JwtAlgorithm> {
+    if sd_jwt.jwt().header().x5c.is_some() {
+        return verify_with_x5c(sd_jwt);
+    }
+
+    let jwks = metadata::resolve(sd_jwt, http_client).await?;
+    verify_with_jwks(sd_jwt, &jwks)
+}
+
+/// Verifies the issuer-signed JWT with a JWKS that has already been trusted.
+pub(super) fn verify_with_jwks(sd_jwt: &SdJwt<'_>, jwks: &JwkSet) -> Result<JwtAlgorithm> {
+    let algorithm = supported_public_algorithm(sd_jwt.jwt().header().alg)?;
+    let key = select_jwk(sd_jwt, jwks)?;
+    validate_jwk_for_algorithm(key, algorithm)?;
+    let decoding_key = decoding_key_from_jwk(key)?;
+    verify_signature(sd_jwt, &decoding_key, algorithm)?;
+    Ok(algorithm)
+}
+
+/// Verifies an issuer-signed JWT whose JOSE header carries an `x5c` chain.
+///
+/// The leaf certificate is only used for signature verification after the
+/// supplied certificate chain validates against a trust anchor.
+pub(super) fn verify_with_x5c(sd_jwt: &SdJwt<'_>) -> Result<JwtAlgorithm> {
+    let algorithm = supported_public_algorithm(sd_jwt.jwt().header().alg)?;
+    let x5c = sd_jwt
+        .jwt()
+        .header()
+        .x5c
+        .as_ref()
+        .filter(|certs| !certs.is_empty())
+        .ok_or_else(|| VerificationError::X5c {
+            message: "JWT header x5c must contain at least one certificate".into(),
+        })?;
+
+    let chain = decode_x5c_chain(x5c)?;
+    validate_x5c_chain(&chain)?;
+    let spki = leaf_spki_for_algorithm(&chain[0], algorithm)?;
+
+    let decoding_key = match algorithm {
+        JwtAlgorithm::RS256
+        | JwtAlgorithm::RS384
+        | JwtAlgorithm::RS512
+        | JwtAlgorithm::PS256
+        | JwtAlgorithm::PS384
+        | JwtAlgorithm::PS512 => DecodingKey::from_rsa_der(&spki),
+        JwtAlgorithm::ES256 | JwtAlgorithm::ES384 => DecodingKey::from_ec_der(&spki),
+        JwtAlgorithm::EdDSA => DecodingKey::from_ed_der(&spki),
+        JwtAlgorithm::HS256 | JwtAlgorithm::HS384 | JwtAlgorithm::HS512 => {
+            return Err(VerificationError::InvalidKey {
+                message: "HMAC algorithms are not supported for x5c verification".into(),
+            });
+        }
+    };
+    verify_signature(sd_jwt, &decoding_key, algorithm)?;
+    Ok(algorithm)
+}
+
+fn verify_signature(
+    sd_jwt: &SdJwt<'_>,
+    decoding_key: &DecodingKey,
+    algorithm: JwtAlgorithm,
+) -> Result<SdJwtClaims> {
+    let mut validation = Validation::new(algorithm);
+    validation.required_spec_claims.clear();
+    validation.validate_exp = false;
+    validation.validate_nbf = false;
+    validation.validate_aud = false;
+
+    decode_jwt::<SdJwtClaims>(sd_jwt.jwt().raw(), decoding_key, &validation)
+        .map(|token| token.claims)
+        .map_err(Into::into)
+}
+
+fn supported_public_algorithm(algorithm: JwtAlgorithm) -> Result<JwtAlgorithm> {
+    match algorithm {
+        JwtAlgorithm::HS256 | JwtAlgorithm::HS384 | JwtAlgorithm::HS512 => {
+            Err(VerificationError::InvalidKey {
+                message: "issuer verification keys must not use symmetric HMAC algorithms".into(),
+            })
+        }
+        _ => Ok(algorithm),
+    }
+}
+
+fn select_jwk<'a>(sd_jwt: &SdJwt<'_>, jwks: &'a JwkSet) -> Result<&'a Jwk> {
+    if let Some(kid) = sd_jwt.jwt().header().kid.as_deref() {
+        return metadata::key_by_id(jwks, kid).ok_or_else(|| VerificationError::KeySelection {
+            message: format!("no trusted key matches kid '{kid}'").into(),
+        });
+    }
+
+    match jwks.keys.as_slice() {
+        [key] => Ok(key),
+        [] => Err(VerificationError::KeySelection {
+            message: "trusted JWKS is empty".into(),
+        }),
+        _ => Err(VerificationError::KeySelection {
+            message: "JWT header kid is required when the trusted JWKS has multiple keys".into(),
+        }),
+    }
+}
+
+fn validate_jwk_for_algorithm(jwk: &Jwk, algorithm: JwtAlgorithm) -> Result<()> {
+    if jwk
+        .prm
+        .key_use
+        .is_some_and(|key_use| key_use != KeyUse::Signing)
+    {
+        return Err(VerificationError::InvalidKey {
+            message: "trusted key use must be sig when present".into(),
+        });
+    }
+
+    if jwk
+        .prm
+        .ops
+        .as_ref()
+        .is_some_and(|ops| !ops.contains(&Operations::Verify))
+    {
+        return Err(VerificationError::InvalidKey {
+            message: "trusted key_ops must be verify when present".into(),
+        });
+    }
+
+    if let Some(key_algorithm) = jwk.prm.alg.as_ref().and_then(jwk_algorithm_to_jwt)
+        && key_algorithm != algorithm
+    {
+        return Err(VerificationError::InvalidKey {
+            message: format!(
+                "JWT alg {algorithm:?} does not match trusted JWK alg {key_algorithm:?}"
+            )
+            .into(),
+        });
+    }
+
+    let compatible = match (algorithm, &jwk.key) {
+        (
+            JwtAlgorithm::RS256
+            | JwtAlgorithm::RS384
+            | JwtAlgorithm::RS512
+            | JwtAlgorithm::PS256
+            | JwtAlgorithm::PS384
+            | JwtAlgorithm::PS512,
+            Key::Rsa(_),
+        ) => true,
+        (JwtAlgorithm::ES256, Key::Ec(ec)) => ec.crv == Curve::P256,
+        (JwtAlgorithm::ES384, Key::Ec(ec)) => ec.crv == Curve::P384,
+        (JwtAlgorithm::EdDSA, Key::Okp(okp)) => {
+            matches!(okp.crv, OkpCurve::Ed25519 | OkpCurve::Ed448)
+        }
+        _ => false,
+    };
+
+    if compatible {
+        Ok(())
+    } else {
+        Err(VerificationError::InvalidKey {
+            message: format!("trusted key type is not compatible with JWT alg {algorithm:?}")
+                .into(),
+        })
+    }
+}
+
+fn jwk_algorithm_to_jwt(algorithm: &JwkAlgorithm) -> Option<JwtAlgorithm> {
+    match algorithm {
+        JwkAlgorithm::Signing(Signing::EdDsa) => Some(JwtAlgorithm::EdDSA),
+        JwkAlgorithm::Signing(Signing::Es256) => Some(JwtAlgorithm::ES256),
+        JwkAlgorithm::Signing(Signing::Es384) => Some(JwtAlgorithm::ES384),
+        JwkAlgorithm::Signing(Signing::Ps256) => Some(JwtAlgorithm::PS256),
+        JwkAlgorithm::Signing(Signing::Ps384) => Some(JwtAlgorithm::PS384),
+        JwkAlgorithm::Signing(Signing::Ps512) => Some(JwtAlgorithm::PS512),
+        JwkAlgorithm::Signing(Signing::Rs256) => Some(JwtAlgorithm::RS256),
+        JwkAlgorithm::Signing(Signing::Rs384) => Some(JwtAlgorithm::RS384),
+        JwkAlgorithm::Signing(Signing::Rs512) => Some(JwtAlgorithm::RS512),
+        JwkAlgorithm::Signing(Signing::Hs256 | Signing::Hs384 | Signing::Hs512) => None,
+        JwkAlgorithm::Signing(Signing::Es256K | Signing::Es512 | Signing::Null) => None,
+        _ => None,
+    }
+}
+
+fn decoding_key_from_jwk(jwk: &Jwk) -> Result<DecodingKey> {
+    let jwt_jwk = serde_json::to_value(jwk)
+        .and_then(serde_json::from_value::<JwtJwk>)
+        .map_err(key_material_error)?;
+
+    DecodingKey::from_jwk(&jwt_jwk).map_err(key_material_error)
+}
+
+fn decode_x5c_chain(x5c: &[String]) -> Result<Vec<Vec<u8>>> {
+    x5c.iter()
+        .enumerate()
+        .map(|(index, encoded)| {
+            STANDARD
+                .decode(encoded)
+                .map_err(|_| VerificationError::X5c {
+                    message: format!("certificate {index} is not valid base64").into(),
+                })
+        })
+        .collect()
+}
+
+fn validate_x5c_chain(chain: &[Vec<u8>]) -> Result<()> {
+    let leaf = CertificateDer::from(chain[0].as_slice());
+    let intermediates = chain[1..]
+        .iter()
+        .map(|cert| CertificateDer::from(cert.as_slice()))
+        .collect::<Vec<_>>();
+    let end_entity = EndEntityCert::try_from(&leaf)
+        .map_err(|source| x5c_error("invalid leaf certificate", source))?;
+
+    end_entity
+        .verify_for_usage(
+            webpki::ALL_VERIFICATION_ALGS,
+            webpki_roots::TLS_SERVER_ROOTS,
+            &intermediates,
+            UnixTime::now(),
+            KeyUsage::server_auth(),
+            None,
+            None,
+        )
+        .map_err(|source| x5c_error("certificate chain is not trusted", source))?;
+    Ok(())
+}
+
+fn leaf_spki_for_algorithm(leaf_der: &[u8], algorithm: JwtAlgorithm) -> Result<Vec<u8>> {
+    let (_, cert) = parse_x509_certificate(leaf_der).map_err(|_| VerificationError::X5c {
+        message: "failed to parse leaf certificate".into(),
+    })?;
+    validate_leaf_key_usage(&cert)?;
+
+    let public_key = cert.public_key();
+    let compatible = match (algorithm, public_key.parsed()) {
+        (
+            JwtAlgorithm::RS256
+            | JwtAlgorithm::RS384
+            | JwtAlgorithm::RS512
+            | JwtAlgorithm::PS256
+            | JwtAlgorithm::PS384
+            | JwtAlgorithm::PS512,
+            Ok(PublicKey::RSA(_)),
+        ) => true,
+        (JwtAlgorithm::ES256 | JwtAlgorithm::ES384, Ok(PublicKey::EC(_))) => true,
+        (JwtAlgorithm::EdDSA, _) => public_key.algorithm.algorithm.to_id_string() == ED25519_OID,
+        _ => false,
+    };
+
+    if !compatible {
+        return Err(VerificationError::InvalidKey {
+            message: format!(
+                "leaf certificate public key is not compatible with JWT alg {algorithm:?}"
+            )
+            .into(),
+        });
+    }
+    Ok(public_key.raw.to_vec())
+}
+
+fn validate_leaf_key_usage(cert: &x509_parser::certificate::X509Certificate<'_>) -> Result<()> {
+    for extension in cert.extensions() {
+        if let ParsedExtension::KeyUsage(key_usage) = extension.parsed_extension()
+            && !key_usage.digital_signature()
+        {
+            return Err(VerificationError::InvalidKey {
+                message: "leaf certificate key usage must allow digitalSignature".into(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn key_material_error(source: impl std::error::Error + Send + Sync + 'static) -> VerificationError {
+    VerificationError::KeyMaterial {
+        source: Box::new(source),
+    }
+}
+
+fn x5c_error(message: &'static str, source: WebPkiError) -> VerificationError {
+    VerificationError::X5c {
+        message: format!("{message}: {source}").into(),
+    }
+}
+
+impl From<JsonError> for VerificationError {
+    fn from(source: JsonError) -> Self {
+        key_material_error(source)
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
@@ -23,18 +23,13 @@ const ED25519_OID: &str = "1.3.101.112";
 /// Trust anchors used to validate an issuer-signed JWT `x5c` certificate path.
 ///
 /// Call `X5cTrustAnchors::default()` to use Mozilla's public WebPKI root certificate set.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub enum X5cTrustAnchors<'a> {
     /// Mozilla's public WebPKI root certificate set.
+    #[default]
     Mozilla,
     /// Caller-provided trust anchors.
     Custom(&'a [TrustAnchor<'a>]),
-}
-
-impl Default for X5cTrustAnchors<'_> {
-    fn default() -> Self {
-        Self::Mozilla
-    }
 }
 
 /// Errors returned while establishing issuer trust or verifying the issuer signature.

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/verification.rs
@@ -11,7 +11,7 @@ use jsonwebtoken::{
 use reqwest_middleware::ClientWithMiddleware;
 use rustls_pki_types::{CertificateDer, TrustAnchor, UnixTime};
 use serde_json::Error as JsonError;
-use webpki::{EndEntityCert, Error as WebPkiError, KeyUsage};
+use webpki::{EndEntityCert, Error as WebPkiError};
 use x509_parser::{extensions::ParsedExtension, parse_x509_certificate, public_key::PublicKey};
 
 use super::{SdJwt, SdJwtClaims, metadata};
@@ -303,12 +303,23 @@ fn validate_with_trust_anchors(chain: &[Vec<u8>], trust_anchors: &[TrustAnchor<'
             trust_anchors,
             &intermediates,
             UnixTime::now(),
-            KeyUsage::server_auth(),
+            &AnyKeyUsage,
             None,
             None,
         )
         .map_err(|source| x5c_error("certificate chain is not trusted", source))?;
     Ok(())
+}
+
+struct AnyKeyUsage;
+
+impl webpki::ExtendedKeyUsageValidator for AnyKeyUsage {
+    fn validate(
+        &self,
+        _iter: webpki::KeyPurposeIdIter<'_, '_>,
+    ) -> std::result::Result<(), WebPkiError> {
+        Ok(())
+    }
 }
 
 fn leaf_spki_for_algorithm(leaf_der: &[u8], algorithm: JwtAlgorithm) -> Result<Vec<u8>> {


### PR DESCRIPTION
RFC 9901 requires issuer JWT signature validation, secure algorithm policy, issuer validation, signing-key ownership validation, and `_sd_alg` validation.

Implement a verifier that:
- validate the certificate chain in `x5c` header against a trust anchor when present.
- selects verification key by `kid` when present
- verifies JWS signature
- maps supported JWS algs to key types
- validates standard time claims where present
- validates `iss` when present

## Acceptance Criteria

- Rejects expired credentials.
- Rejects issuer mismatch.
- Rejects bad signatures.
- Accepts valid SD-JWT VC test fixture.
- Unit tests include ES256 at minimum.