### PR TITLE
Authorization response models for OpenID4VP

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/lib.rs
+++ b/crates/cloud-wallet-openid4vc/src/lib.rs
@@ -2,4 +2,5 @@ pub mod core;
 pub mod errors;
 pub mod formats;
 pub mod oid4vci;
+pub mod oid4vp;
 pub mod utils;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/error.rs
@@ -1,0 +1,54 @@
+//! OAuth and OpenID4VP authorization error codes.
+//!
+//! These error codes are used in authorization error responses as defined in
+//! Section 8.5 of the OpenID4VP specification and follow the OAuth 2.0 error
+//! response format.
+
+use serde::Serialize;
+
+/// OAuth and OpenID4VP authorization error codes used by Section 8.5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationErrorCode {
+    /// The request is missing a required parameter, includes an invalid
+    /// parameter value, or is otherwise malformed.
+    InvalidRequest,
+
+    /// The requested scope is invalid, unknown, or malformed.
+    InvalidScope,
+
+    /// Client authentication failed.
+    InvalidClient,
+
+    /// The resource owner or authorization server denied the request.
+    AccessDenied,
+
+    /// The authenticated client is not authorized to use this authorization
+    /// grant type.
+    UnauthorizedClient,
+
+    /// The authorization server does not support obtaining an authorization
+    /// code using this method.
+    UnsupportedResponseType,
+
+    /// The authorization server encountered an unexpected condition that
+    /// prevented it from completing the request.
+    ServerError,
+
+    /// The authorization server is currently unable to handle the request
+    /// due to a temporary overloading or maintenance of the server.
+    TemporarilyUnavailable,
+
+    /// The Wallet does not support any of the requested VP formats.
+    VpFormatsNotSupported,
+
+    /// The Wallet does not support the request_uri method used in the
+    /// authorization request.
+    InvalidRequestUriMethod,
+
+    /// The transaction data is invalid.
+    InvalidTransactionData,
+
+    /// The Wallet is currently unavailable to process the request.
+    WalletUnavailable,
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/mod.rs
@@ -1,0 +1,3 @@
+mod response;
+
+pub use response::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/mod.rs
@@ -1,3 +1,5 @@
+mod error;
 mod response;
 
+pub use error::*;
 pub use response::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -4,6 +4,8 @@ use serde::{Serialize, Serializer};
 use serde_with::skip_serializing_none;
 use url::Url;
 
+use super::error::AuthorizationErrorCode;
+
 /// A presentation value returned for one DCQL Credential Query.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(untagged)]
@@ -19,7 +21,8 @@ pub enum Presentation {
 ///
 /// Per the spec, the value is a JSON object keyed by `CredentialQuery.id`,
 /// where each entry contains one or more presentations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
 pub struct VpToken {
     entries: BTreeMap<String, Vec<Presentation>>,
 }
@@ -61,15 +64,6 @@ impl VpToken {
     }
 }
 
-impl Serialize for VpToken {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.entries.serialize(serializer)
-    }
-}
-
 fn is_valid_dcql_query_id(query_id: &str) -> bool {
     !query_id.is_empty()
         && query_id
@@ -78,7 +72,8 @@ fn is_valid_dcql_query_id(query_id: &str) -> bool {
 }
 
 /// Authorization Response parameters for OpenID4VP.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
 pub enum AuthorizationResponse {
     /// Successful Authorization Response parameters.
     Success(AuthorizationSuccessResponse),
@@ -89,12 +84,8 @@ pub enum AuthorizationResponse {
 
 impl AuthorizationResponse {
     /// Creates a new successful authorization response with a VP token.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the VP token fails validation.
-    pub fn new(vp_token: VpToken) -> Result<Self, String> {
-        Ok(Self::Success(AuthorizationSuccessResponse::new(vp_token)))
+    pub fn new(vp_token: VpToken) -> Self {
+        Self::Success(AuthorizationSuccessResponse::new(vp_token))
     }
 
     /// Creates a new authorization error response.
@@ -115,18 +106,6 @@ impl AuthorizationResponse {
     /// `application/x-www-form-urlencoded` `direct_post`.
     pub fn as_direct_post_form(&self) -> DirectPostAuthorizationResponse<'_> {
         DirectPostAuthorizationResponse { response: self }
-    }
-}
-
-impl Serialize for AuthorizationResponse {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            Self::Success(response) => response.serialize(serializer),
-            Self::Error(response) => response.serialize(serializer),
-        }
     }
 }
 
@@ -225,24 +204,6 @@ impl AuthorizationErrorResponse {
     }
 }
 
-/// OAuth and OpenID4VP authorization error codes used by Section 8.5.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AuthorizationErrorCode {
-    InvalidRequest,
-    InvalidScope,
-    InvalidClient,
-    AccessDenied,
-    UnauthorizedClient,
-    UnsupportedResponseType,
-    ServerError,
-    TemporarilyUnavailable,
-    VpFormatsNotSupported,
-    InvalidRequestUriMethod,
-    InvalidTransactionData,
-    WalletUnavailable,
-}
-
 /// Form-encoding helper for `direct_post` authorization responses.
 #[derive(Debug, Clone, Copy)]
 pub struct DirectPostAuthorizationResponse<'a> {
@@ -286,6 +247,11 @@ impl<'a> DirectPostAuthorizationSuccessResponse<'a> {
     }
 }
 
