### PR TITLE
Feat/add mso mdoc value digest verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "serde_with",
+ "subtle",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ base64ct = "1.8"
 serde = "1"
 serde_json = "1"
 serde_with = "3"
+subtle = "2"
 
 # Logging and metrics
 tracing = "0.1"
@@ -62,8 +63,12 @@ async-stream = "0.3"
 async-trait.workspace = true
 axum = { version = "0.8", features = ["macros"] }
 base64.workspace = true
-cloud-wallet-crypto = { path = "crates/cloud-wallet-crypto", features = ["jwk"] }
-cloud-wallet-kms = { path = "crates/cloud-wallet-kms", features = ["local-kms"] }
+cloud-wallet-crypto = { path = "crates/cloud-wallet-crypto", features = [
+  "jwk",
+] }
+cloud-wallet-kms = { path = "crates/cloud-wallet-kms", features = [
+  "local-kms",
+] }
 cloud-wallet-openid4vc = { path = "crates/cloud-wallet-openid4vc" }
 color-eyre.workspace = true
 config = "0.15"
@@ -79,7 +84,12 @@ serde_qs = "1.1"
 serde_with.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting", "serde"] }
-tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
+tokio = { version = "1", features = [
+  "macros",
+  "net",
+  "rt-multi-thread",
+  "time",
+] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -92,7 +102,7 @@ features = [
   "ahash",
   "connection-manager",
   "tls-rustls-webpki-roots",
-  "tokio-rustls-comp"
+  "tokio-rustls-comp",
 ]
 
 [dependencies.sqlx]
@@ -103,7 +113,7 @@ features = [
   "postgres",
   "runtime-tokio",
   "sqlite",
-  "tls-rustls-aws-lc-rs"
+  "tls-rustls-aws-lc-rs",
 ]
 
 [dev-dependencies]
@@ -112,7 +122,7 @@ serde_json = { workspace = true }
 testcontainers-modules = { version = "0.15", features = [
   "mysql",
   "postgres",
-  "redis"
+  "redis",
 ] }
 tower = { version = "0.5", features = ["util"] }
 

--- a/crates/cloud-wallet-crypto/Cargo.toml
+++ b/crates/cloud-wallet-crypto/Cargo.toml
@@ -19,7 +19,7 @@ pkcs8 = { version = "0.10", features = ["std"] }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_with = { version = "3", optional = true }
 simple_asn1 = { version = "0.6", optional = true }
-subtle = "2.6"
+subtle.workspace = true
 thiserror.workspace = true
 url = { workspace = true, features = ["serde"], optional = true }
 zeroize.workspace = true

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_urlencoded = "0.7"
 serde_with.workspace = true
+subtle = "2"
 thiserror.workspace = true
 time = { workspace = true, features = ["std", "parsing"] }
 url = { workspace = true, features = ["serde"] }

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 serde_urlencoded = "0.7"
 serde_with.workspace = true
-subtle = "2"
+subtle.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["std", "parsing"] }
 url = { workspace = true, features = ["serde"] }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
@@ -1,13 +1,16 @@
-//! Error types for mDoc (ISO 18013-5) parsing.
+//! Error types for mDoc (ISO 18013-5) parsing and digest verification.
 
 use thiserror::Error;
 
 /// A specialised [`Result`] type for mDoc parsing operations.
 pub type Result<T> = std::result::Result<T, MdocError>;
 
-/// Errors that can occur while parsing an [`IssuerSigned`] mDoc document.
+/// Errors that can occur while parsing or verifying an mDoc document.
 ///
-/// [`IssuerSigned`]: crate::formats::mdoc::ParsedMdoc::parse
+/// Returned by [`ParsedMdoc::parse`] and [`verify_digests`].
+///
+/// [`ParsedMdoc::parse`]: crate::formats::mdoc::ParsedMdoc::parse
+/// [`verify_digests`]: crate::formats::mdoc::verifier::verify_digests
 #[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum MdocError {
@@ -84,7 +87,7 @@ pub enum MdocError {
     /// A CBOR map contains the same text key more than once.
     ///
     /// RFC 8949 §5.6 requires implementations to reject duplicate keys in
-    /// security-sensitive contexts; duplicate keys can hide a second value
+    /// security-sensitive contexts; a duplicate key could hide a second value
     /// behind a valid first one (e.g. `validUntil`, `digestID`).
     #[error("duplicate CBOR map key: '{key}'")]
     DuplicateMapKey {

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -1,4 +1,4 @@
-﻿//! mDoc (ISO 18013-5) parsing support.
+//! mDoc (ISO 18013-5) parsing support.
 //!
 //! This module provides foundational CBOR parsing for `mso_mdoc` credentials
 //! returned by OpenID4VCI issuers. The entry point is [`ParsedMdoc::parse`],
@@ -20,6 +20,8 @@ pub mod verifier;
 pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
 pub use verifier::verify_digests;
+
+use cloud_wallet_crypto::digest::HashAlg;
 
 /// The hash algorithm used in the MSO `digestAlgorithm` field.
 ///
@@ -74,5 +76,16 @@ impl DigestAlgorithm {
 impl std::fmt::Display for DigestAlgorithm {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_mso_str())
+    }
+}
+
+// Bridge to the crypto layer. Placed here so that all `DigestAlgorithm`
+impl From<DigestAlgorithm> for HashAlg {
+    fn from(alg: DigestAlgorithm) -> Self {
+        match alg {
+            DigestAlgorithm::Sha256 => HashAlg::Sha256,
+            DigestAlgorithm::Sha384 => HashAlg::Sha384,
+            DigestAlgorithm::Sha512 => HashAlg::Sha512,
+        }
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -1,4 +1,4 @@
-//! mDoc (ISO 18013-5) parsing support.
+﻿//! mDoc (ISO 18013-5) parsing support.
 //!
 //! This module provides foundational CBOR parsing for `mso_mdoc` credentials
 //! returned by OpenID4VCI issuers. The entry point is [`ParsedMdoc::parse`],
@@ -11,62 +11,6 @@
 //! - [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949) — CBOR
 //! - [RFC 9052](https://www.rfc-editor.org/rfc/rfc9052) — COSE_Sign1
 
-/// The hash algorithm used in the MSO `digestAlgorithm` field.
-///
-/// ISO 18013-5 §9.1.2.5 defines the permitted set as SHA-256, SHA-384, and SHA-512.
-/// A `DigestAlgorithm` value guarantees the algorithm has already been validated
-/// as one of the three supported variants — the parser rejects anything else.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DigestAlgorithm {
-    /// SHA-256 (32-byte output).
-    Sha256,
-    /// SHA-384 (48-byte output).
-    Sha384,
-    /// SHA-512 (64-byte output).
-    Sha512,
-}
-
-impl TryFrom<&str> for DigestAlgorithm {
-    type Error = MdocError;
-
-    fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
-        match s {
-            "SHA-256" => Ok(Self::Sha256),
-            "SHA-384" => Ok(Self::Sha384),
-            "SHA-512" => Ok(Self::Sha512),
-            other => Err(MdocError::UnsupportedDigestAlgorithm {
-                algorithm: other.to_owned(),
-            }),
-        }
-    }
-}
-
-impl DigestAlgorithm {
-    /// Expected hash output size in bytes.
-    pub fn digest_size(self) -> usize {
-        match self {
-            Self::Sha256 => 32,
-            Self::Sha384 => 48,
-            Self::Sha512 => 64,
-        }
-    }
-
-    /// The IANA/MSO string identifier (e.g. `"SHA-256"`).
-    pub fn as_mso_str(self) -> &'static str {
-        match self {
-            Self::Sha256 => "SHA-256",
-            Self::Sha384 => "SHA-384",
-            Self::Sha512 => "SHA-512",
-        }
-    }
-}
-
-impl std::fmt::Display for DigestAlgorithm {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_mso_str())
-    }
-}
-
 pub mod error;
 mod parser;
 #[cfg(test)]
