### PR TITLE
Refactor/add credential detail retrieval with parsed claims

### DIFF
--- a/.github/workflows/cargo_deny.yml
+++ b/.github/workflows/cargo_deny.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Cargo deny
         uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          rust-version: "stable"
 
   cargo-audit:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,22 +43,22 @@ tracing = "0.1"
 base64 = "0.22"
 dashmap = "6"
 rand = "0.10"
-rcgen = {
-  version = "0.14",
-  default-features = false,
-  features = ["aws_lc_rs", "x509-parser"]
-}
 rustls-pki-types = "1.14"
 sqlx = "0.8"
 time = "0.3"
 url = "2.5"
 uuid = "1"
-webpki = {
-  package = "rustls-webpki",
-  version = "0.103",
-  features = ["aws-lc-rs"]
-}
 zeroize = "1.8"
+
+[workspace.dependencies.rcgen]
+version = "0.14"
+default-features = false
+features = ["aws_lc_rs", "x509-parser"]
+
+[workspace.dependencies.webpki]
+package = "rustls-webpki"
+version = "0.103"
+features = ["aws-lc-rs"]
 
 [workspace.lints.clippy]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,15 +76,11 @@ axum = { version = "0.8", features = ["macros"] }
 base64.workspace = true
 cloud-wallet-crypto = {
   path = "crates/cloud-wallet-crypto",
-  features = [
-    "jwk",
-  ]
+  features = ["jwk"]
 }
 cloud-wallet-kms = {
   path = "crates/cloud-wallet-kms",
-  features = [
-    "local-kms",
-  ]
+  features = ["local-kms"]
 }
 cloud-wallet-openid4vc = { path = "crates/cloud-wallet-openid4vc" }
 color-eyre.workspace = true
@@ -104,12 +100,7 @@ thiserror.workspace = true
 time = { workspace = true, features = ["formatting", "serde"] }
 tokio = {
   version = "1",
-  features = [
-    "macros",
-    "net",
-    "rt-multi-thread",
-    "time",
-  ]
+  features = ["macros", "net", "rt-multi-thread", "time"]
 }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true
@@ -123,7 +114,7 @@ features = [
   "ahash",
   "connection-manager",
   "tls-rustls-webpki-roots",
-  "tokio-rustls-comp",
+  "tokio-rustls-comp"
 ]
 
 [dependencies.sqlx]
@@ -143,11 +134,7 @@ reqwest = { version = "0.13", features = ["json"] }
 serde_json = { workspace = true }
 testcontainers-modules = {
   version = "0.15",
-  features = [
-    "mysql",
-    "postgres",
-    "redis",
-  ]
+  features = ["mysql", "postgres", "redis"]
 }
 tower = { version = "0.5", features = ["util"] }
 webpki.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,21 @@ tracing = "0.1"
 base64 = "0.22"
 dashmap = "6"
 rand = "0.10"
-rcgen = { version = "0.14", default-features = false, features = ["x509-parser","aws_lc_rs"] }
+rcgen = {
+  version = "0.14",
+  default-features = false,
+  features = ["aws_lc_rs", "x509-parser"]
+}
 rustls-pki-types = "1.14"
 sqlx = "0.8"
 time = "0.3"
 url = "2.5"
 uuid = "1"
-webpki = { package = "rustls-webpki", version = "0.103", features = ["aws-lc-rs"] }
+webpki = {
+  package = "rustls-webpki",
+  version = "0.103",
+  features = ["aws-lc-rs"]
+}
 zeroize = "1.8"
 
 [workspace.lints.clippy]
@@ -66,12 +74,18 @@ async-stream = "0.3"
 async-trait.workspace = true
 axum = { version = "0.8", features = ["macros"] }
 base64.workspace = true
-cloud-wallet-crypto = { path = "crates/cloud-wallet-crypto", features = [
-  "jwk",
-] }
-cloud-wallet-kms = { path = "crates/cloud-wallet-kms", features = [
-  "local-kms",
-] }
+cloud-wallet-crypto = {
+  path = "crates/cloud-wallet-crypto",
+  features = [
+    "jwk",
+  ]
+}
+cloud-wallet-kms = {
+  path = "crates/cloud-wallet-kms",
+  features = [
+    "local-kms",
+  ]
+}
 cloud-wallet-openid4vc = { path = "crates/cloud-wallet-openid4vc" }
 color-eyre.workspace = true
 config = "0.15"