+/// Serializes an optional `VpToken` as a JSON string for `direct_post` form encoding.
+///
+/// This function is used by `DirectPostAuthorizationSuccessResponse` to serialize
+/// the `vp_token` field as a JSON string (rather than a nested JSON object),
+/// as required by the `application/x-www-form-urlencoded` format.
 fn serialize_optional_vp_token_as_json_string<S>(
     vp_token: &Option<&VpToken>,
     serializer: S,
@@ -476,9 +442,7 @@ mod tests {
             vec![string_presentation("eyJhbGciOiJFUzI1NiJ9...")],
         );
 
-        let response = AuthorizationResponse::new(vp_token(entries))
-            .expect("valid response")
-            .with_state("state-123");
+        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
 
         let json = serde_json::to_value(&response).expect("serialize");
 
@@ -549,9 +513,7 @@ mod tests {
             vec![string_presentation("vp-token-value")],
         );
 
-        let response = AuthorizationResponse::new(vp_token(entries))
-            .expect("valid response")
-            .with_state("state-123");
+        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
 
         let encoded =
             serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -5,48 +5,45 @@ use url::Url;
 
 /// A VP token returned in an OpenID4VP authorization response.
 ///
-/// The `Single` variant represents a single presentation value.
-/// The `Multiple` variant represents a JSON object keyed by `CredentialQuery.id`
-/// values, where each key maps to one or more presentation values.
+/// Per the spec, the value is a JSON object keyed by `CredentialQuery.id`,
+/// where each entry contains one or more presentations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VpToken {
-    Single(String),
-    Multiple(BTreeMap<String, Vec<serde_json::Value>>),
+pub struct VpToken {
+    entries: BTreeMap<String, Vec<serde_json::Value>>,
 }
 
 impl VpToken {
+    /// Creates a new VP token from DCQL query entries.
+    pub fn new(entries: BTreeMap<String, Vec<serde_json::Value>>) -> Self {
+        Self { entries }
+    }
+
+    /// Returns the underlying DCQL entries.
+    pub fn entries(&self) -> &BTreeMap<String, Vec<serde_json::Value>> {
+        &self.entries
+    }
+
     fn validate(&self) -> Result<(), String> {
-        match self {
-            Self::Single(value) => {
-                if value.trim().is_empty() {
-                    return Err("vp_token must not be empty".to_string());
-                }
+        if self.entries.is_empty() {
+            return Err("vp_token must contain at least one credential query entry".to_string());
+        }
+
+        for (query_id, presentations) in &self.entries {
+            if query_id.trim().is_empty() {
+                return Err("vp_token contains an empty credential query id".to_string());
             }
-            Self::Multiple(entries) => {
-                if entries.is_empty() {
-                    return Err(
-                        "vp_token must contain at least one credential query entry".to_string()
-                    );
-                }
 
-                for (query_id, presentations) in entries {
-                    if query_id.trim().is_empty() {
-                        return Err("vp_token contains an empty credential query id".to_string());
-                    }
+            if presentations.is_empty() {
+                return Err(format!(
+                    "vp_token entry '{query_id}' must contain at least one presentation"
+                ));
+            }
 
-                    if presentations.is_empty() {
-                        return Err(format!(
-                            "vp_token entry '{query_id}' must contain at least one presentation"
-                        ));
-                    }
-
-                    for presentation in presentations {
-                        if !presentation.is_string() && !presentation.is_object() {
-                            return Err(format!(
-                                "vp_token entry '{query_id}' contains an invalid presentation value"
-                            ));
-                        }
-                    }
+            for presentation in presentations {
+                if !presentation.is_string() && !presentation.is_object() {
+                    return Err(format!(
+                        "vp_token entry '{query_id}' contains an invalid presentation value"
+                    ));
                 }
             }
         }
@@ -61,11 +58,9 @@ impl Serialize for VpToken {
         S: Serializer,
     {
         self.validate().map_err(serde::ser::Error::custom)?;
-        match self {
-            Self::Single(value) => serializer.serialize_str(value),
-            Self::Multiple(entries) => serializer
-                .serialize_str(&serde_json::to_string(entries).map_err(serde::ser::Error::custom)?),
-        }
+        serializer.serialize_str(
+            &serde_json::to_string(&self.entries).map_err(serde::ser::Error::custom)?,
+        )
     }
 }
 
@@ -78,7 +73,7 @@ impl<'de> Deserialize<'de> for VpToken {
         #[serde(untagged)]
         enum RawVpToken {
             String(String),
-            Multiple(BTreeMap<String, Vec<serde_json::Value>>),
+            Object(BTreeMap<String, Vec<serde_json::Value>>),
         }
 
         let token = match RawVpToken::deserialize(deserializer)? {
@@ -88,12 +83,14 @@ impl<'de> Deserialize<'de> for VpToken {
                         value.trim(),
                     )
                     .map_err(de::Error::custom)?;
-                    VpToken::Multiple(entries)
+                    VpToken::new(entries)
                 } else {
-                    VpToken::Single(value)
+                    return Err(de::Error::custom(
+                        "vp_token must be a JSON-encoded object of credential query entries",
+                    ));
                 }
             }
-            RawVpToken::Multiple(entries) => VpToken::Multiple(entries),
+            RawVpToken::Object(entries) => VpToken::new(entries),
         };
 
         token.validate().map_err(de::Error::custom)?;
@@ -147,24 +144,26 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn serializes_single_vp_token_to_json_string() {
-        let token = VpToken::Single("eyJhbGciOiJFUzI1NiJ9...".to_string());
+    fn serializes_vp_token_with_single_entry_to_json_string() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "my_credential".to_string(),
+            vec![serde_json::Value::String(
+                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
+            )],
+        );
+        let token = VpToken::new(entries);
 
         let json = serde_json::to_value(&token).expect("serialize");
 
-        assert_eq!(json, json!("eyJhbGciOiJFUzI1NiJ9..."));
+        assert_eq!(
+            json,
+            json!(r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9..."]}"#)
+        );
     }
 
     #[test]
-    fn rejects_empty_single_vp_token_on_serialize() {
-        let token = VpToken::Single("   ".to_string());
-
-        let err = serde_json::to_string(&token).unwrap_err();
-        assert!(err.to_string().contains("vp_token must not be empty"));
-    }
-
-    #[test]
-    fn serializes_multiple_vp_token_to_json_string() {
+    fn serializes_vp_token_to_json_string() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -174,7 +173,7 @@ mod tests {
             ],
         );
 
-        let token = VpToken::Multiple(entries);
+        let token = VpToken::new(entries);
 
         let json = serde_json::to_value(&token).expect("serialize");
 
@@ -185,8 +184,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_empty_multiple_vp_token_on_serialize() {
-        let token = VpToken::Multiple(BTreeMap::new());
+    fn rejects_empty_vp_token_on_serialize() {
+        let token = VpToken::new(BTreeMap::new());
 
         let err = serde_json::to_string(&token).unwrap_err();
         assert!(
@@ -196,46 +195,25 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_presentation_value_in_multiple_vp_token_on_serialize() {
+    fn rejects_invalid_presentation_value_on_serialize() {
         let mut entries = BTreeMap::new();
         entries.insert("my_credential".to_string(), vec![serde_json::Value::Null]);
 
-        let token = VpToken::Multiple(entries);
+        let token = VpToken::new(entries);
 
         let err = serde_json::to_string(&token).unwrap_err();
         assert!(err.to_string().contains("invalid presentation value"));
     }
 
     #[test]
-    fn round_trips_single_vp_token_via_form_body() {
-        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()))
-            .with_state("state-123");
-
-        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
-        let decoded: AuthorizationResponse =
-            serde_urlencoded::from_str(&encoded).expect("deserialize");
-
-        assert_eq!(decoded, response);
-
-        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
-            .into_owned()
-            .collect();
-
-        assert_eq!(params.get("vp_token"), Some(&"vp-token-value".to_string()));
-        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
-    }
-
-    #[test]
-    fn round_trips_multiple_vp_token_via_form_body() {
+    fn round_trips_vp_token_via_form_body() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
-            vec![serde_json::Value::String(
-                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
-            )],
+            vec![serde_json::Value::String("vp-token-value".to_string())],
         );
 
-        let response = AuthorizationResponse::new(VpToken::Multiple(entries));
+        let response = AuthorizationResponse::new(VpToken::new(entries)).with_state("state-123");
 
         let encoded = serde_urlencoded::to_string(&response).expect("serialize");
         let decoded: AuthorizationResponse =
@@ -249,35 +227,39 @@ mod tests {
 
         assert_eq!(
             params.get("vp_token"),
-            Some(&r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9..."]}"#.to_string())
+            Some(&r#"{"my_credential":["vp-token-value"]}"#.to_string())
         );
+        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
     }
 
     #[test]
-    fn deserializes_multiple_vp_token_from_json_object_string() {
-        let encoded =
-            "vp_token=%7B%22my_credential%22%3A%5B%22eyJhbGciOiJFUzI1NiJ9...%22%5D%7D&state=xyz";
-        let response: AuthorizationResponse =
-            serde_urlencoded::from_str(encoded).expect("deserialize");
+    fn deserializes_vp_token_from_json_object_string() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "my_credential".to_string(),
+            vec![serde_json::Value::String(
+                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
+            )],
+        );
 
-        match response.vp_token {
-            VpToken::Multiple(entries) => {
-                assert_eq!(entries.get("my_credential").unwrap().len(), 1);
-            }
-            VpToken::Single(_) => panic!("expected multiple vp_token"),
-        }
-        assert_eq!(response.state.as_deref(), Some("xyz"));
+        let token = serde_json::to_string(&VpToken::new(entries)).expect("serialize");
+        let parsed: VpToken = serde_json::from_str(&token).expect("deserialize");
+
+        assert_eq!(parsed.entries().get("my_credential").unwrap().len(), 1);
     }
 
     #[test]
     fn rejects_invalid_vp_token_on_deserialize() {
         let err =
             serde_urlencoded::from_str::<AuthorizationResponse>("vp_token=%20%20").unwrap_err();
-        assert!(err.to_string().contains("vp_token must not be empty"));
+        assert!(
+            err.to_string()
+                .contains("vp_token must be a JSON-encoded object")
+        );
     }
 
     #[test]
-    fn rejects_invalid_multiple_vp_token_on_deserialize() {
+    fn rejects_empty_presentation_list_on_deserialize() {
         let encoded = "vp_token=%7B%22my_credential%22%3A%5B%5D%7D";
         let err = serde_urlencoded::from_str::<AuthorizationResponse>(encoded).unwrap_err();
         assert!(err.to_string().contains("at least one presentation"));

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -1,9 +1,7 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use url::Url;
-
-use crate::errors::{Error, ErrorKind};
 
 /// A VP token returned in an OpenID4VP authorization response.
 ///
@@ -17,52 +15,35 @@ pub enum VpToken {
 }
 
 impl VpToken {
-    /// Validates the VP token contents.
-    ///
-    /// Returns [`ErrorKind::InvalidAuthorizationResponse`] if the token is empty,
-    /// if a multiple-entry token is empty, or if it contains invalid presentation values.
-    pub fn validate(&self) -> Result<(), Error> {
+    fn validate(&self) -> Result<(), String> {
         match self {
             Self::Single(value) => {
                 if value.trim().is_empty() {
-                    return Err(Error::message(
-                        ErrorKind::InvalidAuthorizationResponse,
-                        "vp_token must not be empty",
-                    ));
+                    return Err("vp_token must not be empty".to_string());
                 }
             }
             Self::Multiple(entries) => {
                 if entries.is_empty() {
-                    return Err(Error::message(
-                        ErrorKind::InvalidAuthorizationResponse,
-                        "vp_token must contain at least one credential query entry",
-                    ));
+                    return Err(
+                        "vp_token must contain at least one credential query entry".to_string()
+                    );
                 }
 
                 for (query_id, presentations) in entries {
                     if query_id.trim().is_empty() {
-                        return Err(Error::message(
-                            ErrorKind::InvalidAuthorizationResponse,
-                            "vp_token contains an empty credential query id",
-                        ));
+                        return Err("vp_token contains an empty credential query id".to_string());
                     }
 
                     if presentations.is_empty() {
-                        return Err(Error::message(
-                            ErrorKind::InvalidAuthorizationResponse,
-                            format!(
-                                "vp_token entry '{query_id}' must contain at least one presentation"
-                            ),
+                        return Err(format!(
+                            "vp_token entry '{query_id}' must contain at least one presentation"
                         ));
                     }
 
                     for presentation in presentations {
                         if !presentation.is_string() && !presentation.is_object() {
-                            return Err(Error::message(
-                                ErrorKind::InvalidAuthorizationResponse,
-                                format!(
-                                    "vp_token entry '{query_id}' contains an invalid presentation value"
-                                ),
+                            return Err(format!(
+                                "vp_token entry '{query_id}' contains an invalid presentation value"
                             ));
                         }
                     }
@@ -73,10 +54,10 @@ impl VpToken {
         Ok(())
     }
 
-    fn as_form_value(&self) -> Result<String, serde_json::Error> {
+    fn into_form_value(self) -> Result<String, serde_json::Error> {
         match self {
-            Self::Single(value) => Ok(value.clone()),
-            Self::Multiple(entries) => serde_json::to_string(entries),
+            Self::Single(value) => Ok(value),
+            Self::Multiple(entries) => serde_json::to_string(&entries),
         }
     }
 }
@@ -86,7 +67,44 @@ impl Serialize for VpToken {
     where
         S: Serializer,
     {
-        serializer.serialize_str(&self.as_form_value().map_err(serde::ser::Error::custom)?)
+        self.validate().map_err(serde::ser::Error::custom)?;
+        match self {
+            Self::Single(value) => serializer.serialize_str(value),
+            Self::Multiple(entries) => serializer
+                .serialize_str(&serde_json::to_string(entries).map_err(serde::ser::Error::custom)?),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for VpToken {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum RawVpToken {
+            String(String),
+            Multiple(BTreeMap<String, Vec<serde_json::Value>>),
+        }
+
+        let token = match RawVpToken::deserialize(deserializer)? {
+            RawVpToken::String(value) => {
+                if value.trim_start().starts_with('{') {
+                    let entries = serde_json::from_str::<BTreeMap<String, Vec<serde_json::Value>>>(
+                        value.trim(),
+                    )
+                    .map_err(de::Error::custom)?;
+                    VpToken::Multiple(entries)
+                } else {
+                    VpToken::Single(value)
+                }
+            }
+            RawVpToken::Multiple(entries) => VpToken::Multiple(entries),
+        };
+
+        token.validate().map_err(de::Error::custom)?;
+        Ok(token)
     }
 }
 
@@ -94,12 +112,14 @@ impl Serialize for VpToken {
 ///
 /// This type is serialized as `application/x-www-form-urlencoded` for the
 /// `direct_post` response mode.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AuthorizationResponse {
     /// The VP token returned to the Verifier.
     pub vp_token: VpToken,
 
     /// Optional state value echoed from the authorization request.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<String>,
 }
 
@@ -116,29 +136,6 @@ impl AuthorizationResponse {
     pub fn with_state(mut self, state: impl Into<String>) -> Self {
         self.state = Some(state.into());
         self
-    }
-
-    /// Validates the response payload.
-    pub fn validate(&self) -> Result<(), Error> {
-        self.vp_token.validate()
-    }
-}
-
-impl Serialize for AuthorizationResponse {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut struct_serializer = serializer.serialize_struct(
-            "AuthorizationResponse",
-            if self.state.is_some() { 2 } else { 1 },
-        )?;
-
-        struct_serializer.serialize_field("vp_token", &self.vp_token)?;
-        if let Some(state) = &self.state {
-            struct_serializer.serialize_field("state", state)?;
-        }
-        struct_serializer.end()
     }
 }
 
@@ -157,23 +154,29 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn validates_single_vp_token() {
+    fn serializes_single_vp_token_to_json_string() {
         let token = VpToken::Single("eyJhbGciOiJFUzI1NiJ9...".to_string());
 
-        assert!(token.validate().is_ok());
+        assert_eq!(
+            token.clone().into_form_value().expect("form value"),
+            "eyJhbGciOiJFUzI1NiJ9..."
+        );
+
+        let json = serde_json::to_value(&token).expect("serialize");
+
+        assert_eq!(json, json!("eyJhbGciOiJFUzI1NiJ9..."));
     }
 
     #[test]
-    fn rejects_empty_single_vp_token() {
+    fn rejects_empty_single_vp_token_on_serialize() {
         let token = VpToken::Single("   ".to_string());
 
-        let err = token.validate().unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        let err = serde_json::to_string(&token).unwrap_err();
         assert!(err.to_string().contains("vp_token must not be empty"));
     }
 
     #[test]
-    fn validates_multiple_vp_token() {
+    fn serializes_multiple_vp_token_to_json_string() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -185,15 +188,21 @@ mod tests {
 
         let token = VpToken::Multiple(entries);
 
-        assert!(token.validate().is_ok());
+        assert!(token.clone().into_form_value().is_ok());
+
+        let json = serde_json::to_value(&token).expect("serialize");
+
+        assert_eq!(
+            json,
+            json!(r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9...",{"format":"dc+sd-jwt"}]}"#)
+        );
     }
 
     #[test]
-    fn rejects_empty_multiple_vp_token() {
+    fn rejects_empty_multiple_vp_token_on_serialize() {
         let token = VpToken::Multiple(BTreeMap::new());
 
-        let err = token.validate().unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        let err = serde_json::to_string(&token).unwrap_err();
         assert!(
             err.to_string()
                 .contains("at least one credential query entry")
@@ -201,23 +210,27 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_presentation_value_in_multiple_vp_token() {
+    fn rejects_invalid_presentation_value_in_multiple_vp_token_on_serialize() {
         let mut entries = BTreeMap::new();
         entries.insert("my_credential".to_string(), vec![serde_json::Value::Null]);
 
         let token = VpToken::Multiple(entries);
 
-        let err = token.validate().unwrap_err();
-        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        let err = serde_json::to_string(&token).unwrap_err();
         assert!(err.to_string().contains("invalid presentation value"));
     }
 
     #[test]
-    fn serializes_single_vp_token_as_form_body() {
+    fn round_trips_single_vp_token_via_form_body() {
         let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()))
             .with_state("state-123");
 
         let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        let decoded: AuthorizationResponse =
+            serde_urlencoded::from_str(&encoded).expect("deserialize");
+
+        assert_eq!(decoded, response);
+
         let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
             .into_owned()
             .collect();
@@ -227,7 +240,7 @@ mod tests {
     }
 
     #[test]
-    fn serializes_multiple_vp_token_as_json_string_in_form_body() {
+    fn round_trips_multiple_vp_token_via_form_body() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -239,6 +252,11 @@ mod tests {
         let response = AuthorizationResponse::new(VpToken::Multiple(entries));
 
         let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        let decoded: AuthorizationResponse =
+            serde_urlencoded::from_str(&encoded).expect("deserialize");
+
+        assert_eq!(decoded, response);
+
         let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
             .into_owned()
             .collect();
@@ -247,6 +265,36 @@ mod tests {
             params.get("vp_token"),
             Some(&r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9..."]}"#.to_string())
         );
+    }
+
+    #[test]
+    fn deserializes_multiple_vp_token_from_json_object_string() {
+        let encoded =
+            "vp_token=%7B%22my_credential%22%3A%5B%22eyJhbGciOiJFUzI1NiJ9...%22%5D%7D&state=xyz";
+        let response: AuthorizationResponse =
+            serde_urlencoded::from_str(encoded).expect("deserialize");
+
+        match response.vp_token {
+            VpToken::Multiple(entries) => {
+                assert_eq!(entries.get("my_credential").unwrap().len(), 1);
+            }
+            VpToken::Single(_) => panic!("expected multiple vp_token"),
+        }
+        assert_eq!(response.state.as_deref(), Some("xyz"));
+    }
+
+    #[test]
+    fn rejects_invalid_vp_token_on_deserialize() {
+        let err =
+            serde_urlencoded::from_str::<AuthorizationResponse>("vp_token=%20%20").unwrap_err();
+        assert!(err.to_string().contains("vp_token must not be empty"));
+    }
+
+    #[test]
+    fn rejects_invalid_multiple_vp_token_on_deserialize() {
+        let encoded = "vp_token=%7B%22my_credential%22%3A%5B%5D%7D";
+        let err = serde_urlencoded::from_str::<AuthorizationResponse>(encoded).unwrap_err();
+        assert!(err.to_string().contains("at least one presentation"));
     }
 
     #[test]
@@ -265,21 +313,5 @@ mod tests {
                 "redirect_uri": "https://client.example.org/cb#response_code=abc"
             })
         );
-    }
-
-    #[test]
-    fn validates_authorization_response() {
-        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()));
-
-        assert!(response.validate().is_ok());
-    }
-
-    #[test]
-    fn rejects_blank_state_when_serialized_as_form_body_is_not_needed() {
-        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()))
-            .with_state("");
-
-        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
-        assert!(encoded.contains("state="));
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -58,9 +58,7 @@ impl Serialize for VpToken {
         S: Serializer,
     {
         self.validate().map_err(serde::ser::Error::custom)?;
-        serializer.serialize_str(
-            &serde_json::to_string(&self.entries).map_err(serde::ser::Error::custom)?,
-        )
+        self.entries.serialize(serializer)
     }
 }
 
@@ -99,14 +97,23 @@ impl<'de> Deserialize<'de> for VpToken {
 }
 
 /// Authorization Response parameters for OpenID4VP.
-///
-/// This type is serialized as `application/x-www-form-urlencoded` for the
-/// `direct_post` response mode.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthorizationResponse {
     /// The VP token returned to the Verifier.
-    pub vp_token: VpToken,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vp_token: Option<VpToken>,
+
+    /// Optional ID Token returned when the response type includes `id_token`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id_token: Option<String>,
+
+    /// Optional authorization code returned when the response type includes `code`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+
+    /// Optional issuer identifier returned by response types that define it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iss: Option<String>,
 
     /// Optional state value echoed from the authorization request.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -117,7 +124,10 @@ impl AuthorizationResponse {
     /// Creates a new authorization response.
     pub fn new(vp_token: VpToken) -> Self {
         Self {
-            vp_token,
+            vp_token: Some(vp_token),
+            id_token: None,
+            code: None,
+            iss: None,
             state: None,
         }
     }
@@ -127,11 +137,73 @@ impl AuthorizationResponse {
         self.state = Some(state.into());
         self
     }
+
+    /// Returns a helper that serializes `vp_token` as a JSON string for
+    /// `application/x-www-form-urlencoded` `direct_post`.
+    pub fn as_direct_post_form(&self) -> DirectPostAuthorizationResponse<'_> {
+        DirectPostAuthorizationResponse { response: self }
+    }
+}
+
+/// Form-encoding helper for `direct_post` authorization responses.
+#[derive(Debug, Clone, Copy)]
+pub struct DirectPostAuthorizationResponse<'a> {
+    response: &'a AuthorizationResponse,
+}
+
+impl Serialize for DirectPostAuthorizationResponse<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Form<'a> {
+            #[serde(
+                skip_serializing_if = "Option::is_none",
+                serialize_with = "serialize_optional_vp_token_as_json_string"
+            )]
+            vp_token: Option<&'a VpToken>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            id_token: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            code: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            iss: Option<&'a str>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            state: Option<&'a str>,
+        }
+
+        Form {
+            vp_token: self.response.vp_token.as_ref(),
+            id_token: self.response.id_token.as_deref(),
+            code: self.response.code.as_deref(),
+            iss: self.response.iss.as_deref(),
+            state: self.response.state.as_deref(),
+        }
+        .serialize(serializer)
+    }
+}
+
+fn serialize_optional_vp_token_as_json_string<S>(
+    vp_token: &Option<&VpToken>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match vp_token {
+        Some(vp_token) => {
+            vp_token.validate().map_err(serde::ser::Error::custom)?;
+            serializer.serialize_str(
+                &serde_json::to_string(vp_token.entries()).map_err(serde::ser::Error::custom)?,
+            )
+        }
+        None => serializer.serialize_none(),
+    }
 }
 
 /// Response to the verifier when the Wallet uses the `direct_post` response mode.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct DirectPostResponse {
     /// Optional redirect URI provided by the Verifier.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -144,7 +216,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn serializes_vp_token_with_single_entry_to_json_string() {
+    fn serializes_vp_token_with_single_entry_to_json_object() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -158,12 +230,14 @@ mod tests {
 
         assert_eq!(
             json,
-            json!(r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9..."]}"#)
+            json!({
+                "my_credential": ["eyJhbGciOiJFUzI1NiJ9..."]
+            })
         );
     }
 
     #[test]
-    fn serializes_vp_token_to_json_string() {
+    fn serializes_vp_token_to_json_object() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -179,7 +253,9 @@ mod tests {
 
         assert_eq!(
             json,
-            json!(r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9...",{"format":"dc+sd-jwt"}]}"#)
+            json!({
+                "my_credential": ["eyJhbGciOiJFUzI1NiJ9...", {"format": "dc+sd-jwt"}]
+            })
         );
     }
 
@@ -215,7 +291,8 @@ mod tests {
 
         let response = AuthorizationResponse::new(VpToken::new(entries)).with_state("state-123");
 
-        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        let encoded =
+            serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");
         let decoded: AuthorizationResponse =
             serde_urlencoded::from_str(&encoded).expect("deserialize");
 
@@ -233,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_vp_token_from_json_object_string() {
+    fn serializes_authorization_response_vp_token_as_json_object() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
@@ -242,10 +319,58 @@ mod tests {
             )],
         );
 
-        let token = serde_json::to_string(&VpToken::new(entries)).expect("serialize");
-        let parsed: VpToken = serde_json::from_str(&token).expect("deserialize");
+        let response = AuthorizationResponse::new(VpToken::new(entries)).with_state("state-123");
 
-        assert_eq!(parsed.entries().get("my_credential").unwrap().len(), 1);
+        let json = serde_json::to_value(&response).expect("serialize");
+
+        assert_eq!(
+            json,
+            json!({
+                "vp_token": {
+                    "my_credential": ["eyJhbGciOiJFUzI1NiJ9..."]
+                },
+                "state": "state-123"
+            })
+        );
+    }
+
+    #[test]
+    fn deserializes_vp_token_from_form_json_object_string() {
+        let encoded = "vp_token=%7B%22my_credential%22%3A%5B%22eyJhbGciOiJFUzI1NiJ9...%22%5D%7D";
+
+        let parsed: AuthorizationResponse =
+            serde_urlencoded::from_str(encoded).expect("deserialize");
+
+        assert_eq!(
+            parsed
+                .vp_token
+                .as_ref()
+                .unwrap()
+                .entries()
+                .get("my_credential")
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn deserializes_code_authorization_response_without_vp_token() {
+        let response: AuthorizationResponse =
+            serde_json::from_value(json!({"code": "abc", "state": "xyz"})).expect("deserialize");
+
+        assert_eq!(response.code.as_deref(), Some("abc"));
+        assert_eq!(response.state.as_deref(), Some("xyz"));
+        assert!(response.vp_token.is_none());
+    }
+
+    #[test]
+    fn ignores_unknown_authorization_response_parameters() {
+        let response: AuthorizationResponse =
+            serde_json::from_value(json!({"code": "abc", "extension": "value"}))
+                .expect("deserialize");
+
+        assert_eq!(response.code.as_deref(), Some("abc"));
     }
 
     #[test]
@@ -280,6 +405,20 @@ mod tests {
             json!({
                 "redirect_uri": "https://client.example.org/cb#response_code=abc"
             })
+        );
+    }
+
+    #[test]
+    fn ignores_unknown_direct_post_response_parameters() {
+        let response: DirectPostResponse = serde_json::from_value(json!({
+            "redirect_uri": "https://client.example.org/cb#response_code=abc",
+            "extension": "value"
+        }))
+        .expect("deserialize");
+
+        assert_eq!(
+            response.redirect_uri.as_ref().unwrap().as_str(),
+            "https://client.example.org/cb#response_code=abc"
         );
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -53,14 +53,6 @@ impl VpToken {
 
         Ok(())
     }
-
-    #[allow(dead_code)]
-    fn into_form_value(self) -> Result<String, serde_json::Error> {
-        match self {
-            Self::Single(value) => Ok(value),
-            Self::Multiple(entries) => serde_json::to_string(&entries),
-        }
-    }
 }
 
 impl Serialize for VpToken {
@@ -158,11 +150,6 @@ mod tests {
     fn serializes_single_vp_token_to_json_string() {
         let token = VpToken::Single("eyJhbGciOiJFUzI1NiJ9...".to_string());
 
-        assert_eq!(
-            token.clone().into_form_value().expect("form value"),
-            "eyJhbGciOiJFUzI1NiJ9..."
-        );
-
         let json = serde_json::to_value(&token).expect("serialize");
 
         assert_eq!(json, json!("eyJhbGciOiJFUzI1NiJ9..."));
@@ -188,8 +175,6 @@ mod tests {
         );
 
         let token = VpToken::Multiple(entries);
-
-        assert!(token.clone().into_form_value().is_ok());
 
         let json = serde_json::to_value(&token).expect("serialize");
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -1,7 +1,19 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use serde::{Serialize, Serializer};
+use serde_with::skip_serializing_none;
 use url::Url;
+
+/// A presentation value returned for one DCQL Credential Query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(untagged)]
+pub enum Presentation {
+    /// A compact presentation string, such as an SD-JWT VC presentation.
+    String(String),
+
+    /// A JSON object presentation, such as a JSON-based verifiable presentation.
+    Object(serde_json::Map<String, serde_json::Value>),
+}
 
 /// A VP token returned in an OpenID4VP authorization response.
 ///
@@ -9,17 +21,17 @@ use url::Url;
 /// where each entry contains one or more presentations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VpToken {
-    entries: BTreeMap<String, Vec<serde_json::Value>>,
+    entries: BTreeMap<String, Vec<Presentation>>,
 }
 
 impl VpToken {
     /// Creates a new VP token from DCQL query entries.
-    pub fn new(entries: BTreeMap<String, Vec<serde_json::Value>>) -> Self {
+    pub fn new(entries: BTreeMap<String, Vec<Presentation>>) -> Self {
         Self { entries }
     }
 
     /// Returns the underlying DCQL entries.
-    pub fn entries(&self) -> &BTreeMap<String, Vec<serde_json::Value>> {
+    pub fn entries(&self) -> &BTreeMap<String, Vec<Presentation>> {
         &self.entries
     }
 
@@ -29,22 +41,16 @@ impl VpToken {
         }
 
         for (query_id, presentations) in &self.entries {
-            if query_id.trim().is_empty() {
-                return Err("vp_token contains an empty credential query id".to_string());
+            if !is_valid_dcql_query_id(query_id) {
+                return Err(format!(
+                    "vp_token entry '{query_id}' is not a valid DCQL credential query id"
+                ));
             }
 
             if presentations.is_empty() {
                 return Err(format!(
                     "vp_token entry '{query_id}' must contain at least one presentation"
                 ));
-            }
-
-            for presentation in presentations {
-                if !presentation.is_string() && !presentation.is_object() {
-                    return Err(format!(
-                        "vp_token entry '{query_id}' contains an invalid presentation value"
-                    ));
-                }
             }
         }
 
@@ -62,66 +68,84 @@ impl Serialize for VpToken {
     }
 }
 
-impl<'de> Deserialize<'de> for VpToken {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum RawVpToken {
-            String(String),
-            Object(BTreeMap<String, Vec<serde_json::Value>>),
-        }
-
-        let token = match RawVpToken::deserialize(deserializer)? {
-            RawVpToken::String(value) => {
-                if value.trim_start().starts_with('{') {
-                    let entries = serde_json::from_str::<BTreeMap<String, Vec<serde_json::Value>>>(
-                        value.trim(),
-                    )
-                    .map_err(de::Error::custom)?;
-                    VpToken::new(entries)
-                } else {
-                    return Err(de::Error::custom(
-                        "vp_token must be a JSON-encoded object of credential query entries",
-                    ));
-                }
-            }
-            RawVpToken::Object(entries) => VpToken::new(entries),
-        };
-
-        token.validate().map_err(de::Error::custom)?;
-        Ok(token)
-    }
+fn is_valid_dcql_query_id(query_id: &str) -> bool {
+    !query_id.is_empty()
+        && query_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
 }
 
 /// Authorization Response parameters for OpenID4VP.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AuthorizationResponse {
-    /// The VP token returned to the Verifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vp_token: Option<VpToken>,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthorizationResponse {
+    /// Successful Authorization Response parameters.
+    Success(AuthorizationSuccessResponse),
 
-    /// Optional ID Token returned when the response type includes `id_token`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_token: Option<String>,
-
-    /// Optional authorization code returned when the response type includes `code`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<String>,
-
-    /// Optional issuer identifier returned by response types that define it.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub iss: Option<String>,
-
-    /// Optional state value echoed from the authorization request.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<String>,
+    /// Authorization Error Response parameters.
+    Error(AuthorizationErrorResponse),
 }
 
 impl AuthorizationResponse {
-    /// Creates a new authorization response.
+    /// Creates a new successful authorization response with a VP token.
+    pub fn new(vp_token: VpToken) -> Self {
+        Self::Success(AuthorizationSuccessResponse::new(vp_token))
+    }
+
+    /// Creates a new authorization error response.
+    pub fn error(error: AuthorizationErrorCode) -> Self {
+        Self::Error(AuthorizationErrorResponse::new(error))
+    }
+
+    /// Adds a state value to the response.
+    pub fn with_state(mut self, state: impl Into<String>) -> Self {
+        match &mut self {
+            Self::Success(response) => response.state = Some(state.into()),
+            Self::Error(response) => response.state = Some(state.into()),
+        }
+        self
+    }
+
+    /// Returns a helper that serializes `vp_token` as a JSON string for
+    /// `application/x-www-form-urlencoded` `direct_post`.
+    pub fn as_direct_post_form(&self) -> DirectPostAuthorizationResponse<'_> {
+        DirectPostAuthorizationResponse { response: self }
+    }
+}
+
+impl Serialize for AuthorizationResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Success(response) => response.serialize(serializer),
+            Self::Error(response) => response.serialize(serializer),
+        }
+    }
+}
+
+/// Successful Authorization Response parameters for OpenID4VP.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthorizationSuccessResponse {
+    /// The VP token returned to the Verifier.
+    vp_token: Option<VpToken>,
+
+    /// Optional ID Token returned when the response type includes `id_token`.
+    id_token: Option<String>,
+
+    /// Optional authorization code returned when the response type includes `code`.
+    code: Option<String>,
+
+    /// Optional issuer identifier returned by response types that define it.
+    iss: Option<String>,
+
+    /// Optional state value echoed from the authorization request.
+    state: Option<String>,
+}
+
+impl AuthorizationSuccessResponse {
+    /// Creates a successful response with a VP token.
     pub fn new(vp_token: VpToken) -> Self {
         Self {
             vp_token: Some(vp_token),
@@ -132,17 +156,105 @@ impl AuthorizationResponse {
         }
     }
 
+    /// Creates a successful response with an authorization code.
+    pub fn code(code: impl Into<String>) -> Self {
+        Self {
+            vp_token: None,
+            id_token: None,
+            code: Some(code.into()),
+            iss: None,
+            state: None,
+        }
+    }
+
+    /// Adds an ID Token to the response.
+    pub fn with_id_token(mut self, id_token: impl Into<String>) -> Self {
+        self.id_token = Some(id_token.into());
+        self
+    }
+
+    /// Adds an authorization code to the response.
+    pub fn with_code(mut self, code: impl Into<String>) -> Self {
+        self.code = Some(code.into());
+        self
+    }
+
+    /// Adds an issuer identifier to the response.
+    pub fn with_iss(mut self, iss: impl Into<String>) -> Self {
+        self.iss = Some(iss.into());
+        self
+    }
+
     /// Adds a state value to the response.
     pub fn with_state(mut self, state: impl Into<String>) -> Self {
         self.state = Some(state.into());
         self
     }
+}
 
-    /// Returns a helper that serializes `vp_token` as a JSON string for
-    /// `application/x-www-form-urlencoded` `direct_post`.
-    pub fn as_direct_post_form(&self) -> DirectPostAuthorizationResponse<'_> {
-        DirectPostAuthorizationResponse { response: self }
+/// Authorization Error Response parameters for OpenID4VP.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthorizationErrorResponse {
+    /// Error code describing why the request could not be completed.
+    error: AuthorizationErrorCode,
+
+    /// Optional human-readable error description.
+    error_description: Option<String>,
+
+    /// Optional URI with additional error information.
+    error_uri: Option<Url>,
+
+    /// Optional state value echoed from the authorization request.
+    state: Option<String>,
+}
+
+impl AuthorizationErrorResponse {
+    /// Creates an authorization error response.
+    pub fn new(error: AuthorizationErrorCode) -> Self {
+        Self {
+            error,
+            error_description: None,
+            error_uri: None,
+            state: None,
+        }
     }
+
+    /// Adds a human-readable error description.
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.error_description = Some(description.into());
+        self
+    }
+
+    /// Adds a URI with additional error information.
+    pub fn with_error_uri(mut self, error_uri: Url) -> Self {
+        self.error_uri = Some(error_uri);
+        self
+    }
+
+    /// Adds a state value to the response.
+    pub fn with_state(mut self, state: impl Into<String>) -> Self {
+        self.state = Some(state.into());
+        self
+    }
+}
+
+/// OAuth and OpenID4VP authorization error codes used by Section 8.5.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorizationErrorCode {
+    InvalidRequest,
+    InvalidScope,
+    InvalidClient,
+    AccessDenied,
+    UnauthorizedClient,
+    UnsupportedResponseType,
+    ServerError,
+    TemporarilyUnavailable,
+    VpFormatsNotSupported,
+    InvalidRequestUriMethod,
+    InvalidTransactionData,
+    WalletUnavailable,
 }
 
 /// Form-encoding helper for `direct_post` authorization responses.
@@ -156,31 +268,35 @@ impl Serialize for DirectPostAuthorizationResponse<'_> {
     where
         S: Serializer,
     {
-        #[derive(Serialize)]
-        struct Form<'a> {
-            #[serde(
-                skip_serializing_if = "Option::is_none",
-                serialize_with = "serialize_optional_vp_token_as_json_string"
-            )]
-            vp_token: Option<&'a VpToken>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            id_token: Option<&'a str>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            code: Option<&'a str>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            iss: Option<&'a str>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            state: Option<&'a str>,
+        match self.response {
+            AuthorizationResponse::Success(response) => {
+                DirectPostAuthorizationSuccessResponse::new(response).serialize(serializer)
+            }
+            AuthorizationResponse::Error(response) => response.serialize(serializer),
         }
+    }
+}
 
-        Form {
-            vp_token: self.response.vp_token.as_ref(),
-            id_token: self.response.id_token.as_deref(),
-            code: self.response.code.as_deref(),
-            iss: self.response.iss.as_deref(),
-            state: self.response.state.as_deref(),
+#[skip_serializing_none]
+#[derive(Serialize)]
+struct DirectPostAuthorizationSuccessResponse<'a> {
+    #[serde(serialize_with = "serialize_optional_vp_token_as_json_string")]
+    vp_token: Option<&'a VpToken>,
+    id_token: Option<&'a str>,
+    code: Option<&'a str>,
+    iss: Option<&'a str>,
+    state: Option<&'a str>,
+}
+
+impl<'a> DirectPostAuthorizationSuccessResponse<'a> {
+    fn new(response: &'a AuthorizationSuccessResponse) -> Self {
+        Self {
+            vp_token: response.vp_token.as_ref(),
+            id_token: response.id_token.as_deref(),
+            code: response.code.as_deref(),
+            iss: response.iss.as_deref(),
+            state: response.state.as_deref(),
         }
-        .serialize(serializer)
     }
 }
 
@@ -202,11 +318,34 @@ where
     }
 }
 
+/// Form body for the `direct_post.jwt` response mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DirectPostJwtResponse {
+    response: String,
+}
+
+impl DirectPostJwtResponse {
+    /// Creates a `direct_post.jwt` response form body.
+    pub fn new(response: impl Into<String>) -> Result<Self, String> {
+        let response = response.into();
+        if response.trim().is_empty() {
+            return Err("direct_post.jwt response must not be empty".to_string());
+        }
+
+        Ok(Self { response })
+    }
+
+    /// Returns the encrypted JWT response.
+    pub fn response(&self) -> &str {
+        &self.response
+    }
+}
+
 /// Response to the verifier when the Wallet uses the `direct_post` response mode.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
 pub struct DirectPostResponse {
     /// Optional redirect URI provided by the Verifier.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub redirect_uri: Option<Url>,
 }
 
@@ -215,16 +354,22 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    fn string_presentation(value: &str) -> Presentation {
+        Presentation::String(value.to_string())
+    }
+
+    fn vp_token(entries: BTreeMap<String, Vec<Presentation>>) -> VpToken {
+        VpToken::new(entries)
+    }
+
     #[test]
     fn serializes_vp_token_with_single_entry_to_json_object() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
-            vec![serde_json::Value::String(
-                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
-            )],
+            vec![string_presentation("eyJhbGciOiJFUzI1NiJ9...")],
         );
-        let token = VpToken::new(entries);
+        let token = vp_token(entries);
 
         let json = serde_json::to_value(&token).expect("serialize");
 
@@ -237,31 +382,34 @@ mod tests {
     }
 
     #[test]
-    fn serializes_vp_token_to_json_object() {
+    fn serializes_vp_token_with_object_presentation() {
+        let mut presentation = serde_json::Map::new();
+        presentation.insert("format".to_string(), json!("ldp_vp"));
+
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
             vec![
-                serde_json::Value::String("eyJhbGciOiJFUzI1NiJ9...".to_string()),
-                json!({"format": "dc+sd-jwt"}),
+                string_presentation("eyJhbGciOiJFUzI1NiJ9..."),
+                Presentation::Object(presentation),
             ],
         );
 
-        let token = VpToken::new(entries);
+        let token = vp_token(entries);
 
         let json = serde_json::to_value(&token).expect("serialize");
 
         assert_eq!(
             json,
             json!({
-                "my_credential": ["eyJhbGciOiJFUzI1NiJ9...", {"format": "dc+sd-jwt"}]
+                "my_credential": ["eyJhbGciOiJFUzI1NiJ9...", {"format": "ldp_vp"}]
             })
         );
     }
 
     #[test]
     fn rejects_empty_vp_token_on_serialize() {
-        let token = VpToken::new(BTreeMap::new());
+        let token = vp_token(BTreeMap::new());
 
         let err = serde_json::to_string(&token).unwrap_err();
         assert!(
@@ -271,42 +419,24 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_presentation_value_on_serialize() {
+    fn rejects_invalid_dcql_query_id_on_serialize() {
         let mut entries = BTreeMap::new();
-        entries.insert("my_credential".to_string(), vec![serde_json::Value::Null]);
+        entries.insert(
+            "credential/1".to_string(),
+            vec![string_presentation("vp-token-value")],
+        );
 
-        let token = VpToken::new(entries);
-
-        let err = serde_json::to_string(&token).unwrap_err();
-        assert!(err.to_string().contains("invalid presentation value"));
+        let err = serde_json::to_string(&vp_token(entries)).unwrap_err();
+        assert!(err.to_string().contains("valid DCQL credential query id"));
     }
 
     #[test]
-    fn round_trips_vp_token_via_form_body() {
+    fn rejects_empty_presentation_list_on_serialize() {
         let mut entries = BTreeMap::new();
-        entries.insert(
-            "my_credential".to_string(),
-            vec![serde_json::Value::String("vp-token-value".to_string())],
-        );
+        entries.insert("my_credential".to_string(), Vec::new());
 
-        let response = AuthorizationResponse::new(VpToken::new(entries)).with_state("state-123");
-
-        let encoded =
-            serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");
-        let decoded: AuthorizationResponse =
-            serde_urlencoded::from_str(&encoded).expect("deserialize");
-
-        assert_eq!(decoded, response);
-
-        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
-            .into_owned()
-            .collect();
-
-        assert_eq!(
-            params.get("vp_token"),
-            Some(&r#"{"my_credential":["vp-token-value"]}"#.to_string())
-        );
-        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
+        let err = serde_json::to_string(&vp_token(entries)).unwrap_err();
+        assert!(err.to_string().contains("at least one presentation"));
     }
 
     #[test]
@@ -314,12 +444,10 @@ mod tests {
         let mut entries = BTreeMap::new();
         entries.insert(
             "my_credential".to_string(),
-            vec![serde_json::Value::String(
-                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
-            )],
+            vec![string_presentation("eyJhbGciOiJFUzI1NiJ9...")],
         );
 
-        let response = AuthorizationResponse::new(VpToken::new(entries)).with_state("state-123");
+        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
 
         let json = serde_json::to_value(&response).expect("serialize");
 
@@ -335,59 +463,110 @@ mod tests {
     }
 
     #[test]
-    fn deserializes_vp_token_from_form_json_object_string() {
-        let encoded = "vp_token=%7B%22my_credential%22%3A%5B%22eyJhbGciOiJFUzI1NiJ9...%22%5D%7D";
+    fn serializes_success_response_with_code_without_vp_token() {
+        let response = AuthorizationResponse::Success(AuthorizationSuccessResponse::code("abc"))
+            .with_state("xyz");
 
-        let parsed: AuthorizationResponse =
-            serde_urlencoded::from_str(encoded).expect("deserialize");
+        let json = serde_json::to_value(&response).expect("serialize");
 
         assert_eq!(
-            parsed
-                .vp_token
-                .as_ref()
-                .unwrap()
-                .entries()
-                .get("my_credential")
-                .unwrap()
-                .len(),
-            1
+            json,
+            json!({
+                "code": "abc",
+                "state": "xyz"
+            })
         );
     }
 
     #[test]
-    fn deserializes_code_authorization_response_without_vp_token() {
-        let response: AuthorizationResponse =
-            serde_json::from_value(json!({"code": "abc", "state": "xyz"})).expect("deserialize");
+    fn serializes_error_response() {
+        let response = AuthorizationResponse::error(AuthorizationErrorCode::WalletUnavailable)
+            .with_state("state-123");
 
-        assert_eq!(response.code.as_deref(), Some("abc"));
-        assert_eq!(response.state.as_deref(), Some("xyz"));
-        assert!(response.vp_token.is_none());
-    }
+        let json = serde_json::to_value(&response).expect("serialize");
 
-    #[test]
-    fn ignores_unknown_authorization_response_parameters() {
-        let response: AuthorizationResponse =
-            serde_json::from_value(json!({"code": "abc", "extension": "value"}))
-                .expect("deserialize");
-
-        assert_eq!(response.code.as_deref(), Some("abc"));
-    }
-
-    #[test]
-    fn rejects_invalid_vp_token_on_deserialize() {
-        let err =
-            serde_urlencoded::from_str::<AuthorizationResponse>("vp_token=%20%20").unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("vp_token must be a JSON-encoded object")
+        assert_eq!(
+            json,
+            json!({
+                "error": "wallet_unavailable",
+                "state": "state-123"
+            })
         );
     }
 
     #[test]
-    fn rejects_empty_presentation_list_on_deserialize() {
-        let encoded = "vp_token=%7B%22my_credential%22%3A%5B%5D%7D";
-        let err = serde_urlencoded::from_str::<AuthorizationResponse>(encoded).unwrap_err();
-        assert!(err.to_string().contains("at least one presentation"));
+    fn serializes_error_response_with_optional_fields() {
+        let response = AuthorizationErrorResponse::new(AuthorizationErrorCode::InvalidRequest)
+            .with_description("missing dcql_query")
+            .with_error_uri(Url::parse("https://verifier.example/errors/invalid-request").unwrap())
+            .with_state("state-123");
+
+        let json = serde_json::to_value(&response).expect("serialize");
+
+        assert_eq!(
+            json,
+            json!({
+                "error": "invalid_request",
+                "error_description": "missing dcql_query",
+                "error_uri": "https://verifier.example/errors/invalid-request",
+                "state": "state-123"
+            })
+        );
+    }
+
+    #[test]
+    fn serializes_vp_token_via_direct_post_form_body() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "my_credential".to_string(),
+            vec![string_presentation("vp-token-value")],
+        );
+
+        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
+
+        let encoded =
+            serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");
+        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
+            .into_owned()
+            .collect();
+
+        assert_eq!(
+            params.get("vp_token"),
+            Some(&r#"{"my_credential":["vp-token-value"]}"#.to_string())
+        );
+        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
+    }
+
+    #[test]
+    fn serializes_error_response_via_direct_post_form_body() {
+        let response = AuthorizationResponse::error(AuthorizationErrorCode::AccessDenied)
+            .with_state("state-123");
+
+        let encoded =
+            serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");
+        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
+            .into_owned()
+            .collect();
+
+        assert_eq!(params.get("error"), Some(&"access_denied".to_string()));
+        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
+    }
+
+    #[test]
+    fn serializes_direct_post_jwt_response() {
+        let response = DirectPostJwtResponse::new("encrypted.jwt.response").unwrap();
+
+        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+
+        assert_eq!(encoded, "response=encrypted.jwt.response");
+        assert_eq!(response.response(), "encrypted.jwt.response");
+    }
+
+    #[test]
+    fn rejects_empty_direct_post_jwt_response() {
+        let err = DirectPostJwtResponse::new("  ").unwrap_err();
+
+        assert!(err.contains("must not be empty"));
     }
 
     #[test]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -1,0 +1,285 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize, Serializer, ser::SerializeStruct};
+use url::Url;
+
+use crate::errors::{Error, ErrorKind};
+
+/// A VP token returned in an OpenID4VP authorization response.
+///
+/// The `Single` variant represents a single presentation value.
+/// The `Multiple` variant represents a JSON object keyed by `CredentialQuery.id`
+/// values, where each key maps to one or more presentation values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VpToken {
+    Single(String),
+    Multiple(BTreeMap<String, Vec<serde_json::Value>>),
+}
+
+impl VpToken {
+    /// Validates the VP token contents.
+    ///
+    /// Returns [`ErrorKind::InvalidAuthorizationResponse`] if the token is empty,
+    /// if a multiple-entry token is empty, or if it contains invalid presentation values.
+    pub fn validate(&self) -> Result<(), Error> {
+        match self {
+            Self::Single(value) => {
+                if value.trim().is_empty() {
+                    return Err(Error::message(
+                        ErrorKind::InvalidAuthorizationResponse,
+                        "vp_token must not be empty",
+                    ));
+                }
+            }
+            Self::Multiple(entries) => {
+                if entries.is_empty() {
+                    return Err(Error::message(
+                        ErrorKind::InvalidAuthorizationResponse,
+                        "vp_token must contain at least one credential query entry",
+                    ));
+                }
+
+                for (query_id, presentations) in entries {
+                    if query_id.trim().is_empty() {
+                        return Err(Error::message(
+                            ErrorKind::InvalidAuthorizationResponse,
+                            "vp_token contains an empty credential query id",
+                        ));
+                    }
+
+                    if presentations.is_empty() {
+                        return Err(Error::message(
+                            ErrorKind::InvalidAuthorizationResponse,
+                            format!(
+                                "vp_token entry '{query_id}' must contain at least one presentation"
+                            ),
+                        ));
+                    }
+
+                    for presentation in presentations {
+                        if !presentation.is_string() && !presentation.is_object() {
+                            return Err(Error::message(
+                                ErrorKind::InvalidAuthorizationResponse,
+                                format!(
+                                    "vp_token entry '{query_id}' contains an invalid presentation value"
+                                ),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn as_form_value(&self) -> Result<String, serde_json::Error> {
+        match self {
+            Self::Single(value) => Ok(value.clone()),
+            Self::Multiple(entries) => serde_json::to_string(entries),
+        }
+    }
+}
+
+impl Serialize for VpToken {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.as_form_value().map_err(serde::ser::Error::custom)?)
+    }
+}
+
+/// Authorization Response parameters for OpenID4VP.
+///
+/// This type is serialized as `application/x-www-form-urlencoded` for the
+/// `direct_post` response mode.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthorizationResponse {
+    /// The VP token returned to the Verifier.
+    pub vp_token: VpToken,
+
+    /// Optional state value echoed from the authorization request.
+    pub state: Option<String>,
+}
+
+impl AuthorizationResponse {
+    /// Creates a new authorization response.
+    pub fn new(vp_token: VpToken) -> Self {
+        Self {
+            vp_token,
+            state: None,
+        }
+    }
+
+    /// Adds a state value to the response.
+    pub fn with_state(mut self, state: impl Into<String>) -> Self {
+        self.state = Some(state.into());
+        self
+    }
+
+    /// Validates the response payload.
+    pub fn validate(&self) -> Result<(), Error> {
+        self.vp_token.validate()
+    }
+}
+
+impl Serialize for AuthorizationResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut struct_serializer = serializer.serialize_struct(
+            "AuthorizationResponse",
+            if self.state.is_some() { 2 } else { 1 },
+        )?;
+
+        struct_serializer.serialize_field("vp_token", &self.vp_token)?;
+        if let Some(state) = &self.state {
+            struct_serializer.serialize_field("state", state)?;
+        }
+        struct_serializer.end()
+    }
+}
+
+/// Response to the verifier when the Wallet uses the `direct_post` response mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DirectPostResponse {
+    /// Optional redirect URI provided by the Verifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_uri: Option<Url>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_single_vp_token() {
+        let token = VpToken::Single("eyJhbGciOiJFUzI1NiJ9...".to_string());
+
+        assert!(token.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_single_vp_token() {
+        let token = VpToken::Single("   ".to_string());
+
+        let err = token.validate().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        assert!(err.to_string().contains("vp_token must not be empty"));
+    }
+
+    #[test]
+    fn validates_multiple_vp_token() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "my_credential".to_string(),
+            vec![
+                serde_json::Value::String("eyJhbGciOiJFUzI1NiJ9...".to_string()),
+                json!({"format": "dc+sd-jwt"}),
+            ],
+        );
+
+        let token = VpToken::Multiple(entries);
+
+        assert!(token.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_multiple_vp_token() {
+        let token = VpToken::Multiple(BTreeMap::new());
+
+        let err = token.validate().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        assert!(
+            err.to_string()
+                .contains("at least one credential query entry")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_presentation_value_in_multiple_vp_token() {
+        let mut entries = BTreeMap::new();
+        entries.insert("my_credential".to_string(), vec![serde_json::Value::Null]);
+
+        let token = VpToken::Multiple(entries);
+
+        let err = token.validate().unwrap_err();
+        assert_eq!(err.kind(), ErrorKind::InvalidAuthorizationResponse);
+        assert!(err.to_string().contains("invalid presentation value"));
+    }
+
+    #[test]
+    fn serializes_single_vp_token_as_form_body() {
+        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()))
+            .with_state("state-123");
+
+        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
+            .into_owned()
+            .collect();
+
+        assert_eq!(params.get("vp_token"), Some(&"vp-token-value".to_string()));
+        assert_eq!(params.get("state"), Some(&"state-123".to_string()));
+    }
+
+    #[test]
+    fn serializes_multiple_vp_token_as_json_string_in_form_body() {
+        let mut entries = BTreeMap::new();
+        entries.insert(
+            "my_credential".to_string(),
+            vec![serde_json::Value::String(
+                "eyJhbGciOiJFUzI1NiJ9...".to_string(),
+            )],
+        );
+
+        let response = AuthorizationResponse::new(VpToken::Multiple(entries));
+
+        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        let params: BTreeMap<_, _> = url::form_urlencoded::parse(encoded.as_bytes())
+            .into_owned()
+            .collect();
+
+        assert_eq!(
+            params.get("vp_token"),
+            Some(&r#"{"my_credential":["eyJhbGciOiJFUzI1NiJ9..."]}"#.to_string())
+        );
+    }
+
+    #[test]
+    fn serializes_direct_post_response() {
+        let response = DirectPostResponse {
+            redirect_uri: Some(
+                Url::parse("https://client.example.org/cb#response_code=abc").unwrap(),
+            ),
+        };
+
+        let json = serde_json::to_value(&response).expect("serialize");
+
+        assert_eq!(
+            json,
+            json!({
+                "redirect_uri": "https://client.example.org/cb#response_code=abc"
+            })
+        );
+    }
+
+    #[test]
+    fn validates_authorization_response() {
+        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()));
+
+        assert!(response.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_blank_state_when_serialized_as_form_body_is_not_needed() {
+        let response = AuthorizationResponse::new(VpToken::Single("vp-token-value".to_string()))
+            .with_state("");
+
+        let encoded = serde_urlencoded::to_string(&response).expect("serialize");
+        assert!(encoded.contains("state="));
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -26,21 +26,19 @@ pub struct VpToken {
 
 impl VpToken {
     /// Creates a new VP token from DCQL query entries.
-    pub fn new(entries: BTreeMap<String, Vec<Presentation>>) -> Self {
-        Self { entries }
-    }
-
-    /// Returns the underlying DCQL entries.
-    pub fn entries(&self) -> &BTreeMap<String, Vec<Presentation>> {
-        &self.entries
-    }
-
-    fn validate(&self) -> Result<(), String> {
-        if self.entries.is_empty() {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The entries map is empty
+    /// - Any query ID is not a valid DCQL credential query identifier
+    /// - Any presentation array is empty
+    pub fn new(entries: BTreeMap<String, Vec<Presentation>>) -> Result<Self, String> {
+        if entries.is_empty() {
             return Err("vp_token must contain at least one credential query entry".to_string());
         }
 
-        for (query_id, presentations) in &self.entries {
+        for (query_id, presentations) in &entries {
             if !is_valid_dcql_query_id(query_id) {
                 return Err(format!(
                     "vp_token entry '{query_id}' is not a valid DCQL credential query id"
@@ -54,7 +52,12 @@ impl VpToken {
             }
         }
 
-        Ok(())
+        Ok(Self { entries })
+    }
+
+    /// Returns the underlying DCQL entries.
+    pub fn entries(&self) -> &BTreeMap<String, Vec<Presentation>> {
+        &self.entries
     }
 }
 
@@ -63,7 +66,6 @@ impl Serialize for VpToken {
     where
         S: Serializer,
     {
-        self.validate().map_err(serde::ser::Error::custom)?;
         self.entries.serialize(serializer)
     }
 }
@@ -87,8 +89,12 @@ pub enum AuthorizationResponse {
 
 impl AuthorizationResponse {
     /// Creates a new successful authorization response with a VP token.
-    pub fn new(vp_token: VpToken) -> Self {
-        Self::Success(AuthorizationSuccessResponse::new(vp_token))
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the VP token fails validation.
+    pub fn new(vp_token: VpToken) -> Result<Self, String> {
+        Ok(Self::Success(AuthorizationSuccessResponse::new(vp_token)))
     }
 
     /// Creates a new authorization error response.
@@ -193,17 +199,14 @@ impl AuthorizationSuccessResponse {
 }
 
 /// Authorization Error Response parameters for OpenID4VP.
+///
+/// Per Section 8.5 of the OpenID4VP specification, error responses follow the
+/// OAuth 2.0 error response format.
 #[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AuthorizationErrorResponse {
     /// Error code describing why the request could not be completed.
     error: AuthorizationErrorCode,
-
-    /// Optional human-readable error description.
-    error_description: Option<String>,
-
-    /// Optional URI with additional error information.
-    error_uri: Option<Url>,
 
     /// Optional state value echoed from the authorization request.
     state: Option<String>,
@@ -214,22 +217,8 @@ impl AuthorizationErrorResponse {
     pub fn new(error: AuthorizationErrorCode) -> Self {
         Self {
             error,
-            error_description: None,
-            error_uri: None,
             state: None,
         }
-    }
-
-    /// Adds a human-readable error description.
-    pub fn with_description(mut self, description: impl Into<String>) -> Self {
-        self.error_description = Some(description.into());
-        self
-    }
-
-    /// Adds a URI with additional error information.
-    pub fn with_error_uri(mut self, error_uri: Url) -> Self {
-        self.error_uri = Some(error_uri);
-        self
     }
 
     /// Adds a state value to the response.
@@ -309,7 +298,6 @@ where
 {
     match vp_token {
         Some(vp_token) => {
-            vp_token.validate().map_err(serde::ser::Error::custom)?;
             serializer.serialize_str(
                 &serde_json::to_string(vp_token.entries()).map_err(serde::ser::Error::custom)?,
             )
@@ -318,26 +306,74 @@ where
     }
 }
 
+/// A compact JWE (JSON Web Encryption) string in the form `HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG`.
+///
+/// Per RFC 7516, a JWE consists of five non-empty parts separated by dots.
+/// This type validates the structural shape at construction time.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CompactJwe(String);
+
+impl CompactJwe {
+    /// Creates a new `CompactJwe` from a string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The string is empty or contains only whitespace
+    /// - The string does not contain exactly 5 dot-separated parts
+    /// - Any part is empty
+    pub fn new(jwe: impl Into<String>) -> Result<Self, String> {
+        let jwe = jwe.into();
+        if jwe.trim().is_empty() {
+            return Err("JWE must not be empty".to_string());
+        }
+
+        let parts: Vec<&str> = jwe.split('.').collect();
+        if parts.len() != 5 {
+            return Err(format!(
+                "JWE must have 5 dot-separated parts, found {}",
+                parts.len()
+            ));
+        }
+
+        for (i, part) in parts.iter().enumerate() {
+            if part.is_empty() {
+                return Err(format!("JWE part {} is empty", i + 1));
+            }
+        }
+
+        Ok(Self(jwe))
+    }
+
+    /// Returns the underlying JWE string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 /// Form body for the `direct_post.jwt` response mode.
+///
+/// Per OpenID4VP Section 8.3, the `response` parameter contains an unsigned encrypted JWT (JWE)
+/// carrying the Authorization Response payload.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DirectPostJwtResponse {
-    response: String,
+    response: CompactJwe,
 }
 
 impl DirectPostJwtResponse {
     /// Creates a `direct_post.jwt` response form body.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the response is not a valid compact JWE.
     pub fn new(response: impl Into<String>) -> Result<Self, String> {
-        let response = response.into();
-        if response.trim().is_empty() {
-            return Err("direct_post.jwt response must not be empty".to_string());
-        }
-
-        Ok(Self { response })
+        let jwe = CompactJwe::new(response)?;
+        Ok(Self { response: jwe })
     }
 
     /// Returns the encrypted JWT response.
     pub fn response(&self) -> &str {
-        &self.response
+        self.response.as_str()
     }
 }
 
@@ -359,7 +395,7 @@ mod tests {
     }
 
     fn vp_token(entries: BTreeMap<String, Vec<Presentation>>) -> VpToken {
-        VpToken::new(entries)
+        VpToken::new(entries).expect("valid vp_token")
     }
 
     #[test]
@@ -408,10 +444,8 @@ mod tests {
     }
 
     #[test]
-    fn rejects_empty_vp_token_on_serialize() {
-        let token = vp_token(BTreeMap::new());
-
-        let err = serde_json::to_string(&token).unwrap_err();
+    fn rejects_empty_vp_token_at_construction() {
+        let err = VpToken::new(BTreeMap::new()).unwrap_err();
         assert!(
             err.to_string()
                 .contains("at least one credential query entry")
@@ -419,23 +453,23 @@ mod tests {
     }
 
     #[test]
-    fn rejects_invalid_dcql_query_id_on_serialize() {
+    fn rejects_invalid_dcql_query_id_at_construction() {
         let mut entries = BTreeMap::new();
         entries.insert(
             "credential/1".to_string(),
             vec![string_presentation("vp-token-value")],
         );
 
-        let err = serde_json::to_string(&vp_token(entries)).unwrap_err();
+        let err = VpToken::new(entries).unwrap_err();
         assert!(err.to_string().contains("valid DCQL credential query id"));
     }
 
     #[test]
-    fn rejects_empty_presentation_list_on_serialize() {
+    fn rejects_empty_presentation_list_at_construction() {
         let mut entries = BTreeMap::new();
         entries.insert("my_credential".to_string(), Vec::new());
 
-        let err = serde_json::to_string(&vp_token(entries)).unwrap_err();
+        let err = VpToken::new(entries).unwrap_err();
         assert!(err.to_string().contains("at least one presentation"));
     }
 
@@ -447,7 +481,9 @@ mod tests {
             vec![string_presentation("eyJhbGciOiJFUzI1NiJ9...")],
         );
 
-        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
+        let response = AuthorizationResponse::new(vp_token(entries))
+            .expect("valid response")
+            .with_state("state-123");
 
         let json = serde_json::to_value(&response).expect("serialize");
 
@@ -495,10 +531,8 @@ mod tests {
     }
 
     #[test]
-    fn serializes_error_response_with_optional_fields() {
+    fn serializes_error_response_with_state() {
         let response = AuthorizationErrorResponse::new(AuthorizationErrorCode::InvalidRequest)
-            .with_description("missing dcql_query")
-            .with_error_uri(Url::parse("https://verifier.example/errors/invalid-request").unwrap())
             .with_state("state-123");
 
         let json = serde_json::to_value(&response).expect("serialize");
@@ -507,8 +541,6 @@ mod tests {
             json,
             json!({
                 "error": "invalid_request",
-                "error_description": "missing dcql_query",
-                "error_uri": "https://verifier.example/errors/invalid-request",
                 "state": "state-123"
             })
         );
@@ -522,7 +554,9 @@ mod tests {
             vec![string_presentation("vp-token-value")],
         );
 
-        let response = AuthorizationResponse::new(vp_token(entries)).with_state("state-123");
+        let response = AuthorizationResponse::new(vp_token(entries))
+            .expect("valid response")
+            .with_state("state-123");
 
         let encoded =
             serde_urlencoded::to_string(response.as_direct_post_form()).expect("serialize");
@@ -554,19 +588,36 @@ mod tests {
 
     #[test]
     fn serializes_direct_post_jwt_response() {
-        let response = DirectPostJwtResponse::new("encrypted.jwt.response").unwrap();
+        // Valid JWE format: 5 dot-separated parts
+        let response =
+            DirectPostJwtResponse::new("HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG").unwrap();
 
         let encoded = serde_urlencoded::to_string(&response).expect("serialize");
 
-        assert_eq!(encoded, "response=encrypted.jwt.response");
-        assert_eq!(response.response(), "encrypted.jwt.response");
+        assert_eq!(encoded, "response=HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG");
+        assert_eq!(response.response(), "HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG");
     }
 
     #[test]
     fn rejects_empty_direct_post_jwt_response() {
         let err = DirectPostJwtResponse::new("  ").unwrap_err();
 
-        assert!(err.contains("must not be empty"));
+        assert!(err.contains("JWE must not be empty"));
+    }
+
+    #[test]
+    fn rejects_jwe_with_wrong_number_of_parts() {
+        // Only 3 parts
+        let err = DirectPostJwtResponse::new("part1.part2.part3").unwrap_err();
+        assert!(err.contains("JWE must have 5 dot-separated parts"));
+        assert!(err.contains("found 3"));
+    }
+
+    #[test]
+    fn rejects_jwe_with_empty_part() {
+        // 5 parts but one is empty
+        let err = DirectPostJwtResponse::new("part1..part3.part4.part5").unwrap_err();
+        assert!(err.contains("JWE part 2 is empty"));
     }
 
     #[test]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -54,6 +54,7 @@ impl VpToken {
         Ok(())
     }
 
+    #[allow(dead_code)]
     fn into_form_value(self) -> Result<String, serde_json::Error> {
         match self {
             Self::Single(value) => Ok(value),

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -180,21 +180,50 @@ impl AuthorizationSuccessResponse {
 /// Authorization Error Response parameters for OpenID4VP.
 ///
 /// Per Section 8.5 of the OpenID4VP specification, error responses follow the
-/// OAuth 2.0 error response format.
+/// OAuth 2.0 error response format defined in RFC 6749 Section 4.1.2.1.
 #[skip_serializing_none]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct AuthorizationErrorResponse {
     /// Error code describing why the request could not be completed.
     error: AuthorizationErrorCode,
 
+    /// Human-readable ASCII text providing additional information about the error.
+    ///
+    /// Per RFC 6749, this is optional and used to provide additional information
+    /// beyond what the error code indicates.
+    error_description: Option<String>,
+
+    /// URI identifying a human-readable web page with information about the error.
+    ///
+    /// Per RFC 6749, this is optional and provides a way to link to more detailed
+    /// error documentation.
+    error_uri: Option<String>,
+
     /// Optional state value echoed from the authorization request.
     state: Option<String>,
 }
 
 impl AuthorizationErrorResponse {
-    /// Creates an authorization error response.
+    /// Creates an authorization error response with just an error code.
     pub fn new(error: AuthorizationErrorCode) -> Self {
-        Self { error, state: None }
+        Self {
+            error,
+            error_description: None,
+            error_uri: None,
+            state: None,
+        }
+    }
+
+    /// Adds a human-readable error description to the response.
+    pub fn with_error_description(mut self, description: impl Into<String>) -> Self {
+        self.error_description = Some(description.into());
+        self
+    }
+
+    /// Adds a URI pointing to additional error information to the response.
+    pub fn with_error_uri(mut self, uri: impl Into<String>) -> Self {
+        self.error_uri = Some(uri.into());
+        self
     }
 
     /// Adds a state value to the response.
@@ -269,7 +298,13 @@ where
 
 /// A compact JWE (JSON Web Encryption) string in the form `HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG`.
 ///
-/// Per RFC 7516, a JWE consists of five non-empty parts separated by dots.
+/// Per RFC 7516 Section 3.1, a JWE consists of five parts separated by dots:
+/// - Protected header (always required, non-empty)
+/// - Encrypted key (may be empty for algorithms like ECDH-ES that don't use a separate key)
+/// - Initialization vector (may be empty for algorithms that don't use an IV)
+/// - Ciphertext (always required, non-empty)
+/// - Authentication tag (may be empty for algorithms that don't use an authentication tag)
+///
 /// This type validates the structural shape at construction time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CompactJwe(String);
@@ -282,7 +317,8 @@ impl CompactJwe {
     /// Returns an error if:
     /// - The string is empty or contains only whitespace
     /// - The string does not contain exactly 5 dot-separated parts
-    /// - Any part is empty
+    /// - The protected header (first part) is empty
+    /// - The ciphertext (fourth part) is empty
     pub fn new(jwe: impl Into<String>) -> Result<Self, String> {
         let jwe = jwe.into();
         if jwe.trim().is_empty() {
@@ -297,11 +333,22 @@ impl CompactJwe {
             ));
         }
 
-        for (i, part) in parts.iter().enumerate() {
-            if part.is_empty() {
-                return Err(format!("JWE part {} is empty", i + 1));
-            }
+        // Protected header (first part) must always be present and non-empty
+        if parts[0].is_empty() {
+            return Err("JWE protected header (part 1) must not be empty".to_string());
         }
+
+        // Encrypted key (second part) may be empty for algorithms like ECDH-ES
+        // that use key agreement and don't have a separate encrypted key
+
+        // IV (third part) may be empty for algorithms that don't use an IV
+
+        // Ciphertext (fourth part) must always be present and non-empty
+        if parts[3].is_empty() {
+            return Err("JWE ciphertext (part 4) must not be empty".to_string());
+        }
+
+        // Authentication tag (fifth part) may be empty for algorithms that don't use an auth tag
 
         Ok(Self(jwe))
     }
@@ -574,10 +621,25 @@ mod tests {
     }
 
     #[test]
-    fn rejects_jwe_with_empty_part() {
-        // 5 parts but one is empty
-        let err = DirectPostJwtResponse::new("part1..part3.part4.part5").unwrap_err();
-        assert!(err.contains("JWE part 2 is empty"));
+    fn accepts_jwe_with_empty_encrypted_key() {
+        // ECDH-ES produces JWEs with empty encrypted key (second part)
+        // Format: HEADER..IV.CIPHERTEXT.TAG
+        let response = DirectPostJwtResponse::new("HEADER..IV.CIPHERTEXT.TAG").unwrap();
+        assert_eq!(response.response(), "HEADER..IV.CIPHERTEXT.TAG");
+    }
+
+    #[test]
+    fn rejects_jwe_with_empty_header() {
+        // Header (first part) must always be present
+        let err = DirectPostJwtResponse::new(".KEY.IV.CIPHERTEXT.TAG").unwrap_err();
+        assert!(err.contains("protected header"));
+    }
+
+    #[test]
+    fn rejects_jwe_with_empty_ciphertext() {
+        // Ciphertext (fourth part) must always be present
+        let err = DirectPostJwtResponse::new("HEADER.KEY.IV..TAG").unwrap_err();
+        assert!(err.contains("ciphertext"));
     }
 
     #[test]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs
@@ -215,10 +215,7 @@ pub struct AuthorizationErrorResponse {
 impl AuthorizationErrorResponse {
     /// Creates an authorization error response.
     pub fn new(error: AuthorizationErrorCode) -> Self {
-        Self {
-            error,
-            state: None,
-        }
+        Self { error, state: None }
     }
 
     /// Adds a state value to the response.
@@ -297,11 +294,9 @@ where
     S: Serializer,
 {
     match vp_token {
-        Some(vp_token) => {
-            serializer.serialize_str(
-                &serde_json::to_string(vp_token.entries()).map_err(serde::ser::Error::custom)?,
-            )
-        }
+        Some(vp_token) => serializer.serialize_str(
+            &serde_json::to_string(vp_token.entries()).map_err(serde::ser::Error::custom)?,
+        ),
         None => serializer.serialize_none(),
     }
 }
@@ -595,7 +590,10 @@ mod tests {
         let encoded = serde_urlencoded::to_string(&response).expect("serialize");
 
         assert_eq!(encoded, "response=HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG");
-        assert_eq!(response.response(), "HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG");
+        assert_eq!(
+            response.response(),
+            "HEADER.ENCRYPTED_KEY.IV.CIPHERTEXT.TAG"
+        );
     }
 
     #[test]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -1,0 +1,1 @@
+pub mod authorization;


### PR DESCRIPTION
## What changed
- Added a new `oid4vp` module with authorization response models for OpenID4VP.
- Implemented `AuthorizationResponse`, `VpToken`, and `DirectPostResponse` in `crates/cloud-wallet-openid4vc/src/oid4vp/authorization/response.rs`.
- Wired the module into `crates/cloud-wallet-openid4vc/src/lib.rs`.

## Why
- Issue #249 requires the wallet to model OpenID4VP authorization responses and support `direct_post` serialization.
- The implementation mirrors the spec shape for single-presentation and DCQL multi-presentation `vp_token` payloads.

## Validation
- `cargo fmt --all`
- `cargo test -p cloud-wallet-openid4vc oid4vp -- --nocapture`
- `cargo test -p cloud-wallet-openid4vc`