@@ -77,7 +21,7 @@ pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
 pub use verifier::verify_digests;
 
-/// Hash algorithm declared in the MSO `digestAlgorithm` field.
+/// The hash algorithm used in the MSO `digestAlgorithm` field.
 ///
 /// ISO 18013-5 §9.1.2.5 defines the permitted set as SHA-256, SHA-384, and SHA-512.
 /// A `DigestAlgorithm` value guarantees the algorithm has already been validated

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -11,6 +11,62 @@
 //! - [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949) — CBOR
 //! - [RFC 9052](https://www.rfc-editor.org/rfc/rfc9052) — COSE_Sign1
 
+/// The hash algorithm used in the MSO `digestAlgorithm` field.
+///
+/// ISO 18013-5 §9.1.2.5 defines the permitted set as SHA-256, SHA-384, and SHA-512.
+/// A `DigestAlgorithm` value guarantees the algorithm has already been validated
+/// as one of the three supported variants — the parser rejects anything else.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DigestAlgorithm {
+    /// SHA-256 (32-byte output).
+    Sha256,
+    /// SHA-384 (48-byte output).
+    Sha384,
+    /// SHA-512 (64-byte output).
+    Sha512,
+}
+
+impl TryFrom<&str> for DigestAlgorithm {
+    type Error = MdocError;
+
+    fn try_from(s: &str) -> std::result::Result<Self, Self::Error> {
+        match s {
+            "SHA-256" => Ok(Self::Sha256),
+            "SHA-384" => Ok(Self::Sha384),
+            "SHA-512" => Ok(Self::Sha512),
+            other => Err(MdocError::UnsupportedDigestAlgorithm {
+                algorithm: other.to_owned(),
+            }),
+        }
+    }
+}
+
+impl DigestAlgorithm {
+    /// Expected hash output size in bytes.
+    pub fn digest_size(self) -> usize {
+        match self {
+            Self::Sha256 => 32,
+            Self::Sha384 => 48,
+            Self::Sha512 => 64,
+        }
+    }
+
+    /// The IANA/MSO string identifier (e.g. `"SHA-256"`).
+    pub fn as_mso_str(self) -> &'static str {
+        match self {
+            Self::Sha256 => "SHA-256",
+            Self::Sha384 => "SHA-384",
+            Self::Sha512 => "SHA-512",
+        }
+    }
+}
+
+impl std::fmt::Display for DigestAlgorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_mso_str())
+    }
+}
+
 pub mod error;
 mod parser;
 #[cfg(test)]

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -15,9 +15,11 @@ pub mod error;
 mod parser;
 #[cfg(test)]
 mod tests;
+pub mod verifier;
 
 pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
+pub use verifier::verify_digests;
 
 /// Hash algorithm declared in the MSO `digestAlgorithm` field.
 ///
@@ -26,10 +28,11 @@ pub use parser::{IssuerSignedItem, ParsedMdoc};
 /// as one of the three supported variants — the parser rejects anything else.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DigestAlgorithm {
+    /// SHA-256 (32-byte output).
     Sha256,
-
+    /// SHA-384 (48-byte output).
     Sha384,
-
+    /// SHA-512 (64-byte output).
     Sha512,
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
@@ -203,7 +203,6 @@ impl ParsedMdoc {
             signed_at,
             valid_from,
             valid_until,
-
             value_digests,
             device_key,
             name_spaces,

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
@@ -10,7 +10,6 @@ use time::format_description::well_known::Rfc3339;
 
 use super::DigestAlgorithm;
 use super::error::{MdocError, Result};
-use super::DigestAlgorithm;
 
 /// A parsed mDoc `IssuerSigned` structure.
 ///
@@ -287,7 +286,7 @@ fn take_entry(map: &mut Vec<(Value, Value)>, key: &'static str) -> Result<Value>
     let pos = map
         .iter()
         .position(|(k, _)| matches!(k, Value::Text(s) if s == key))
-        .ok_or(MdocError::MissingField { field: key })?;;
+        .ok_or(MdocError::MissingField { field: key })?;
     Ok(map.remove(pos).1)
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
@@ -442,10 +442,18 @@ fn parse_name_spaces(val: Value) -> Result<HashMap<String, Vec<IssuerSignedItem>
 /// Parses one `IssuerSignedItemBytes` entry (`#6.24(bstr .cbor IssuerSignedItem)`).
 fn parse_issuer_signed_item(val: Value) -> Result<IssuerSignedItem> {
     // Encode the original #6.24(bstr) before consuming val.
-    // ISO 18013-5 §9.3.1: digest_i = SHA-256(#6.24(bstr .cbor IssuerSignedItem_i)).
+    // ISO 18013-5 §9.3.1: digest_i = digest_algorithm(#6.24(bstr .cbor IssuerSignedItem_i)).
     // Encoding directly from val avoids reconstructing the tag after destructuring,
     // which would introduce a superfluous encode step. Correctness relies on
     // deterministic CBOR (RFC 8949 §4.2), which ISO 18013-5 §8.1 mandates.
+    //
+    // Limitation: `encode_value` re-serialises via ciborium, which always uses
+    // minimal CBOR framing. If an issuer emits non-minimal framing on the outer
+    // `#6.24` wrapper (e.g. a two-byte tag-24 encoding rather than the canonical
+    // `0xD8 0x18` form), the re-encoded bytes will differ from the original wire
+    // bytes, causing `verify_digests` to return `DigestMismatch` for an otherwise
+    // valid credential. Only issuers that violate the mandatory deterministic-CBOR
+    // requirement of ISO 18013-5 §8.1 are affected.
     let raw_tag24_bytes = encode_value(&val).map_err(|reason| MdocError::CborEncode { reason })?;
 
     let inner_bytes = match val {

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/parser.rs
@@ -10,6 +10,7 @@ use time::format_description::well_known::Rfc3339;
 
 use super::DigestAlgorithm;
 use super::error::{MdocError, Result};
+use super::DigestAlgorithm;
 
 /// A parsed mDoc `IssuerSigned` structure.
 ///
@@ -286,7 +287,7 @@ fn take_entry(map: &mut Vec<(Value, Value)>, key: &'static str) -> Result<Value>
     let pos = map
         .iter()
         .position(|(k, _)| matches!(k, Value::Text(s) if s == key))
-        .ok_or(MdocError::MissingField { field: key })?;
+        .ok_or(MdocError::MissingField { field: key })?;;
     Ok(map.remove(pos).1)
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -577,7 +577,10 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
                 Value::Array(vec![item_tag24_val]),
             )]),
         ),
-        (Value::Text("issuerAuth".into()), Value::Tag(18, Box::new(cose_sign1))),
+        (
+            Value::Text("issuerAuth".into()),
+            Value::Tag(18, Box::new(cose_sign1)),
+        ),
     ]);
 
     Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