@@ -88,12 +102,15 @@ serde_qs = "1.1"
 serde_with.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting", "serde"] }
-tokio = { version = "1", features = [
-  "macros",
-  "net",
-  "rt-multi-thread",
-  "time",
-] }
+tokio = {
+  version = "1",
+  features = [
+    "macros",
+    "net",
+    "rt-multi-thread",
+    "time",
+  ]
+}
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -124,11 +141,14 @@ features = [
 rcgen.workspace = true
 reqwest = { version = "0.13", features = ["json"] }
 serde_json = { workspace = true }
-testcontainers-modules = { version = "0.15", features = [
-  "mysql",
-  "postgres",
-  "redis",
-] }
+testcontainers-modules = {
+  version = "0.15",
+  features = [
+    "mysql",
+    "postgres",
+    "redis",
+  ]
+}
 tower = { version = "0.5", features = ["util"] }
 webpki.workspace = true
 

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -10,8 +10,8 @@ cloud-wallet-crypto = { path = "../cloud-wallet-crypto", features = ["jwk"] }
 base64.workspace = true
 base64ct = { workspace = true, features = ["alloc"] }
 ciborium = "0.2"
-coset = "0.4"
 color-eyre.workspace = true
+coset = "0.4"
 csscolorparser = { version = "0.8", features = ["serde"] }
 futures = "0.3"
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
@@ -26,13 +26,12 @@ serde_urlencoded = "0.7"
 serde_with.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
-x509-parser = { version = "0.18", features = ["verify"] }
-time = { workspace = true, features = ["std", "parsing"] }
+time = { workspace = true, features = ["parsing", "std"] }
 url = { workspace = true, features = ["serde"] }
 validator = { version = "0.20", features = ["derive"] }
-webpki-roots = "1"
 webpki.workspace = true
-
+webpki-roots = "1"
+x509-parser = { version = "0.18", features = ["verify"] }
 
 [dev-dependencies]
 rcgen.workspace = true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -675,31 +675,30 @@ paths:
       operationId: getCredential
       summary: Retrieve a single credential by its internal wallet ID
       description: |
-        Returns the decoded payload of a single credential identified by its
-        internal wallet UUID. The `id` is the value returned in the
+        Returns renderable credential claims for a single credential identified
+        by its internal wallet UUID. The `id` is the value returned in the
         `credential_ids` array of the issuance `completed` SSE event.
+
+        Metadata such as issuer, format, status, issue time, expiry, and display
+        information is returned by the credential list and issuance endpoints.
+        This detail endpoint intentionally returns only the disclosed claims
+        object needed by the frontend rendering view.
       tags:
         - Credentials
       parameters:
         - $ref: '#/components/parameters/CredentialId'
       responses:
         '200':
-          description: Decoded credential payload.
+          description: Renderable credential claims.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CredentialRecord'
+                $ref: '#/components/schemas/RenderedCredentialClaims'
               example:
-                id: c3d4e5f6-7890-abcd-ef12-3456789abcde
-                credential_configuration_id: eu.europa.ec.eudi.pid.1
-                format: dc+sd-jwt
-                issuer: https://issuer.example.eu
-                status: active
-                issued_at: "2026-04-08T14:35:00Z"
-                expires_at: "2027-04-08T14:35:00Z"
-                claims:
-                  given_name: Jane
-                  family_name: Doe
+                given_name: Jane
+                family_name: Doe
+                address:
+                  locality: Brussels
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':
@@ -711,6 +710,15 @@ paths:
               example:
                 error: credential_not_found
                 error_description: No credential with that ID exists for the authenticated tenant.
+        '501':
+          description: Stored credential format cannot be rendered as claims yet.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: unsupported_credential_format
+                error_description: Rendering claims for credential format 'mso_mdoc' is not supported yet.
         '500':
           $ref: '#/components/responses/InternalServerError'
 
@@ -1444,77 +1452,20 @@ components:
             - `internal` — unexpected wallet backend error.
           example: authorization
 
-    CredentialRecord:
+    RenderedCredentialClaims:
       type: object
       description: |
-        Decoded payload of a single verifiable credential stored in the wallet.
-        The `claims` object contains the credential-specific attributes whose
-        structure depends on the credential type and format.
-      required:
-        - id
-        - credential_configuration_id
-        - format
-        - issuer
-        - status
-        - issued_at
-        - claims
-      properties:
-        id:
-          type: string
-          format: uuid
-          description: Internal wallet credential ID (UUID v4).
-          example: c3d4e5f6-7890-abcd-ef12-3456789abcde
-        credential_configuration_id:
-          type: string
-          description: Credential configuration identifier from the issuer's metadata.
-          example: eu.europa.ec.eudi.pid.1
-        format:
-          type: string
-          description: Credential format.
-          enum:
-            - dc+sd-jwt
-            - mso_mdoc
-            - jwt_vc_json
-            - jwt_vc_json-ld
-            - ldp_vc
-          example: dc+sd-jwt
-        issuer:
-          type: string
-          format: uri
-          description: Issuer identifier URI.
-          example: https://issuer.example.eu
-        status:
-          type: string
-          description: Current validity status of the credential.
-          enum:
-            - active
-            - expired
-            - revoked
-            - suspended
-          example: active
-        issued_at:
-          type: string
-          format: date-time
-          description: ISO 8601 timestamp when the credential was issued.
-          example: "2026-04-08T14:35:00Z"
-        expires_at:
-          description: |
-            ISO 8601 timestamp when the credential expires. `null` if the
-            credential has no expiry.
-          oneOf:
-            - type: string
-              format: date-time
-            - type: 'null'
-          example: "2027-04-08T14:35:00Z"
-        claims:
-          type: object
-          description: |
-            Decoded credential claims. The structure is credential-type
-            specific. Additional properties are permitted.
-          additionalProperties: true
-          example:
-            given_name: Jane
-            family_name: Doe
+        Credential-specific claims disclosed from the stored raw credential and
+        prepared for UI rendering. This object intentionally does not include
+        wallet metadata such as id, issuer, status, format, issue time, expiry,
+        or display metadata; those values are already provided by the list and
+        issuance endpoints.
+      additionalProperties: true
+      example:
+        given_name: Jane
+        family_name: Doe
+        address:
+          locality: Brussels
 
     CredentialSummary:
       type: object

--- a/src/domain/models/credential.rs
+++ b/src/domain/models/credential.rs
@@ -1,7 +1,7 @@
 use core::str::FromStr;
 
 pub use cloud_wallet_openid4vc::oid4vci::metadata::CredentialDisplay;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use time::UtcDateTime;
 use url::Url;
 use uuid::Uuid;
@@ -216,60 +216,17 @@ pub struct CredentialListResponse {
     pub credentials: Vec<CredentialSummary>,
 }
 
-/// Response body for a single verifiable credential stored in the wallet.
-///
-/// `claims` is always `null` in the current implementation; format-specific
-/// claim decoding will be added in a future iteration.
-#[derive(Debug, Serialize)]
-pub struct CredentialRecord {
-    pub id: Uuid,
-    pub credential_configuration_id: String,
-    pub format: String,
-    pub issuer: String,
-    pub status: String,
-    pub issued_at: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub expires_at: Option<String>,
-    /// Decoded credential claims. Format-specific parsing is out of scope for
-    /// this implementation; field is always `null`.
-    pub claims: serde_json::Value,
-}
-
 /// Filter criteria for listing credentials.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct CredentialFilter {
     pub tenant_id: Option<Uuid>,
-    #[serde(deserialize_with = "deserialize_credential_types")]
     pub credential_types: Option<Vec<String>>,
     pub status: Option<CredentialStatus>,
     pub format: Option<CredentialFormat>,
     pub issuer: Option<String>,
     pub subject: Option<String>,
     pub exclude_expired: bool,
-}
-
-fn deserialize_credential_types<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let Some(values) = Option::<Vec<String>>::deserialize(deserializer)? else {
-        return Ok(None);
-    };
-
-    let credential_types = values
-        .into_iter()
-        .flat_map(|value| {
-            value
-                .split(',')
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .map(ToOwned::to_owned)
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-
-    Ok((!credential_types.is_empty()).then_some(credential_types))
 }
 
 impl CredentialFilter {

--- a/src/domain/models/credential.rs
+++ b/src/domain/models/credential.rs
@@ -197,6 +197,12 @@ pub struct CredentialSummary {
     /// The date and time when the credential was issued.
     #[serde(serialize_with = "serialize_utc_datetime_rfc3339")]
     pub issued_at: UtcDateTime,
+    /// The date and time when the credential expires, if known.
+    #[serde(
+        rename = "expires_at",
+        serialize_with = "serialize_optional_utc_datetime_rfc3339"
+    )]
+    pub valid_until: Option<UtcDateTime>,
 }
 
 fn serialize_utc_datetime_rfc3339<S>(value: &UtcDateTime, serializer: S) -> Result<S::Ok, S::Error>