@@ -590,6 +593,199 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
 /// `elementValue = "Doe"`.
 fn build_issuer_signed_with_correct_digests() -> String {
     build_issuer_signed_with_correct_digests_for(HashAlg::Sha256, "SHA-256")
+}
+
+/// Builds an `IssuerSigned` with two items in one namespace, both with correct SHA-256
+/// digests.
+///
+/// Items: `digestID = 0` → `family_name = "Doe"`, `digestID = 1` → `given_name = "John"`.
+/// Both `raw_tag24_bytes` and `valueDigests` entries are consistent so that
+/// `verify_digests` passes without tampering.
+fn build_two_item_mdoc() -> String {
+    let alg = HashAlg::Sha256;
+    let (bytes0, digest0) = item_tag24_and_digest(0, "family_name", "Doe", alg);
+    let (bytes1, digest1) = item_tag24_and_digest(1, "given_name", "John", alg);
+
+    let val0: Value =
+        ciborium::de::from_reader(bytes0.as_slice()).expect("round-trip must succeed");
+    let val1: Value =
+        ciborium::de::from_reader(bytes1.as_slice()).expect("round-trip must succeed");
+
+    let device_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![0u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![0u8; 32])),
+    ]);
+    let mso = Value::Map(vec![
+        (Value::Text("version".into()), Value::Text("1.0".into())),
+        (
+            Value::Text("digestAlgorithm".into()),
+            Value::Text("SHA-256".into()),
+        ),
+        (
+            Value::Text("valueDigests".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Map(vec![
+                    (Value::Integer(0u64.into()), Value::Bytes(digest0)),
+                    (Value::Integer(1u64.into()), Value::Bytes(digest1)),
+                ]),
+            )]),
+        ),
+        (
+            Value::Text("deviceKeyInfo".into()),
+            Value::Map(vec![(Value::Text("deviceKey".into()), device_key)]),
+        ),
+        (
+            Value::Text("docType".into()),
+            Value::Text("org.iso.18013.5.1.mDL".into()),
+        ),
+        (
+            Value::Text("validityInfo".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("signed".into()),
+                    Value::Tag(0, Box::new(Value::Text("1999-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validFrom".into()),
+                    Value::Tag(0, Box::new(Value::Text("2020-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validUntil".into()),
+                    Value::Tag(0, Box::new(Value::Text("9998-01-01T00:00:00Z".into()))),
+                ),
+            ]),
+        ),
+    ]);
+    let mso_bytes = cbor(&mso);
+    let mso_payload = cbor(&Value::Tag(24, Box::new(Value::Bytes(mso_bytes))));
+    let protected_header_bytes = vec![0xa1u8, 0x01, 0x26];
+    let cose_sign1 = Value::Array(vec![
+        Value::Bytes(protected_header_bytes),
+        Value::Map(vec![]),
+        Value::Bytes(mso_payload),
+        Value::Bytes(vec![0u8; 64]),
+    ]);
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![val0, val1]),
+            )]),
+        ),
+        (
+            Value::Text("issuerAuth".into()),
+            Value::Tag(18, Box::new(cose_sign1)),
+        ),
+    ]);
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+/// Builds an `IssuerSigned` with one item in each of two namespaces, both with correct
+/// SHA-256 digests.
+///
+/// Namespaces:
+/// - `"org.iso.18013.5.1"` → `digestID = 0`, `family_name = "Doe"`
+/// - `"org.iso.18013.5.1.US"` → `digestID = 0`, `domestic_driving_privileges = "A"`
+fn build_two_namespace_mdoc() -> String {
+    let alg = HashAlg::Sha256;
+    let (bytes_ns1, digest_ns1) = item_tag24_and_digest(0, "family_name", "Doe", alg);
+    let (bytes_ns2, digest_ns2) = item_tag24_and_digest(0, "domestic_driving_privileges", "A", alg);
+
+    let val_ns1: Value =
+        ciborium::de::from_reader(bytes_ns1.as_slice()).expect("round-trip must succeed");
+    let val_ns2: Value =
+        ciborium::de::from_reader(bytes_ns2.as_slice()).expect("round-trip must succeed");
+
+    let device_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![0u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![0u8; 32])),
+    ]);
+    let mso = Value::Map(vec![
+        (Value::Text("version".into()), Value::Text("1.0".into())),
+        (
+            Value::Text("digestAlgorithm".into()),
+            Value::Text("SHA-256".into()),
+        ),
+        (
+            Value::Text("valueDigests".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("org.iso.18013.5.1".into()),
+                    Value::Map(vec![(
+                        Value::Integer(0u64.into()),
+                        Value::Bytes(digest_ns1),
+                    )]),
+                ),
+                (
+                    Value::Text("org.iso.18013.5.1.US".into()),
+                    Value::Map(vec![(
+                        Value::Integer(0u64.into()),
+                        Value::Bytes(digest_ns2),
+                    )]),
+                ),
+            ]),
+        ),
+        (
+            Value::Text("deviceKeyInfo".into()),
+            Value::Map(vec![(Value::Text("deviceKey".into()), device_key)]),
+        ),
+        (
+            Value::Text("docType".into()),
+            Value::Text("org.iso.18013.5.1.mDL".into()),
+        ),
+        (
+            Value::Text("validityInfo".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("signed".into()),
+                    Value::Tag(0, Box::new(Value::Text("1999-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validFrom".into()),
+                    Value::Tag(0, Box::new(Value::Text("2020-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validUntil".into()),
+                    Value::Tag(0, Box::new(Value::Text("9998-01-01T00:00:00Z".into()))),
+                ),
+            ]),
+        ),
+    ]);
+    let mso_bytes = cbor(&mso);
+    let mso_payload = cbor(&Value::Tag(24, Box::new(Value::Bytes(mso_bytes))));
+    let protected_header_bytes = vec![0xa1u8, 0x01, 0x26];
+    let cose_sign1 = Value::Array(vec![
+        Value::Bytes(protected_header_bytes),
+        Value::Map(vec![]),
+        Value::Bytes(mso_payload),
+        Value::Bytes(vec![0u8; 64]),
+    ]);
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("org.iso.18013.5.1".into()),
+                    Value::Array(vec![val_ns1]),
+                ),
+                (
+                    Value::Text("org.iso.18013.5.1.US".into()),
+                    Value::Array(vec![val_ns2]),
+                ),
+            ]),
+        ),
+        (
+            Value::Text("issuerAuth".into()),
+            Value::Tag(18, Box::new(cose_sign1)),
+        ),
+    ]);
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
 }
 
 // ── verify_digests tests ──────────────────────────────────────────────────────
@@ -1054,6 +1250,92 @@ fn verify_digests_rejects_missing_digest() {
     // Assert
     assert!(
         matches!(err, MdocError::MissingDigest { ref namespace, digest_id: 0 } if namespace == "org.iso.18013.5.1"),
+        "expected MissingDigest {{ namespace: org.iso.18013.5.1, digest_id: 0 }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_digests_rejects_second_of_two_items_in_same_namespace() {
+    // Arrange: mdoc with two items in one namespace; confirm it passes clean first.
+    let raw = build_two_item_mdoc();
+    let mut mdoc = ParsedMdoc::parse(&raw).expect("two-item mdoc should parse");
+    assert!(
+        verify_digests(&mdoc).is_ok(),
+        "all digests should pass before tampering"
+    );
+
+    // Corrupt the second item (digestID 1) — exercises the inner item loop.
+    let items = mdoc
+        .name_spaces
+        .get_mut("org.iso.18013.5.1")
+        .expect("namespace must be present");
+    let item1 = items
+        .iter_mut()
+        .find(|i| i.digest_id == 1)
+        .expect("digestID 1 must be present");
+    *item1.raw_tag24_bytes.last_mut().expect("bytes non-empty") ^= 0xFF;
+
+    // Act
+    let err = verify_digests(&mdoc).expect_err("tampered second item must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DigestMismatch { ref namespace, digest_id: 1 }
+            if namespace == "org.iso.18013.5.1"),
+        "expected DigestMismatch {{ namespace: org.iso.18013.5.1, digest_id: 1 }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_digests_rejects_item_in_second_namespace() {
+    // Arrange: mdoc with items across two namespaces; confirm it passes clean first.
+    let raw = build_two_namespace_mdoc();
+    let mut mdoc = ParsedMdoc::parse(&raw).expect("two-namespace mdoc should parse");
+    assert!(
+        verify_digests(&mdoc).is_ok(),
+        "all digests should pass before tampering"
+    );
+
+    // Corrupt the item in the second namespace — confirms both namespaces are checked.
+    let items = mdoc
+        .name_spaces
+        .get_mut("org.iso.18013.5.1.US")
+        .expect("second namespace must be present");
+    *items[0]
+        .raw_tag24_bytes
+        .last_mut()
+        .expect("bytes non-empty") ^= 0xFF;
+
+    // Act
+    let err =
+        verify_digests(&mdoc).expect_err("tampered item in second namespace must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DigestMismatch { ref namespace, digest_id: 0 }
+            if namespace == "org.iso.18013.5.1.US"),
+        "expected DigestMismatch {{ namespace: org.iso.18013.5.1.US, digest_id: 0 }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_digests_rejects_namespace_absent_from_value_digests() {
+    // Arrange: valid mdoc; remove the entire namespace key from value_digests.
+    // This covers the `value_digests.get(namespace) → None` branch in verify_digests,
+    // which is distinct from removing only the digestID entry (covered by
+    // `verify_digests_rejects_missing_digest`).
+    let raw = build_issuer_signed_with_correct_digests();
+    let mut mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc should parse");
+    mdoc.value_digests.remove("org.iso.18013.5.1");
+
+    // Act
+    let err =
+        verify_digests(&mdoc).expect_err("namespace absent from value_digests must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MissingDigest { ref namespace, digest_id: 0 }
+            if namespace == "org.iso.18013.5.1"),
         "expected MissingDigest {{ namespace: org.iso.18013.5.1, digest_id: 0 }}, got: {err:?}"
     );
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -6,6 +6,7 @@ use time::format_description::well_known::Rfc3339;
 use super::DigestAlgorithm;
 use super::error::MdocError;
 use super::parser::ParsedMdoc;
+use super::verifier::verify_digests;
 
 // CBOR construction helpers
 
@@ -456,6 +457,173 @@ fn rejects_duplicate_namespace_in_value_digests() {
     );
 }
 