@@ -208,6 +214,19 @@ where
 
     let value = value.format(&Rfc3339).map_err(S::Error::custom)?;
     serializer.serialize_str(&value)
+}
+
+fn serialize_optional_utc_datetime_rfc3339<S>(
+    value: &Option<UtcDateTime>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match value {
+        Some(value) => serialize_utc_datetime_rfc3339(value, serializer),
+        None => serializer.serialize_none(),
+    }
 }
 
 /// Response body for `GET /api/v1/credentials`.

--- a/src/outbound/credential.rs
+++ b/src/outbound/credential.rs
@@ -368,7 +368,7 @@ struct FilterBuilder<'d> {
 impl<'d> FilterBuilder<'d> {
     fn for_summaries(driver: &'d Driver) -> Self {
         let sql = String::from(
-            "SELECT c.id AS credential_id, c.issued_at, \
+            "SELECT c.id AS credential_id, c.issued_at, c.valid_until, \
              d.display, d.issuer_name, d.credential_type \
              FROM credentials c \
              INNER JOIN credential_display_metadata d \
@@ -607,6 +607,7 @@ static UPSERT_DISPLAY_METADATA_MYSQL: Query = Query::new(
 struct DisplayMetadataRecord {
     credential_id: String,
     issued_at: i64,
+    valid_until: Option<i64>,
     display: Vec<u8>,
     issuer_name: String,
     credential_type: String,
@@ -618,6 +619,10 @@ impl TryFrom<DisplayMetadataRecord> for CredentialSummary {
     fn try_from(row: DisplayMetadataRecord) -> Result<Self> {
         let id = Uuid::from_str(&row.credential_id)?;
         let issued_at = UtcDateTime::from_unix_timestamp(row.issued_at)?;
+        let valid_until = row
+            .valid_until
+            .map(UtcDateTime::from_unix_timestamp)
+            .transpose()?;
         let display = serde_json::from_slice(&row.display)?;
 
         Ok(Self {
@@ -628,6 +633,7 @@ impl TryFrom<DisplayMetadataRecord> for CredentialSummary {
                 credential_type: row.credential_type,
             },
             issued_at,
+            valid_until,
         })
     }
 }
@@ -817,6 +823,7 @@ impl CredentialRepo for MemoryCredentialRepo {
                         id: cred.id,
                         display: display_ref.value().clone(),
                         issued_at: cred.issued_at,
+                        valid_until: cred.valid_until,
                     });
                 }
             }

--- a/src/server/handlers/credentials.rs
+++ b/src/server/handlers/credentials.rs
@@ -232,7 +232,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_sd_jwt_claims_without_reverification() {
+    fn renders_sd_jwt_claims() {
         let claims = render_claims(&credential(raw_sd_jwt())).expect("claims should render");
 
         assert_eq!(claims["given_name"], "Ada");

--- a/src/server/handlers/credentials.rs
+++ b/src/server/handlers/credentials.rs
@@ -3,14 +3,14 @@ use axum::{
     http::StatusCode,
     response::IntoResponse,
 };
+use cloud_wallet_openid4vc::formats::sd_jwt::SdJwt;
 use serde_qs::{Config, DuplicateKeyBehavior};
 use std::{borrow::Cow, sync::OnceLock};
-use time::format_description::well_known::Rfc3339;
 use url::Url;
 use uuid::Uuid;
 
 use crate::domain::models::credential::{
-    Credential, CredentialFilter, CredentialListResponse, CredentialRecord,
+    Credential, CredentialFilter, CredentialFormat, CredentialListResponse,
 };
 use crate::server::error::ApiError;
 use crate::server::{AppState, responses::ResponseBody};
@@ -52,8 +52,8 @@ pub async fn get_credential<S: SessionStore>(
         .find_by_id(id, tenant_id)
         .await?;
 
-    let record = to_record(credential)?;
-    Ok(ResponseBody::new(StatusCode::OK, record))
+    let claims = render_claims(&credential)?;
+    Ok(ResponseBody::new(StatusCode::OK, claims))
 }
 
 /// Deletes a credential owned by the authenticated tenant.
@@ -102,32 +102,15 @@ fn query_config() -> &'static Config {
     })
 }
 
-/// Map a domain `Credential` to its HTTP response shape.
-fn to_record(c: Credential) -> Result<CredentialRecord, ApiError> {
-    let credential_configuration_id = c
-        .credential_types
-        .into_iter()
-        .next()
-        .ok_or_else(|| ApiError::internal("credential has no credential_types"))?;
-    Ok(CredentialRecord {
-        id: c.id,
-        credential_configuration_id,
-        format: c.format.as_str().to_string(),
-        issuer: c.issuer,
-        status: c.status.as_str().to_string(),
-        issued_at: format_utc(c.issued_at).map_err(ApiError::internal)?,
-        expires_at: c
-            .valid_until
-            .map(format_utc)
-            .transpose()
-            .map_err(ApiError::internal)?,
-        claims: serde_json::Value::Null,
-    })
-}
-
-/// Format a `UtcDateTime` as an RFC 3339 string.
-fn format_utc(dt: time::UtcDateTime) -> Result<String, time::error::Format> {
-    dt.format(&Rfc3339)
+fn render_claims(c: &Credential) -> Result<serde_json::Value, ApiError> {
+    match c.format {
+        CredentialFormat::SdJwtVc => SdJwt::parse(&c.raw_credential)
+            .and_then(|sd_jwt| sd_jwt.to_rendered_claims())
+            .map_err(|error| {
+                ApiError::internal(format!("failed to parse stored SD-JWT VC claims: {error}"))
+            }),
+        _ => Ok(serde_json::Value::Null),
+    }
 }
 
 fn invalid_query(description: impl Into<String>) -> ApiError {
@@ -142,6 +125,53 @@ fn invalid_query(description: impl Into<String>) -> ApiError {
 mod tests {
     use super::*;
     use crate::domain::models::credential::{CredentialFormat, CredentialStatus};
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+
+    fn b64(value: serde_json::Value) -> String {
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&value).expect("test JSON should serialize"))
+    }
+
+    fn compact_jwt(header: serde_json::Value, claims: serde_json::Value) -> String {
+        format!("{}.{}.sig", b64(header), b64(claims))
+    }
+
+    fn raw_sd_jwt() -> String {
+        let jwt = compact_jwt(
+            serde_json::json!({ "alg": "ES256", "typ": "dc+sd-jwt" }),
+            serde_json::json!({
+                "iss": "https://issuer.example.com",
+                "sub": "did:example:subject",
+                "iat": 1_683_000_000,
+                "exp": 1_883_000_000,
+                "vct": "eu.europa.ec.eudi.pid.1",
+                "given_name": "Ada",
+                "family_name": "Lovelace",
+                "address": {
+                    "locality": "London"
+                }
+            }),
+        );
+        format!("{jwt}~")
+    }
+
+    fn credential(raw_credential: String) -> Credential {
+        Credential {
+            id: Uuid::new_v4(),
+            tenant_id: Uuid::new_v4(),
+            issuer: "https://issuer.example.com".to_string(),
+            subject: Some("did:example:subject".to_string()),
+            credential_types: vec!["eu.europa.ec.eudi.pid.1".to_string()],
+            format: CredentialFormat::SdJwtVc,
+            external_id: None,
+            status: CredentialStatus::Active,
+            issued_at: time::UtcDateTime::now(),
+            valid_until: None,
+            is_revoked: false,
+            status_location: None,
+            status_index: None,
+            raw_credential,
+        }
+    }
 
     #[test]
     fn parses_credential_filters() {
@@ -199,5 +229,19 @@ mod tests {
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
         assert_eq!(error.error, "invalid_request");
         assert!(error.error_description.is_some());
+    }
+
+    #[test]
+    fn renders_sd_jwt_claims_without_reverification() {
+        let claims = render_claims(&credential(raw_sd_jwt())).expect("claims should render");
+
+        assert_eq!(claims["given_name"], "Ada");
+        assert_eq!(claims["family_name"], "Lovelace");
+        assert_eq!(claims["address"]["locality"], "London");
+        assert!(claims.get("iss").is_none());
+        assert!(claims.get("sub").is_none());
+        assert!(claims.get("iat").is_none());
+        assert!(claims.get("exp").is_none());
+        assert!(claims.get("vct").is_none());
     }
 }

--- a/src/server/handlers/credentials.rs
+++ b/src/server/handlers/credentials.rs
@@ -131,7 +131,7 @@ fn render_claims(c: &Credential) -> Result<serde_json::Value, ApiError> {
             .map_err(|error| {
                 ApiError::internal(format!("failed to parse stored SD-JWT VC claims: {error}"))
             }),
-        _ => Ok(serde_json::Value::Null),
+        format => Err(unsupported_credential_format(format)),
     }
 }
 
@@ -140,6 +140,16 @@ fn invalid_query(description: impl Into<String>) -> ApiError {
         status: StatusCode::BAD_REQUEST,
         error: Cow::Borrowed("invalid_request"),
         error_description: Some(description.into()),
+    }
+}
+
+fn unsupported_credential_format(format: CredentialFormat) -> ApiError {
+    ApiError {
+        status: StatusCode::NOT_IMPLEMENTED,
+        error: Cow::Borrowed("unsupported_credential_format"),
+        error_description: Some(format!(
+            "Rendering claims for credential format '{format}' is not supported yet."
+        )),
     }
 }
 
@@ -279,5 +289,22 @@ mod tests {
         assert!(claims.get("iat").is_none());
         assert!(claims.get("exp").is_none());
         assert!(claims.get("vct").is_none());
+    }
+
+    #[test]
+    fn rejects_claim_rendering_for_unsupported_formats() {
+        let mut credential = credential("{}".to_string());
+        credential.format = CredentialFormat::Mdoc;
+
+        let error = render_claims(&credential).unwrap_err();
+
+        assert_eq!(error.status, StatusCode::NOT_IMPLEMENTED);
+        assert_eq!(error.error, "unsupported_credential_format");
+        assert!(
+            error
+                .error_description
+                .as_deref()
+                .is_some_and(|description| description.contains("mso_mdoc"))
+        );
     }
 }