+// ── digest-verification helpers ──────────────────────────────────────────────
+
+/// Builds the `#6.24(bstr .cbor IssuerSignedItem)` encoding for one item
+/// and returns `(raw_tag24_bytes, real_sha256_digest)`.
+///
+/// This mirrors exactly what `parse_issuer_signed_item` stores in
+/// `IssuerSignedItem::raw_tag24_bytes` so that the digest computed here will
+/// match what `verify_digests` recomputes.
+fn item_tag24_and_digest(
+    digest_id: u64,
+    element_identifier: &str,
+    element_value: &str,
+) -> (Vec<u8>, Vec<u8>) {
+    use cloud_wallet_crypto::digest::HashAlg;
+
+    let item = Value::Map(vec![
+        (
+            Value::Text("digestID".into()),
+            Value::Integer(digest_id.into()),
+        ),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text(element_identifier.into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text(element_value.into()),
+        ),
+    ]);
+
+    let inner_bytes = cbor(&item);
+    let tag24 = Value::Tag(24, Box::new(Value::Bytes(inner_bytes)));
+    let raw_tag24_bytes = cbor(&tag24);
+
+    let digest = HashAlg::Sha256.hash(&raw_tag24_bytes);
+    (raw_tag24_bytes, digest.as_ref().to_vec())
+}
+
+/// Builds a complete `IssuerSigned` base64url string whose `valueDigests` entries
+/// are the real SHA-256 hashes of the corresponding `#6.24` item encodings.
+///
+/// The single item has `digestID = 0`, `elementIdentifier = "family_name"`,
+/// `elementValue = "Doe"`.
+fn build_issuer_signed_with_correct_digests() -> String {
+    let (item_tag24_bytes, digest_bytes) = item_tag24_and_digest(0, "family_name", "Doe");
+
+    // Reconstruct the #6.24 value for embedding in nameSpaces.
+    let item_tag24_val: Value = ciborium::de::from_reader(item_tag24_bytes.as_slice())
+        .expect("round-trip must succeed");
+
+    let device_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![0u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![0u8; 32])),
+    ]);
+
+    let mso = Value::Map(vec![
+        (Value::Text("version".into()), Value::Text("1.0".into())),
+        (
+            Value::Text("digestAlgorithm".into()),
+            Value::Text("SHA-256".into()),
+        ),
+        (
+            Value::Text("valueDigests".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Map(vec![(
+                    Value::Integer(0u64.into()),
+                    Value::Bytes(digest_bytes),
+                )]),
+            )]),
+        ),
+        (
+            Value::Text("deviceKeyInfo".into()),
+            Value::Map(vec![(Value::Text("deviceKey".into()), device_key)]),
+        ),
+        (
+            Value::Text("docType".into()),
+            Value::Text("org.iso.18013.5.1.mDL".into()),
+        ),
+        (
+            Value::Text("validityInfo".into()),
+            Value::Map(vec![
+                (
+                    Value::Text("signed".into()),
+                    Value::Tag(0, Box::new(Value::Text("1999-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validFrom".into()),
+                    Value::Tag(0, Box::new(Value::Text("2020-01-01T00:00:00Z".into()))),
+                ),
+                (
+                    Value::Text("validUntil".into()),
+                    Value::Tag(0, Box::new(Value::Text("9998-01-01T00:00:00Z".into()))),
+                ),
+            ]),
+        ),
+    ]);
+
+    let mso_bytes = cbor(&mso);
+    let protected_header_bytes = vec![0xa1u8, 0x01, 0x26];
+
+    // ISO 18013-5 §9.1.2: COSE payload must be MobileSecurityObjectBytes = #6.24(bstr .cbor MSO).
+    let mso_payload = cbor(&Value::Tag(24, Box::new(Value::Bytes(mso_bytes))));
+
+    let cose_sign1 = Value::Array(vec![
+        Value::Bytes(protected_header_bytes),
+        Value::Map(vec![]),
+        Value::Bytes(mso_payload),
+        Value::Bytes(vec![0u8; 64]),
+    ]);
+
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24_val]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+// ── verify_digests tests ──────────────────────────────────────────────────────
+
+#[test]
+fn verify_digests_passes_for_all_valid() {
+    // Arrange: mdoc whose valueDigests contain the real SHA-256 of each item
+    let raw = build_issuer_signed_with_correct_digests();
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc should parse");
+
+    // Act
+    let result = verify_digests(&mdoc);
+
+    // Assert
+    assert!(result.is_ok(), "all valid digests should pass: {result:?}");
+}
+
+#[test]
+fn verify_digests_rejects_tampered_item() {
+    // Arrange: parse a valid mdoc, then corrupt the raw bytes of the first item
+    let raw = build_issuer_signed_with_correct_digests();
+    let mut mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc should parse");
+
+    let items = mdoc
+        .name_spaces
+        .get_mut("org.iso.18013.5.1")
+        .expect("namespace must be present");
+    // Flip the last byte of raw_tag24_bytes — the digest will no longer match.
+    let last = items[0].raw_tag24_bytes.last_mut().expect("bytes non-empty");
+    *last ^= 0xFF;
+
+    // Act
+    let err = verify_digests(&mdoc).expect_err("tampered item must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DigestMismatch { .. }),
+        "expected DigestMismatch, got: {err:?}"
+    );
+}
+
 #[test]
 fn rejects_wrong_digest_length() {
     // Arrange: SHA-256 MSO but digest bytes are 64 bytes (SHA-512 size).
@@ -827,5 +995,27 @@ fn rejects_empty_namespace_item_array() {
             }
         ),
         "expected UnexpectedCborType {{ field: \"IssuerNameSpaces\" }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_digests_rejects_missing_digest() {
+    // Arrange: parse a valid mdoc, then remove the digest entry for the item
+    let raw = build_issuer_signed_with_correct_digests();
+    let mut mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc should parse");
+
+    // Remove the only entry in the namespace digest map so the lookup fails.
+    mdoc.value_digests
+        .get_mut("org.iso.18013.5.1")
+        .expect("namespace must be present")
+        .remove(&0);
+
+    // Act
+    let err = verify_digests(&mdoc).expect_err("missing digest must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MissingDigest { .. }),
+        "expected MissingDigest, got: {err:?}"
     );
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -1,5 +1,6 @@
 use base64ct::{Base64UrlUnpadded, Encoding as _};
 use ciborium::Value;
+use cloud_wallet_crypto::digest::HashAlg;
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
@@ -168,7 +169,7 @@ fn parses_valid_mdoc() {
     // Assert: top-level fields
     assert_eq!(mdoc.doc_type, "org.iso.18013.5.1.mDL");
 
-    // Assert: digest_algorithm is the validated enum variant
+    // Assert: digest_algorithm is the enum variant, not a raw string
     assert_eq!(mdoc.digest_algorithm, DigestAlgorithm::Sha256);
 
     // Assert: namespace contains the single item we inserted
@@ -469,9 +470,8 @@ fn item_tag24_and_digest(
     digest_id: u64,
     element_identifier: &str,
     element_value: &str,
+    alg: HashAlg,
 ) -> (Vec<u8>, Vec<u8>) {
-    use cloud_wallet_crypto::digest::HashAlg;
-
     let item = Value::Map(vec![
         (
             Value::Text("digestID".into()),
@@ -492,17 +492,17 @@ fn item_tag24_and_digest(
     let tag24 = Value::Tag(24, Box::new(Value::Bytes(inner_bytes)));
     let raw_tag24_bytes = cbor(&tag24);
 
-    let digest = HashAlg::Sha256.hash(&raw_tag24_bytes);
+    let digest = alg.hash(&raw_tag24_bytes);
     (raw_tag24_bytes, digest.as_ref().to_vec())
 }
 
 /// Builds a complete `IssuerSigned` base64url string whose `valueDigests` entries
-/// are the real SHA-256 hashes of the corresponding `#6.24` item encodings.
+/// are the real hashes (using `alg`) of the corresponding `#6.24` item encodings.
 ///
 /// The single item has `digestID = 0`, `elementIdentifier = "family_name"`,
 /// `elementValue = "Doe"`.
-fn build_issuer_signed_with_correct_digests() -> String {
-    let (item_tag24_bytes, digest_bytes) = item_tag24_and_digest(0, "family_name", "Doe");
+fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> String {
+    let (item_tag24_bytes, digest_bytes) = item_tag24_and_digest(0, "family_name", "Doe", alg);
 
     // Reconstruct the #6.24 value for embedding in nameSpaces.
     let item_tag24_val: Value = ciborium::de::from_reader(item_tag24_bytes.as_slice())
@@ -519,17 +519,11 @@ fn build_issuer_signed_with_correct_digests() -> String {
         (Value::Text("version".into()), Value::Text("1.0".into())),
         (
             Value::Text("digestAlgorithm".into()),
-            Value::Text("SHA-256".into()),
+            Value::Text(alg_str.into()),
         ),
         (
             Value::Text("valueDigests".into()),
-            Value::Map(vec![(
-                Value::Text("org.iso.18013.5.1".into()),
-                Value::Map(vec![(
-                    Value::Integer(0u64.into()),
-                    Value::Bytes(digest_bytes),
-                )]),
-            )]),
+            Value::Map(vec![(Value::Text("org.iso.18013.5.1".into()), Value::Map(vec![(Value::Integer(0u64.into()), Value::Bytes(digest_bytes))]))]),
         ),
         (
             Value::Text("deviceKeyInfo".into()),
@@ -560,8 +554,6 @@ fn build_issuer_signed_with_correct_digests() -> String {
 
     let mso_bytes = cbor(&mso);
     let protected_header_bytes = vec![0xa1u8, 0x01, 0x26];
-
-    // ISO 18013-5 §9.1.2: COSE payload must be MobileSecurityObjectBytes = #6.24(bstr .cbor MSO).
     let mso_payload = cbor(&Value::Tag(24, Box::new(Value::Bytes(mso_bytes))));
 
     let cose_sign1 = Value::Array(vec![
@@ -574,15 +566,21 @@ fn build_issuer_signed_with_correct_digests() -> String {
     let issuer_signed = Value::Map(vec![
         (
             Value::Text("nameSpaces".into()),
-            Value::Map(vec![(
-                Value::Text("org.iso.18013.5.1".into()),
-                Value::Array(vec![item_tag24_val]),
-            )]),
+            Value::Map(vec![(Value::Text("org.iso.18013.5.1".into()), Value::Array(vec![item_tag24_val]))]),
         ),
         (Value::Text("issuerAuth".into()), cose_sign1),
     ]);
 
     Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+/// Builds a complete `IssuerSigned` base64url string whose `valueDigests` entries
+/// are the real SHA-256 hashes of the corresponding `#6.24` item encodings.
+///
+/// The single item has `digestID = 0`, `elementIdentifier = "family_name"`,
+/// `elementValue = "Doe"`.
+fn build_issuer_signed_with_correct_digests() -> String {
+    build_issuer_signed_with_correct_digests_for(HashAlg::Sha256, "SHA-256")
 }
 
 // ── verify_digests tests ──────────────────────────────────────────────────────
@@ -598,6 +596,34 @@ fn verify_digests_passes_for_all_valid() {
 
     // Assert
     assert!(result.is_ok(), "all valid digests should pass: {result:?}");
+}
+
+#[test]
+fn verify_digests_passes_sha384() {
+    // Arrange: mdoc whose valueDigests contain the real SHA-384 of each item
+    let raw = build_issuer_signed_with_correct_digests_for(HashAlg::Sha384, "SHA-384");
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid SHA-384 mdoc should parse");
+    assert_eq!(mdoc.digest_algorithm, DigestAlgorithm::Sha384);
+
+    // Act
+    let result = verify_digests(&mdoc);
+
+    // Assert
+    assert!(result.is_ok(), "SHA-384 digests should pass: {result:?}");
+}
+
+#[test]
+fn verify_digests_passes_sha512() {
+    // Arrange: mdoc whose valueDigests contain the real SHA-512 of each item
+    let raw = build_issuer_signed_with_correct_digests_for(HashAlg::Sha512, "SHA-512");
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid SHA-512 mdoc should parse");
+    assert_eq!(mdoc.digest_algorithm, DigestAlgorithm::Sha512);
+
+    // Act
+    let result = verify_digests(&mdoc);
+
+    // Assert
+    assert!(result.is_ok(), "SHA-512 digests should pass: {result:?}");
 }
 
 #[test]
@@ -619,8 +645,8 @@ fn verify_digests_rejects_tampered_item() {
 
     // Assert
     assert!(
-        matches!(err, MdocError::DigestMismatch { .. }),
-        "expected DigestMismatch, got: {err:?}"
+        matches!(err, MdocError::DigestMismatch { ref namespace, digest_id: 0 } if namespace == "org.iso.18013.5.1"),
+        "expected DigestMismatch {{ namespace: org.iso.18013.5.1, digest_id: 0 }}, got: {err:?}"
     );
 }
 
@@ -1015,7 +1041,7 @@ fn verify_digests_rejects_missing_digest() {
 
     // Assert
     assert!(
-        matches!(err, MdocError::MissingDigest { .. }),
-        "expected MissingDigest, got: {err:?}"
+        matches!(err, MdocError::MissingDigest { ref namespace, digest_id: 0 } if namespace == "org.iso.18013.5.1"),
+        "expected MissingDigest {{ namespace: org.iso.18013.5.1, digest_id: 0 }}, got: {err:?}"
     );
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -505,8 +505,8 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
     let (item_tag24_bytes, digest_bytes) = item_tag24_and_digest(0, "family_name", "Doe", alg);
 
     // Reconstruct the #6.24 value for embedding in nameSpaces.
-    let item_tag24_val: Value = ciborium::de::from_reader(item_tag24_bytes.as_slice())
-        .expect("round-trip must succeed");
+    let item_tag24_val: Value =
+        ciborium::de::from_reader(item_tag24_bytes.as_slice()).expect("round-trip must succeed");
 
     let device_key = Value::Map(vec![
         (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
@@ -523,7 +523,13 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
         ),
         (
             Value::Text("valueDigests".into()),
-            Value::Map(vec![(Value::Text("org.iso.18013.5.1".into()), Value::Map(vec![(Value::Integer(0u64.into()), Value::Bytes(digest_bytes))]))]),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Map(vec![(
+                    Value::Integer(0u64.into()),
+                    Value::Bytes(digest_bytes),
+                )]),
+            )]),
         ),
         (
             Value::Text("deviceKeyInfo".into()),
@@ -566,7 +572,10 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
     let issuer_signed = Value::Map(vec![
         (
             Value::Text("nameSpaces".into()),
-            Value::Map(vec![(Value::Text("org.iso.18013.5.1".into()), Value::Array(vec![item_tag24_val]))]),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24_val]),
+            )]),
         ),
         (Value::Text("issuerAuth".into()), cose_sign1),
     ]);
@@ -637,7 +646,10 @@ fn verify_digests_rejects_tampered_item() {
         .get_mut("org.iso.18013.5.1")
         .expect("namespace must be present");
     // Flip the last byte of raw_tag24_bytes — the digest will no longer match.
-    let last = items[0].raw_tag24_bytes.last_mut().expect("bytes non-empty");
+    let last = items[0]
+        .raw_tag24_bytes
+        .last_mut()
+        .expect("bytes non-empty");
     *last ^= 0xFF;
 
     // Act

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -577,7 +577,7 @@ fn build_issuer_signed_with_correct_digests_for(alg: HashAlg, alg_str: &str) -> 
                 Value::Array(vec![item_tag24_val]),
             )]),
         ),
-        (Value::Text("issuerAuth".into()), cose_sign1),
+        (Value::Text("issuerAuth".into()), Value::Tag(18, Box::new(cose_sign1))),
     ]);
 
     Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -19,32 +19,41 @@ use subtle::ConstantTimeEq as _;
 use cloud_wallet_crypto::digest::HashAlg;
 
 use super::error::{MdocError, Result};
+use super::DigestAlgorithm;
 use super::parser::ParsedMdoc;
+
+impl From<DigestAlgorithm> for HashAlg {
+    fn from(alg: DigestAlgorithm) -> Self {
+        match alg {
+            DigestAlgorithm::Sha256 => HashAlg::Sha256,
+            DigestAlgorithm::Sha384 => HashAlg::Sha384,
+            DigestAlgorithm::Sha512 => HashAlg::Sha512,
+        }
+    }
+}
 
 /// Verifies that every `IssuerSignedItem` in `parsed` hashes to its corresponding
 /// entry in the MSO `valueDigests` map (ISO/IEC 18013-5 §9.1.2).
 ///
 /// # Algorithm selection
 ///
-/// The algorithm is determined by the MSO `digestAlgorithm` field stored in
-/// [`ParsedMdoc::digest_algorithm`]. Supported values:
+/// The algorithm is determined by [`ParsedMdoc::digest_algorithm`], which the parser
+/// has already validated. The conversion to [`HashAlg`] is infallible.
 ///
-/// | MSO string  | Algorithm         |
-/// |-------------|-------------------|
-/// | `"SHA-256"` | SHA-256 (32 bytes) |
-/// | `"SHA-384"` | SHA-384 (48 bytes) |
-/// | `"SHA-512"` | SHA-512 (64 bytes) |
+/// # Selective disclosure
 ///
-/// Any other string returns [`MdocError::UnsupportedDigestAlgorithm`].
+/// Only items present in `name_spaces` (the disclosed set) are checked.
+/// Entries in `value_digests` with no corresponding disclosed item are intentionally
+/// skipped — selective disclosure is explicitly permitted by ISO/IEC 18013-5 §9.1.2.
 ///
 /// # Errors
 ///
-/// - [`MdocError::UnsupportedDigestAlgorithm`] — unrecognised `digestAlgorithm` string.
 /// - [`MdocError::MissingDigest`] — no `valueDigests` entry for a presented item's
 ///   namespace + `digestID`.
 /// - [`MdocError::DigestMismatch`] — the computed hash does not match the stored digest.
+#[must_use = "digest verification failure must be handled"]
 pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
-    let alg = parse_digest_algorithm(&parsed.digest_algorithm)?;
+    let alg = HashAlg::from(parsed.digest_algorithm);
 
     for (namespace, items) in &parsed.name_spaces {
         for item in items {
@@ -59,9 +68,12 @@ pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
                     digest_id: item.digest_id,
                 })?;
 
-            // Constant-time comparison — prevents timing-oracle attacks on digest values.
-            let matches: bool = computed.as_ref().ct_eq(stored.as_slice()).into();
-            if !matches {
+            // `parse_value_digests` enforces that every stored digest has exactly
+            // `digest_algorithm.digest_size()` bytes, matching `computed.as_ref()`.
+            // Both slices are therefore guaranteed equal-length — `ct_eq` is fully
+            // constant-time (not just constant-time-on-equal-length inputs).
+            let digest_ok: bool = computed.as_ref().ct_eq(stored.as_slice()).into();
+            if !digest_ok {
                 return Err(MdocError::DigestMismatch {
                     namespace: namespace.clone(),
                     digest_id: item.digest_id,
@@ -71,19 +83,4 @@ pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Maps the MSO `digestAlgorithm` string to a [`HashAlg`] variant.
-///
-/// Only SHA-256, SHA-384, and SHA-512 are permitted by IANA COSE Algorithms for
-/// use in mDoc (ISO/IEC 18013-5 §9.1.2 Table 1).
-fn parse_digest_algorithm(algorithm: &str) -> Result<HashAlg> {
-    match algorithm {
-        "SHA-256" => Ok(HashAlg::Sha256),
-        "SHA-384" => Ok(HashAlg::Sha384),
-        "SHA-512" => Ok(HashAlg::Sha512),
-        other => Err(MdocError::UnsupportedDigestAlgorithm {
-            algorithm: other.to_owned(),
-        }),
-    }
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -1,0 +1,89 @@
+//! Digest integrity verification for ISO 18013-5 mDoc credentials.
+//!
+//! This module implements the `valueDigests` check described in ISO/IEC 18013-5 §9.1.2:
+//! every `IssuerSignedItem` must hash (under the algorithm named in the MSO
+//! `digestAlgorithm` field) to the corresponding entry in `valueDigests`.
+//!
+//! # Crypto backend
+//!
+//! Hashing is performed via [`cloud_wallet_crypto::digest::HashAlg`], which delegates to
+//! `aws_lc_rs::digest`. No separate `sha2` crate is used.
+//!
+//! # Constant-time comparison
+//!
+//! The computed digest is compared against the stored value with
+//! [`subtle::ConstantTimeEq`] to prevent timing-oracle attacks (OWASP A02).
+
+use subtle::ConstantTimeEq as _;
+
+use cloud_wallet_crypto::digest::HashAlg;
+
+use super::error::{MdocError, Result};
+use super::parser::ParsedMdoc;
+
+/// Verifies that every `IssuerSignedItem` in `parsed` hashes to its corresponding
+/// entry in the MSO `valueDigests` map (ISO/IEC 18013-5 §9.1.2).
+///
+/// # Algorithm selection
+///
+/// The algorithm is determined by the MSO `digestAlgorithm` field stored in
+/// [`ParsedMdoc::digest_algorithm`]. Supported values:
+///
+/// | MSO string  | Algorithm         |
+/// |-------------|-------------------|
+/// | `"SHA-256"` | SHA-256 (32 bytes) |
+/// | `"SHA-384"` | SHA-384 (48 bytes) |
+/// | `"SHA-512"` | SHA-512 (64 bytes) |
+///
+/// Any other string returns [`MdocError::UnsupportedDigestAlgorithm`].
+///
+/// # Errors
+///
+/// - [`MdocError::UnsupportedDigestAlgorithm`] — unrecognised `digestAlgorithm` string.
+/// - [`MdocError::MissingDigest`] — no `valueDigests` entry for a presented item's
+///   namespace + `digestID`.
+/// - [`MdocError::DigestMismatch`] — the computed hash does not match the stored digest.
+pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
+    let alg = parse_digest_algorithm(&parsed.digest_algorithm)?;
+
+    for (namespace, items) in &parsed.name_spaces {
+        for item in items {
+            let computed = alg.hash(&item.raw_tag24_bytes);
+
+            let stored = parsed
+                .value_digests
+                .get(namespace)
+                .and_then(|ns_map| ns_map.get(&item.digest_id))
+                .ok_or_else(|| MdocError::MissingDigest {
+                    namespace: namespace.clone(),
+                    digest_id: item.digest_id,
+                })?;
+
+            // Constant-time comparison — prevents timing-oracle attacks on digest values.
+            let matches: bool = computed.as_ref().ct_eq(stored.as_slice()).into();
+            if !matches {
+                return Err(MdocError::DigestMismatch {
+                    namespace: namespace.clone(),
+                    digest_id: item.digest_id,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Maps the MSO `digestAlgorithm` string to a [`HashAlg`] variant.
+///
+/// Only SHA-256, SHA-384, and SHA-512 are permitted by IANA COSE Algorithms for
+/// use in mDoc (ISO/IEC 18013-5 §9.1.2 Table 1).
+fn parse_digest_algorithm(algorithm: &str) -> Result<HashAlg> {
+    match algorithm {
+        "SHA-256" => Ok(HashAlg::Sha256),
+        "SHA-384" => Ok(HashAlg::Sha384),
+        "SHA-512" => Ok(HashAlg::Sha512),
+        other => Err(MdocError::UnsupportedDigestAlgorithm {
+            algorithm: other.to_owned(),
+        }),
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -18,19 +18,8 @@ use subtle::ConstantTimeEq as _;
 
 use cloud_wallet_crypto::digest::HashAlg;
 
-use super::DigestAlgorithm;
 use super::error::{MdocError, Result};
 use super::parser::ParsedMdoc;
-
-impl From<DigestAlgorithm> for HashAlg {
-    fn from(alg: DigestAlgorithm) -> Self {
-        match alg {
-            DigestAlgorithm::Sha256 => HashAlg::Sha256,
-            DigestAlgorithm::Sha384 => HashAlg::Sha384,
-            DigestAlgorithm::Sha512 => HashAlg::Sha512,
-        }
-    }
-}
 
 /// Verifies that every `IssuerSignedItem` in `parsed` hashes to its corresponding
 /// entry in the MSO `valueDigests` map (ISO/IEC 18013-5 §9.1.2).
@@ -69,9 +58,11 @@ pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
                 })?;
 
             // `parse_value_digests` enforces that every stored digest has exactly
-            // `digest_algorithm.digest_size()` bytes, matching `computed.as_ref()`.
-            // Both slices are therefore guaranteed equal-length — `ct_eq` is fully
-            // constant-time (not just constant-time-on-equal-length inputs).
+            // `digest_algorithm.digest_size()` bytes; `aws_lc_rs::digest` always
+            // produces the same fixed output length. Both slices are therefore
+            // guaranteed equal-length, so `ct_eq` runs in unconditional constant
+            // time over all N content bytes — `subtle` only provides constant-time
+            // behaviour when both slices have the same length.
             let digest_ok: bool = computed.as_ref().ct_eq(stored.as_slice()).into();
             if !digest_ok {
                 return Err(MdocError::DigestMismatch {

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -18,8 +18,8 @@ use subtle::ConstantTimeEq as _;
 
 use cloud_wallet_crypto::digest::HashAlg;
 
-use super::error::{MdocError, Result};
 use super::DigestAlgorithm;
+use super::error::{MdocError, Result};
 use super::parser::ParsedMdoc;
 
 impl From<DigestAlgorithm> for HashAlg {


### PR DESCRIPTION
Without digest verification, a credential where a data element's value has been modified after signing would be stored silently. The MSO contains a `valueDigests` map every `IssuerSignedItem` must hash to its corresponding entry. This issue implements that check using the project's existing `aws-lc-rs` crypto backend. A separate `sha2` crate must not be added.


**Acceptance Criteria**

- [ ] `subtle = "2"` added for constant-time comparison
- [ ] `pub fn verify_digests(parsed: &ParsedMdoc) -> Result<(), MdocError>` in `mdoc/verifier.rs`
- [ ] Each `IssuerSignedItem.raw_tag24_bytes` hashed using `aws_lc_rs::digest` — supports SHA-256, SHA-384, SHA-512
- [ ] Hash compared against `value_digests[namespace][digest_id]` using `subtle::ConstantTimeEq`  not `==`
- [ ] Any single mismatch or missing digest rejects the entire credential
- [ ] Tests cover: all digests valid, one tampered item, missing digest entry

**References**
- [ISO/IEC 18013-5 §9.1.2](https://www.iso.org/standard/69084.html)  `valueDigests` and hashing requirement
- [IANA COSE Algorithms](https://www.iana.org/assignments/cose/cose.xhtml#algorithms)