--- a/src/server/handlers/credentials.rs
+++ b/src/server/handlers/credentials.rs
@@ -80,9 +80,10 @@ fn deserialize_filter(query: Option<&str>) -> Result<CredentialFilter, ApiError>
         return Ok(CredentialFilter::default());
     };
 
-    let filter: CredentialFilter = (*query_config())
+    let mut filter: CredentialFilter = (*query_config())
         .deserialize_str(query)
         .map_err(|error| invalid_query(format!("invalid credentials filter query: {error}")))?;
+    normalize_credential_type_filter(&mut filter)?;
 
     // Validate issuer is a valid URI if provided
     if let Some(ref issuer) = filter.issuer
@@ -91,6 +92,27 @@ fn deserialize_filter(query: Option<&str>) -> Result<CredentialFilter, ApiError>
         return Err(invalid_query("issuer must be a valid URI"));
     }
     Ok(filter)
+}
+
+fn normalize_credential_type_filter(filter: &mut CredentialFilter) -> Result<(), ApiError> {
+    let Some(types) = filter.credential_types.take() else {
+        return Ok(());
+    };
+
+    let mut normalized = Vec::new();
+    for value in types {
+        for ty in value.split(',').map(str::trim) {
+            if ty.is_empty() {
+                return Err(invalid_query(
+                    "credential_types must not contain empty values",
+                ));
+            }
+            normalized.push(ty.to_owned());
+        }
+    }
+
+    filter.credential_types = Some(normalized);
+    Ok(())
 }
 
 fn query_config() -> &'static Config {
@@ -229,6 +251,20 @@ mod tests {
         assert_eq!(error.status, StatusCode::BAD_REQUEST);
         assert_eq!(error.error, "invalid_request");
         assert!(error.error_description.is_some());
+    }
+
+    #[test]
+    fn rejects_empty_credential_type_filter_values() {
+        let error = deserialize_filter(Some("credential_types=EmployeeBadge,,Pid")).unwrap_err();
+
+        assert_eq!(error.status, StatusCode::BAD_REQUEST);
+        assert_eq!(error.error, "invalid_request");
+        assert!(
+            error
+                .error_description
+                .as_deref()
+                .is_some_and(|description| description.contains("credential_types"))
+        );
     }
 
     #[test]

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -481,7 +481,7 @@ async fn list_credentials_returns_expires_at_when_credential_has_expiry() {
 
     // Act
     let response = Client::new()
-        .get(format!("{}/api/v1/credentials/{id}", server.base_url))
+        .get(format!("{}/api/v1/credentials", server.base_url))
         .bearer_auth(&token)
         .send()
         .await
@@ -490,10 +490,18 @@ async fn list_credentials_returns_expires_at_when_credential_has_expiry() {
     // Assert: expires_at is present and is a non-null string
     assert_eq!(response.status(), 200);
     let body: serde_json::Value = response.json().await.unwrap();
+    let credential = body["credentials"]
+        .as_array()
+        .and_then(|credentials| {
+            credentials
+                .iter()
+                .find(|credential| credential["id"] == id.to_string())
+        })
+        .expect("expiring credential should be listed");
     assert!(
-        body["expires_at"].is_string(),
+        credential["expires_at"].is_string(),
         "expected expires_at to be a date-time string, got: {}",
-        body["expires_at"]
+        credential["expires_at"]
     );
 }
 

--- a/tests/credentials.rs
+++ b/tests/credentials.rs
@@ -1,5 +1,6 @@
 mod utils;
 
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use cloud_identity_wallet::domain::models::credential::{
     Credential, CredentialDisplay, CredentialDisplayMetadata, CredentialFormat, CredentialStatus,
 };
@@ -7,6 +8,33 @@ use cloud_identity_wallet::domain::ports::CredentialRepo;
 use reqwest::Client;
 use time::UtcDateTime;
 use uuid::Uuid;
+
+fn b64(value: serde_json::Value) -> String {
+    URL_SAFE_NO_PAD.encode(serde_json::to_vec(&value).expect("test JSON should serialize"))
+}
+
+fn compact_jwt(header: serde_json::Value, claims: serde_json::Value) -> String {
+    format!("{}.{}.sig", b64(header), b64(claims))
+}
+
+fn raw_sd_jwt() -> String {
+    let jwt = compact_jwt(
+        serde_json::json!({ "alg": "ES256", "typ": "dc+sd-jwt" }),
+        serde_json::json!({
+            "iss": "https://issuer.example.com",
+            "sub": "did:example:subject",
+            "iat": 1_683_000_000,
+            "exp": 1_883_000_000,
+            "vct": "eu.europa.ec.eudi.pid.1",
+            "given_name": "Ada",
+            "family_name": "Lovelace",
+            "address": {
+                "locality": "London"
+            }
+        }),
+    );
+    format!("{jwt}~")
+}
 
 /// Build a minimal `Credential` owned by `tenant_id`.
 fn make_credential(tenant_id: Uuid) -> Credential {
@@ -24,7 +52,7 @@ fn make_credential(tenant_id: Uuid) -> Credential {
         is_revoked: false,
         status_location: None,
         status_index: None,
-        raw_credential: "dummy".to_string(),
+        raw_credential: raw_sd_jwt(),
     }
 }
 
@@ -306,10 +334,14 @@ async fn get_credential_returns_credential_for_owner() {
     // Assert
     assert_eq!(response.status(), 200);
     let body: serde_json::Value = response.json().await.unwrap();
-    assert_eq!(body["id"], id.to_string());
-    assert_eq!(body["format"], "dc+sd-jwt");
-    assert_eq!(body["status"], "active");
-    assert!(body.get("issued_at").is_some());
+    assert_eq!(body["given_name"], "Ada");
+    assert_eq!(body["family_name"], "Lovelace");
+    assert_eq!(body["address"]["locality"], "London");
+    assert!(body.get("iss").is_none());
+    assert!(body.get("sub").is_none());
+    assert!(body.get("iat").is_none());
+    assert!(body.get("exp").is_none());
+    assert!(body.get("vct").is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Credential retrieval should not re-verify credentials already validated during issuance. It should parse the raw credential and transform disclosed claims for UI rendering. Update credential detail API to return renderable claims from raw credential.