### PR TITLE
Feat/mso mdoc cose sign1 signature verification and iaca trust store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,45 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 1.0.69",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,9 +213,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.17"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517aa062d8bd9015ee23d6daa5e1c1372328412fdae4e6c4c1be9b69c6ad37a2"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -269,7 +230,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.1",
  "time",
  "tokio",
  "tracing",
@@ -343,7 +304,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -353,10 +314,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kms"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff0bb3e6249447a5ecfeec4616de4f04498a4337302b6ffe221b4a8745905c4"
+checksum = "217276b3d948ec05b2726d66b2c9013567ca42751052c287ec45800ee81799c9"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -370,17 +332,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.104.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa6622798e19e6a76b690562085dd4771c736cd48343464a53ab4ae2f2c9f84"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -395,16 +358,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.4"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-http",
@@ -415,7 +378,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -445,7 +408,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -456,15 +419,15 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -480,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.6"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-schema",
@@ -524,7 +487,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -536,16 +499,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -571,20 +534,20 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.8"
+version = "1.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -632,7 +595,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -663,7 +626,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -747,7 +710,7 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn",
 ]
 
@@ -762,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 dependencies = [
  "serde_core",
 ]
@@ -803,7 +766,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -872,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -900,14 +863,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -1093,13 +1056,11 @@ dependencies = [
  "jsonwebtoken",
  "percent-encoding",
  "rcgen",
- "rcgen",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "rustls-pki-types",
  "rustls-webpki",
- "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1112,7 +1073,6 @@ dependencies = [
  "validator",
  "webpki-roots 1.0.7",
  "wiremock",
- "x509-parser",
  "x509-parser",
 ]
 
@@ -1127,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "color-eyre"
@@ -1489,12 +1449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,20 +1482,6 @@ name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1587,9 +1527,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2006,7 +1946,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2154,9 +2094,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2180,7 +2120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -2191,7 +2131,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2219,16 +2159,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2260,7 +2200,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2293,7 +2233,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -2582,9 +2522,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2679,14 +2619,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.5",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2723,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lru-slab"
@@ -2760,9 +2700,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -2788,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2956,15 +2896,6 @@ name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
  "asn1-rs",
 ]
@@ -3568,25 +3499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rcgen"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
-dependencies = [
- "aws-lc-rs",
- "pem",
- "ring",
- "rustls-pki-types",
- "time",
- "x509-parser",
- "yasna",
-]
-
-[[package]]
 name = "redis"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
+checksum = "a12e6b5f4d8ef33944e833e2b1859ad478deab6e431d7337b30ee2efe21f7543"
 dependencies = [
  "ahash",
  "arc-swap",
@@ -3626,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
  "bitflags",
 ]
@@ -3696,16 +3612,16 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -3743,7 +3659,7 @@ checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.0",
+ "http 1.4.1",
  "reqwest",
  "serde",
  "thiserror 2.0.18",
@@ -3760,7 +3676,7 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.0",
+ "http 1.4.1",
  "hyper",
  "reqwest",
  "reqwest-middleware",
@@ -3869,15 +3785,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4263,6 +4170,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,9 +4258,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4693,7 +4606,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "itertools 0.14.0",
  "log",
  "memchr",
@@ -4955,7 +4868,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -5012,7 +4925,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -5131,9 +5044,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5179,9 +5092,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -5223,7 +5136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
 ]
@@ -5261,9 +5174,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5393,9 +5306,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5406,9 +5319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5416,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5426,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5439,9 +5352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5496,9 +5409,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5893,7 +5806,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -6019,26 +5932,9 @@ dependencies = [
  "lazy_static",
  "nom",
  "oid-registry",
- "rusticata-macros",
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
  "ring",
  "rusticata-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -6086,19 +5982,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "yasna"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
-dependencies = [
- "time",
-]
-
-[[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6119,18 +6006,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,11 +1093,13 @@ dependencies = [
  "jsonwebtoken",
  "percent-encoding",
  "rcgen",
+ "rcgen",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "rustls-pki-types",
  "rustls-webpki",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -1071,6 +1112,7 @@ dependencies = [
  "validator",
  "webpki-roots 1.0.7",
  "wiremock",
+ "x509-parser",
  "x509-parser",
 ]
 
@@ -1447,6 +1489,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,6 +1528,20 @@ name = "der-parser"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -2899,6 +2961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3568,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "aws-lc-rs",
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redis"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,6 +3857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -5930,6 +6025,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5969,6 +6082,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
 dependencies = [
  "bit-vec",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1"
 base64 = "0.22"
 dashmap = "6"
 rand = "0.10"
-rcgen = { version = "0.14", default-features = false, features = ["aws_lc_rs"] }
+rcgen = { version = "0.14", default-features = false, features = ["x509-parser","aws_lc_rs"] }
 rustls-pki-types = "1.14"
 sqlx = "0.8"
 time = "0.3"

--- a/crates/cloud-wallet-openid4vc/Cargo.toml
+++ b/crates/cloud-wallet-openid4vc/Cargo.toml
@@ -26,14 +26,16 @@ serde_urlencoded = "0.7"
 serde_with.workspace = true
 subtle.workspace = true
 thiserror.workspace = true
+x509-parser = { version = "0.18", features = ["verify"] }
 time = { workspace = true, features = ["std", "parsing"] }
 url = { workspace = true, features = ["serde"] }
 validator = { version = "0.20", features = ["derive"] }
 webpki-roots = "1"
 webpki.workspace = true
-x509-parser = "0.18"
+
 
 [dev-dependencies]
 rcgen.workspace = true
+rustls-pki-types.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wiremock = "0.6"

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
@@ -1,0 +1,316 @@
+//! X.509 certificate chain validation helpers for ISO 18013-5 mDoc issuer authentication.
+//!
+//! This module provides utilities to:
+//! - Validate a DER-encoded certificate chain against a set of trusted IACA roots
+//!   (RFC 5280, ISO 18013-5 §9.1.2).
+//! - Check that a Document Signer Certificate (DSC) carries the mandatory Extended Key
+//!   Usage OID `1.0.18013.5.1.2` (ISO 18013-5 §9.1.2).
+//! - Extract the raw SubjectPublicKeyInfo (SPKI) bytes from a parsed certificate
+//!   so they can be passed to `cloud_wallet_crypto` verifying-key constructors.
+//!
+//! All functions are `pub(super)` — they are internal to the `mdoc` module and are not
+//! part of the public crate API.
+//!
+//! Callers are expected to parse the DSC once (`X509Certificate::from_der`) and pass a
+//! reference to the parsed certificate rather than raw DER bytes, avoiding redundant
+//! ASN.1 parsing for every validation step.
+
+use time::OffsetDateTime;
+use x509_parser::prelude::{FromDer as _, ParsedExtension, X509Certificate};
+
+use super::error::{MdocError, Result};
+
+/// The OID required in the DSC Extended Key Usage extension (ISO 18013-5 §9.1.2).
+const DSC_EKU_OID: &str = "1.0.18013.5.1.2";
+
+/// Validates that `chain[0]` (the Document Signer Certificate) chains up to at least
+/// one certificate in `trusted_roots` via standard X.509 path validation.
+///
+/// The chain must be ordered leaf-first: `chain[0]` is the DSC, subsequent entries are
+/// intermediate CAs, and the last entry should be signed by a trusted root (or itself
+/// be a trusted root).
+///
+/// # Returns
+///
+/// The DER bytes of the specific trusted root that anchors the chain.  Callers use
+/// this to perform per-certificate consistency checks (e.g. country code) against the
+/// one root that actually signed the chain, not against every root in the trust store.
+///
+/// # Errors
+///
+/// - [`MdocError::InvalidCertificateChain`] — the chain is empty, a certificate is
+///   malformed, a signature in the chain is invalid, or no trusted root anchors it.
+pub(super) fn validate_cert_chain(chain: &[Vec<u8>], trusted_roots: &[Vec<u8>]) -> Result<Vec<u8>> {
+    if chain.is_empty() {
+        return Err(MdocError::InvalidCertificateChain {
+            reason: "certificate chain is empty".into(),
+        });
+    }
+
+    // ISO 18013-5 Annex B §B.1: IACA root must not appear in x5chain (prevents trust-anchor bypass).
+    for cert_der in chain {
+        if trusted_roots.iter().any(|root| root == cert_der) {
+            return Err(MdocError::InvalidCertificateChain {
+                reason: "IACA root certificate must not appear in the x5chain \
+                         (ISO 18013-5 Annex B section B.1)"
+                    .into(),
+            });
+        }
+    }
+
+    // Full RFC 5280 path validation (name constraints, CRL/OCSP) is out of scope;
+    // we verify signatures and root anchoring only.
+    let parsed_chain: Vec<X509Certificate<'_>> = chain
+        .iter()
+        .enumerate()
+        .map(|(i, der)| {
+            let (_, cert) =
+                X509Certificate::from_der(der).map_err(|e| MdocError::InvalidCertificateChain {
+                    reason: format!("failed to parse certificate at chain index {i}: {e}"),
+                })?;
+            Ok(cert)
+        })
+        .collect::<Result<_>>()?;
+
+    for i in 0..parsed_chain.len().saturating_sub(1) {
+        let subject = &parsed_chain[i];
+        let issuer = &parsed_chain[i + 1];
+
+        subject.verify_signature(Some(issuer.public_key())).map_err(|_| {
+            MdocError::InvalidCertificateChain {
+                reason: format!(
+                    "signature of certificate at index {i} does not verify under the next certificate"
+                ),
+            }
+        })?;
+    }
+
+    let last = parsed_chain
+        .last()
+        .expect("chain is non-empty; checked above");
+
+    // Find the specific trusted root that anchors this chain and return its DER bytes.
+    // Returning the anchoring root (rather than a boolean) lets callers check per-cert
+    // attributes (country code, state) against the one root that actually signed the chain.
+    let anchoring_root = trusted_roots
+        .iter()
+        .find(|root_der| {
+            let Ok((_, root_cert)) = X509Certificate::from_der(root_der) else {
+                return false;
+            };
+            // A self-signed root matches if it is structurally equal to the last chain cert
+            // (i.e. the chain already ends with the root itself), or if the last cert is
+            // signed by this root.
+            last.verify_signature(Some(root_cert.public_key())).is_ok()
+        })
+        .ok_or_else(|| MdocError::InvalidCertificateChain {
+            reason: "chain does not terminate at a trusted IACA root".into(),
+        })?;
+
+    Ok(anchoring_root.clone())
+}
+
+/// Checks that the Document Signer Certificate carries the mandatory Extended Key Usage
+/// OID `1.0.18013.5.1.2` (ISO 18013-5 §9.1.2).
+///
+/// # Errors
+///
+/// - [`MdocError::MissingDocSignerEku`] — the EKU extension is absent or does not
+///   include the required OID.
+pub(super) fn check_dsc_eku(dsc: &X509Certificate<'_>) -> Result<()> {
+    let has_required_eku = dsc
+        .extensions()
+        .iter()
+        .filter_map(|ext| {
+            if let ParsedExtension::ExtendedKeyUsage(eku) = ext.parsed_extension() {
+                Some(eku)
+            } else {
+                None
+            }
+        })
+        .any(|eku| {
+            eku.other
+                .iter()
+                .any(|oid| oid.to_id_string() == DSC_EKU_OID)
+        });
+
+    if !has_required_eku {
+        return Err(MdocError::MissingDocSignerEku);
+    }
+
+    Ok(())
+}
+
+/// Checks that the Document Signer Certificate has the `digitalSignature` key usage bit
+/// set (ISO 18013-5 Annex B Table B.3).
+///
+/// # Errors
+///
+/// - [`MdocError::MissingDigitalSignatureKeyUsage`] — the Key Usage extension is absent
+///   or the `digitalSignature` bit is not set.
+pub(super) fn check_dsc_key_usage(dsc: &X509Certificate<'_>) -> Result<()> {
+    let digital_signature_set = dsc
+        .extensions()
+        .iter()
+        .find_map(|ext| {
+            if let ParsedExtension::KeyUsage(ku) = ext.parsed_extension() {
+                Some(ku.digital_signature())
+            } else {
+                None
+            }
+        })
+        .unwrap_or(false); // absent extension → treat as not set
+
+    if !digital_signature_set {
+        return Err(MdocError::MissingDigitalSignatureKeyUsage);
+    }
+
+    Ok(())
+}
+
+/// Extracts the raw SubjectPublicKeyInfo (SPKI) DER bytes from a parsed certificate.
+///
+/// The returned bytes are suitable for passing directly to
+/// `cloud_wallet_crypto::ecdsa::VerifyingKey::from_spki_der` or
+/// `cloud_wallet_crypto::ed25519::VerifyingKey::from_spki_der`.
+pub(super) fn extract_spki(dsc: &X509Certificate<'_>) -> Vec<u8> {
+    dsc.public_key().raw.to_vec()
+}
+
+/// Checks that the Document Signer Certificate validity period does not exceed the
+/// 457-day maximum mandated by ISO 18013-5 Annex B Table B.3.
+///
+/// # Errors
+///
+/// - [`MdocError::InvalidCertificateChain`] — the validity period exceeds 457 days,
+///   or `notAfter` is not strictly after `notBefore` (structurally invalid cert).
+pub(super) fn check_dsc_validity_period(dsc: &X509Certificate<'_>) -> Result<()> {
+    let not_before = dsc.validity().not_before.timestamp();
+    let not_after = dsc.validity().not_after.timestamp();
+
+    // Reject certs with an inverted or zero-length validity window before checking duration.
+    if not_after <= not_before {
+        return Err(MdocError::InvalidCertificateChain {
+            reason: "DSC notAfter is not strictly after notBefore".into(),
+        });
+    }
+
+    const MAX_VALIDITY_SECS: i64 = 457 * 24 * 60 * 60;
+    if not_after - not_before > MAX_VALIDITY_SECS {
+        return Err(MdocError::InvalidCertificateChain {
+            reason: format!(
+                "DSC validity period ({} days) exceeds the 457-day maximum \
+                 (ISO 18013-5 Annex B Table B.3)",
+                (not_after - not_before) / 86_400
+            ),
+        });
+    }
+
+    Ok(())
+}
+
+/// Verifies that the MSO `validityInfo.signed` timestamp falls within the Document
+/// Signer Certificate's validity window (ISO 18013-5 §9.3.1 step 5).
+///
+/// # Errors
+///
+/// - [`MdocError::SignedOutsideDscValidity`] - `signed_at` is before `notBefore` or
+///   after `notAfter`.
+pub(super) fn check_signed_within_dsc_validity(
+    dsc: &X509Certificate<'_>,
+    signed_at: OffsetDateTime,
+) -> Result<()> {
+    let not_before = dsc.validity().not_before.timestamp();
+    let not_after = dsc.validity().not_after.timestamp();
+    let signed_ts = signed_at.unix_timestamp();
+
+    if signed_ts < not_before || signed_ts > not_after {
+        return Err(MdocError::SignedOutsideDscValidity {
+            signed_at: signed_ts,
+            not_before,
+            not_after,
+        });
+    }
+
+    Ok(())
+}
+
+/// Checks that the Document Signer Certificate subject country code matches the
+/// anchoring IACA root certificate subject country code (ISO 18013-5 §9.3.3).
+///
+/// Accepts the DER of the **specific root that anchored the chain** (returned by
+/// [`validate_cert_chain`]) rather than the full trust store.  Checking all roots
+/// would incorrectly reject a valid DSC in a multi-country trust store whenever any
+/// root from a different country is also present.
+///
+/// The check is only performed when both the DSC and the anchoring root carry a
+/// `CountryName` attribute.  If either party omits the attribute the check is
+/// skipped (conservative — absence is not itself an error).
+///
+/// # Errors
+///
+/// - [`MdocError::InvalidCertificateChain`] — the anchoring root DER fails to parse.
+/// - [`MdocError::CountryMismatch`] — the DSC and the anchoring root both have country
+///   codes and they differ.
+/// - [`MdocError::StateMismatch`] — the DSC and the anchoring root both have a
+///   `stateOrProvinceName` attribute and the values differ (ISO 18013-5 §9.3.3).
+pub(super) fn check_country_consistency(
+    dsc: &X509Certificate<'_>,
+    anchoring_root_der: &[u8],
+) -> Result<()> {
+    let dsc_country: Option<String> = dsc
+        .subject()
+        .iter_country()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .map(str::to_owned);
+
+    let dsc_state: Option<String> = dsc
+        .subject()
+        .iter_state_or_province()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .map(str::to_owned);
+
+    let (_, root) = X509Certificate::from_der(anchoring_root_der).map_err(|e| {
+        MdocError::InvalidCertificateChain {
+            reason: format!(
+                "failed to parse anchoring IACA root for country-consistency check: {e}"
+            ),
+        }
+    })?;
+
+    let iaca_country: Option<String> = root
+        .subject()
+        .iter_country()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .map(str::to_owned);
+
+    if let (Some(dsc_c), Some(iaca_c)) = (&dsc_country, iaca_country)
+        && dsc_c != &iaca_c
+    {
+        return Err(MdocError::CountryMismatch {
+            dsc_country: dsc_c.clone(),
+            iaca_country: iaca_c,
+        });
+    }
+
+    let iaca_state: Option<String> = root
+        .subject()
+        .iter_state_or_province()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .map(str::to_owned);
+
+    if let (Some(dsc_s), Some(iaca_s)) = (&dsc_state, iaca_state)
+        && dsc_s != &iaca_s
+    {
+        return Err(MdocError::StateMismatch {
+            dsc_state: dsc_s.clone(),
+            iaca_state: iaca_s,
+        });
+    }
+
+    Ok(())
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
@@ -186,4 +186,122 @@ pub enum MdocError {
         /// Actual byte length found.
         actual: usize,
     },
+
+    /// The COSE_Sign1 protected header has no algorithm field, or the algorithm
+    /// field is a text label rather than an integer.
+    ///
+    /// ISO 18013-5 §9.1.2 requires the algorithm to be present and to be one of
+    /// the integer COSE algorithm identifiers.
+    #[error("COSE_Sign1 protected header is missing the algorithm field")]
+    MissingAlgorithm,
+
+    /// The COSE_Sign1 algorithm identifier is not supported for issuer signature
+    /// verification.
+    ///
+    /// Supported algorithm identifiers: -7 (ES256/P-256), -35 (ES384/P-384),
+    /// -36 (ES512/P-521), -8 (EdDSA/Ed25519).
+    #[error("unsupported COSE signature algorithm: {alg}")]
+    UnsupportedAlgorithm {
+        /// The raw COSE algorithm integer label.
+        alg: i64,
+    },
+
+    /// The `x5chain` header (COSE unprotected header label 33) is absent.
+    ///
+    /// ISO 18013-5 §9.1.2 requires the issuer certificate chain to be conveyed
+    /// in the `x5chain` header so the verifier can validate the signing certificate.
+    #[error("x5chain (COSE header key 33) not found in unprotected header")]
+    MissingX5Chain,
+
+    /// The Document Signer Certificate (DSC) does not carry the required Extended Key
+    /// Usage OID.
+    ///
+    /// ISO 18013-5 §9.1.2 mandates that every DSC includes OID 1.0.18013.5.1.2 in its
+    /// Extended Key Usage extension.
+    #[error("document signer certificate is missing required EKU OID 1.0.18013.5.1.2")]
+    MissingDocSignerEku,
+
+    /// The Document Signer Certificate does not have the `digitalSignature` key usage
+    /// bit set, or its Key Usage extension is absent entirely.
+    ///
+    /// ISO 18013-5 Annex B Table B.3 requires every DSC to carry a critical Key Usage
+    /// extension with (at least) the `digitalSignature` bit asserted.
+    #[error(
+        "document signer certificate missing required digitalSignature key usage bit \
+         (ISO 18013-5 Annex B Table B.3)"
+    )]
+    MissingDigitalSignatureKeyUsage,
+
+    /// The certificate chain could not be validated against a trusted IACA root.
+    ///
+    /// This covers both structural chain errors (e.g. signature mismatch between
+    /// consecutive certificates) and the absence of any trusted root for the chain.
+    #[error("certificate chain validation failed: {reason}")]
+    InvalidCertificateChain {
+        /// Human-readable description of why validation failed.
+        reason: String,
+    },
+
+    /// The COSE_Sign1 signature does not verify against the Document Signer Certificate.
+    ///
+    /// Returned when the cryptographic signature check (EC-DSA or EdDSA) fails after
+    /// a valid certificate chain has already been established.
+    #[error("issuer signature verification failed")]
+    InvalidIssuerSignature,
+
+    /// DSC subject country code does not match the IACA root subject country (ISO 18013-5 §9.3.3).
+    ///
+    /// Country consistency is checked between the Document Signer Certificate subject DN
+    /// and the trust-store IACA root subject DN; both must carry the same ISO 3166-1
+    /// alpha-2 `CountryName` attribute when the attribute is present in both certs.
+    #[error(
+        "country mismatch: DSC subject country '{dsc_country}' differs from IACA subject country '{iaca_country}'"
+    )]
+    CountryMismatch {
+        /// Country code from the DSC's subject distinguished name.
+        dsc_country: String,
+        /// Country code from the IACA root's subject distinguished name.
+        iaca_country: String,
+    },
+
+    /// DSC subject stateOrProvinceName does not match the IACA root subject stateOrProvinceName
+    /// (ISO 18013-5 §9.3.3).
+    ///
+    /// When both the DSC and the trusted IACA root carry a `stateOrProvinceName` attribute in
+    /// their subject DNs, the values must be equal.
+    #[error(
+        "state/province mismatch: DSC subject state '{dsc_state}' differs from IACA subject state '{iaca_state}'"
+    )]
+    StateMismatch {
+        /// stateOrProvinceName from the DSC's subject distinguished name.
+        dsc_state: String,
+        /// stateOrProvinceName from the IACA root's subject distinguished name.
+        iaca_state: String,
+    },
+
+    /// MSO `validityInfo.signed` falls outside the Document Signer Certificate validity
+    /// window (ISO 18013-5 §9.3.1 step 5).
+    ///
+    /// The three timestamps are provided as Unix seconds for diagnostic logging.
+    #[error("MSO signed at {signed_at} is outside DSC validity window [{not_before}, {not_after}]")]
+    SignedOutsideDscValidity {
+        /// The `validityInfo.signed` timestamp from the MSO, as a Unix second.
+        signed_at: i64,
+        /// The DSC `notBefore` timestamp, as a Unix second.
+        not_before: i64,
+        /// The DSC `notAfter` timestamp, as a Unix second.
+        not_after: i64,
+    },
+
+    /// MSO `docType` does not match the outer document `docType` (ISO 18013-5 §9.3.1 step 4).
+    ///
+    /// The `docType` in the MSO payload must equal the `docType` in the enclosing document
+    /// structure; a mismatch indicates the credential was prepared for a different document type.
+    #[error("docType mismatch: MSO contains '{mso}' but outer document contains '{document}'")]
+    DocTypeMismatch {
+        /// The `docType` string as it appeared in the MSO.
+        mso: String,
+        /// The `docType` string from the outer document.
+        document: String,
+    },
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -11,6 +11,7 @@
 //! - [RFC 8949](https://www.rfc-editor.org/rfc/rfc8949) — CBOR
 //! - [RFC 9052](https://www.rfc-editor.org/rfc/rfc9052) — COSE_Sign1
 
+mod cert_chain;
 pub mod error;
 mod parser;
 #[cfg(test)]
@@ -19,7 +20,9 @@ pub mod verifier;
 
 pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
-pub use verifier::verify_digests;
+pub use verifier::{
+    IacaTrustStore, IssuerInfo, StaticTrustStore, verify_digests, verify_issuer_signature,
+};
 
 use cloud_wallet_crypto::digest::HashAlg;
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -1373,7 +1373,8 @@ fn build_chain_params(
     dsc_state: Option<&str>,
 ) -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
     use rcgen::{
-        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer,
+        KeyUsagePurpose,
     };
     let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
     let mut iaca_params =
@@ -1391,6 +1392,7 @@ fn build_chain_params(
         .self_signed(&iaca_key)
         .expect("self-signed IACA cert must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     let dsc_aws_key =
         cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
@@ -1430,7 +1432,7 @@ fn build_chain_params(
     }
     dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .signed_by(&dsc_rcgen_key, &iaca_issuer)
         .expect("DSC signing by IACA must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 
@@ -1845,7 +1847,8 @@ fn verify_issuer_signature_rejects_dsc_validity_too_long() {
 /// `cloud_wallet_crypto::ecdsa::Curve::P521`.
 fn build_chain_p521() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
     use rcgen::{
-        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer,
+        KeyUsagePurpose,
     };
 
     let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
@@ -1856,6 +1859,7 @@ fn build_chain_p521() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair)
         .self_signed(&iaca_key)
         .expect("self-signed IACA cert must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     let dsc_aws_key =
         cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P521)
@@ -1885,7 +1889,7 @@ fn build_chain_p521() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair)
         .push(DnType::CommonName, "DSC P521");
     dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .signed_by(&dsc_rcgen_key, &iaca_issuer)
         .expect("DSC P-521 signing by IACA must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 
@@ -2006,7 +2010,8 @@ fn verify_issuer_signature_rejects_state_mismatch() {
 /// bit is NOT set (only `ContentCommitment`), exercising the key-usage rejection path.
 fn build_chain_dsc_wrong_key_usage() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
     use rcgen::{
-        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer,
+        KeyUsagePurpose,
     };
 
     let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
@@ -2017,6 +2022,7 @@ fn build_chain_dsc_wrong_key_usage() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::
         .self_signed(&iaca_key)
         .expect("self-signed IACA cert must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     let dsc_aws_key =
         cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
@@ -2048,7 +2054,7 @@ fn build_chain_dsc_wrong_key_usage() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::
         .distinguished_name
         .push(DnType::CommonName, "DSC Wrong KU");
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .signed_by(&dsc_rcgen_key, &iaca_issuer)
         .expect("DSC signing must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 
@@ -2259,7 +2265,7 @@ fn build_three_cert_chain() -> (
     cloud_wallet_crypto::ecdsa::KeyPair,
 ) {
     use rcgen::{
-        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyUsagePurpose,
     };
 
     // IACA root (self-signed CA)
@@ -2271,6 +2277,7 @@ fn build_three_cert_chain() -> (
         .self_signed(&iaca_key)
         .expect("IACA self-sign must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     // Intermediate CA (signed by IACA root)
     let int_key = rcgen::KeyPair::generate().expect("Intermediate CA key generation must succeed");
@@ -2278,9 +2285,10 @@ fn build_three_cert_chain() -> (
         CertificateParams::new(vec!["Three-tier Intermediate CA".to_string()]).expect("int params");
     int_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
     let int_cert = int_params
-        .signed_by(&int_key, &iaca_cert, &iaca_key)
+        .signed_by(&int_key, &iaca_issuer)
         .expect("Intermediate CA signing must succeed");
     let int_der: Vec<u8> = int_cert.der().to_vec();
+    let int_issuer = Issuer::new(int_params, int_key);
 
     // DSC (signed by Intermediate CA)
     let dsc_aws_key =
@@ -2309,7 +2317,7 @@ fn build_three_cert_chain() -> (
     dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
     dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &int_cert, &int_key)
+        .signed_by(&dsc_rcgen_key, &int_issuer)
         .expect("DSC signing by Intermediate CA must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 
@@ -2771,7 +2779,7 @@ fn verify_issuer_signature_rejects_ed448_algorithm() {
 /// Returns `(iaca_der, dsc_der, dsc_signing_key)`.
 fn build_chain_p384() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
     use rcgen::{
-        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyUsagePurpose,
     };
 
     let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
@@ -2782,6 +2790,7 @@ fn build_chain_p384() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair)
         .self_signed(&iaca_key)
         .expect("self-signed IACA cert must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     let dsc_aws_key =
         cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P384)
@@ -2808,7 +2817,7 @@ fn build_chain_p384() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair)
     dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
     dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .signed_by(&dsc_rcgen_key, &iaca_issuer)
         .expect("DSC P-384 signing by IACA must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 
@@ -2909,7 +2918,7 @@ fn verify_issuer_signature_accepts_valid_es384() {
 /// Returns `(iaca_der, dsc_der, dsc_signing_key)`.
 fn build_chain_ed25519() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ed25519::KeyPair) {
     use rcgen::{
-        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyUsagePurpose,
     };
 
     let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
@@ -2920,6 +2929,7 @@ fn build_chain_ed25519() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ed25519::Key
         .self_signed(&iaca_key)
         .expect("self-signed IACA cert must succeed");
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+    let iaca_issuer = Issuer::new(iaca_params, iaca_key);
 
     let dsc_aws_key = cloud_wallet_crypto::ed25519::KeyPair::generate()
         .expect("aws-lc-rs Ed25519 key generation must succeed");
@@ -2949,7 +2959,7 @@ fn build_chain_ed25519() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ed25519::Key
     dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
     dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
     let dsc_cert = dsc_params
-        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .signed_by(&dsc_rcgen_key, &iaca_issuer)
         .expect("DSC Ed25519 signing by IACA must succeed");
     let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -458,8 +458,6 @@ fn rejects_duplicate_namespace_in_value_digests() {
     );
 }
 
-// ── digest-verification helpers ──────────────────────────────────────────────
-
 /// Builds the `#6.24(bstr .cbor IssuerSignedItem)` encoding for one item
 /// and returns `(raw_tag24_bytes, real_sha256_digest)`.
 ///
@@ -787,8 +785,6 @@ fn build_two_namespace_mdoc() -> String {
     ]);
     Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
 }
-
-// ── verify_digests tests ──────────────────────────────────────────────────────
 
 #[test]
 fn verify_digests_passes_for_all_valid() {
@@ -2082,8 +2078,6 @@ fn verify_issuer_signature_rejects_missing_key_usage() {
     );
 }
 
-// ── New helpers and tests added to improve coverage ─────────────────────────
-
 /// Builds an `IssuerSigned` where the x5chain unprotected header value is a
 /// single `bstr` rather than `[bstr]`.  Per RFC 9360 §2 both forms are valid.
 fn build_issuer_signed_single_bstr_x5chain(
@@ -2324,8 +2318,6 @@ fn build_three_cert_chain() -> (
     (iaca_der, int_der, dsc_der, dsc_aws_key)
 }
 
-// ── BLOCKING-2: signed timestamp after DSC notAfter ──────────────────────────
-
 #[test]
 fn verify_issuer_signature_rejects_signed_after_dsc_expiry() {
     // Arrange: DSC validity window 2023-01-01..2023-06-30 (170 days, well under the
@@ -2359,8 +2351,6 @@ fn verify_issuer_signature_rejects_signed_after_dsc_expiry() {
     );
 }
 
-// ── NB-10: single-bstr x5chain ───────────────────────────────────────────────
-
 #[test]
 fn verify_issuer_signature_accepts_single_bstr_x5chain() {
     // RFC 9360 §2 permits x5chain to be either a single bstr or an array of
@@ -2380,8 +2370,6 @@ fn verify_issuer_signature_accepts_single_bstr_x5chain() {
         "credential with single-bstr x5chain must be accepted: {result:?}"
     );
 }
-
-// ── NB-11: multi-cert chain (IACA → IntCA → DSC) ─────────────────────────────
 
 #[test]
 fn verify_issuer_signature_accepts_intermediate_ca_chain() {
@@ -2434,8 +2422,6 @@ fn verify_issuer_signature_rejects_tampered_intermediate() {
     );
 }
 
-// ── NB-12: empty trust store ──────────────────────────────────────────────────
-
 #[test]
 fn verify_issuer_signature_rejects_empty_trust_store() {
     // An empty trust store cannot anchor any chain.
@@ -2456,8 +2442,6 @@ fn verify_issuer_signature_rejects_empty_trust_store() {
     );
 }
 
-// ── NB-13: Brainpool P-256/P-384/P-512 algorithm identifiers ─────────────────
-//
 // Algorithm IDs -38, -47, -48 (Brainpool) must be recognised by read_cose_alg
 // and reach dispatch_verify, which returns UnsupportedAlgorithm immediately.
 // The credential structure must otherwise be valid (chain, EKU, etc.) so the
@@ -2528,8 +2512,6 @@ fn verify_issuer_signature_rejects_brainpool_p512_algorithm() {
     );
 }
 
-// ── NB-4: IACA root present in x5chain ────────────────────────────────────────
-
 #[test]
 fn verify_issuer_signature_rejects_iaca_root_in_x5chain() {
     // ISO 18013-5 Annex B §B.1: the IACA root must NOT appear in x5chain.
@@ -2557,8 +2539,6 @@ fn verify_issuer_signature_rejects_iaca_root_in_x5chain() {
     );
 }
 
-// ── NB-5: Ed448 public key rejected ──────────────────────────────────────────
-
 /// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
 /// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
 ///
@@ -2576,7 +2556,6 @@ fn build_ed448_dsc_manual(
         X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
     let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
 
-    // ── Minimal DER helpers ──────────────────────────────────────────────────
     fn len_bytes(n: usize) -> Vec<u8> {
         if n < 128 {
             vec![n as u8]
@@ -2645,7 +2624,6 @@ fn build_ed448_dsc_manual(
         tlv(0x17, s.as_bytes().to_vec())
     }
 
-    // ── Build TBSCertificate ─────────────────────────────────────────────────
     let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
     let serial = integer_pos(vec![0x01]); // serialNumber = 1
     let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
@@ -2771,8 +2749,6 @@ fn verify_issuer_signature_rejects_ed448_algorithm() {
         "expected UnsupportedAlgorithm {{ alg: -8 }}, got: {err:?}"
     );
 }
-
-// ── NB-6: ES384 and Ed25519 happy-path tests ──────────────────────────────────
 
 /// Builds an IACA root (P-256) and a DSC backed by a P-384 key (ES384 / -35).
 ///

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -7,7 +7,7 @@ use time::format_description::well_known::Rfc3339;
 use super::DigestAlgorithm;
 use super::error::MdocError;
 use super::parser::ParsedMdoc;
-use super::verifier::verify_digests;
+use super::verifier::{StaticTrustStore, verify_digests, verify_issuer_signature};
 
 // CBOR construction helpers
 
@@ -1337,5 +1337,1709 @@ fn verify_digests_rejects_namespace_absent_from_value_digests() {
         matches!(err, MdocError::MissingDigest { ref namespace, digest_id: 0 }
             if namespace == "org.iso.18013.5.1"),
         "expected MissingDigest {{ namespace: org.iso.18013.5.1, digest_id: 0 }}, got: {err:?}"
+    );
+}
+
+/// ISO 18013-5 Document Signer Certificate EKU OID (arc 1.0.18013.5.1.2).
+/// Encoded as relative OID component integers for rcgen `ExtendedKeyUsagePurpose::Other`.
+const DSC_EKU_OID: &[u64] = &[1, 0, 18013, 5, 1, 2];
+
+/// Builds an IACA root CA cert and a DSC cert signed by that IACA, returning
+/// `(iaca_der, dsc_der, dsc_signing_key)` where `dsc_signing_key` is backed by
+/// `aws-lc-rs` so that signatures produced by it can be verified by
+/// `cloud_wallet_crypto::ecdsa::VerifyingKey`.
+///
+/// The `include_dsc_eku` flag controls whether the DSC carries the mandatory
+/// ISO 18013-5 EKU OID; set it to `false` to exercise the missing-EKU path.
+fn build_chain(include_dsc_eku: bool) -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
+    build_chain_params(include_dsc_eku, None, None, None, None, None)
+}
+
+/// Parameterised version of [`build_chain`] for tests that need specific DSC validity
+/// dates, per-country-code attributes, or stateOrProvinceName attributes.
+///
+/// - `dsc_validity`: `(not_before, not_after)` for the DSC; defaults to a 396-day window
+///   (`2023-12-01` to `2024-12-31`) that covers the `minimal_mso_cbor()` `signed` timestamp.
+/// - `iaca_country`: `CountryName` for the IACA subject DN (e.g. `"DE"`).
+/// - `dsc_country`: `CountryName` for the DSC subject DN (e.g. `"FR"`).
+/// - `iaca_state`: `stateOrProvinceName` for the IACA subject DN (e.g. `"California"`).
+/// - `dsc_state`: `stateOrProvinceName` for the DSC subject DN (e.g. `"NewYork"`).
+fn build_chain_params(
+    include_dsc_eku: bool,
+    dsc_validity: Option<(time::OffsetDateTime, time::OffsetDateTime)>,
+    iaca_country: Option<&str>,
+    dsc_country: Option<&str>,
+    iaca_state: Option<&str>,
+    dsc_state: Option<&str>,
+) -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+    let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["IACA Root".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    if let Some(c) = iaca_country {
+        iaca_params.distinguished_name.push(DnType::CountryName, c);
+    }
+    if let Some(s) = iaca_state {
+        iaca_params
+            .distinguished_name
+            .push(DnType::StateOrProvinceName, s);
+    }
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("self-signed IACA cert must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("aws-lc-rs DSC key generation must succeed");
+
+    let dsc_pkcs8 = dsc_aws_key.to_pkcs8_der();
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading aws-lc-rs key into rcgen must succeed");
+
+    // Default DSC validity: 396-day window that covers the minimal_mso_cbor() signed date.
+    let (not_before, not_after) = dsc_validity.unwrap_or_else(|| {
+        (
+            OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse"),
+            OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse"),
+        )
+    });
+
+    let mut dsc_params = CertificateParams::new(vec!["DSC".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    if include_dsc_eku {
+        dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    }
+    if let Some(c) = dsc_country {
+        dsc_params.distinguished_name.push(DnType::CountryName, c);
+    }
+    if let Some(s) = dsc_state {
+        dsc_params
+            .distinguished_name
+            .push(DnType::StateOrProvinceName, s);
+    }
+    dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .expect("DSC signing by IACA must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, dsc_der, dsc_aws_key)
+}
+
+/// Constructs the COSE Sig_Structure (RFC 9052 §4.4) and signs it with
+/// `signing_key`, then assembles a raw `IssuerSigned` CBOR payload suitable
+/// for `ParsedMdoc::parse`.
+///
+/// The unprotected header carries `x5chain` (label 33) as an array of two
+/// DER-encoded certs: `[dsc_der, iaca_der]`.
+///
+/// If `tamper` is `true` the COSE signature bytes are altered after signing so
+/// that signature verification fails while the payload structure remains valid.
+fn build_issuer_signed_with_issuer_auth(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    signing_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+    tamper: bool,
+) -> String {
+    // {1: -7} (ES256), CBOR-encoded: a1 01 26
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x26];
+
+    // RFC 9052 §4.4 Sig_Structure: ["Signature1", protected_bstr, external_aad, payload]
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]), // external AAD = b""
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+
+    let sig_bytes = signing_key
+        .sign_sha256(&tbs)
+        .expect("COSE signing must succeed");
+
+    // Flip one byte so signature verification fails while CBOR structure stays intact.
+    let final_sig: Vec<u8> = if tamper {
+        let mut corrupted = sig_bytes.to_vec();
+        corrupted[0] ^= 0xff;
+        corrupted
+    } else {
+        sig_bytes.to_vec()
+    };
+
+    // Label 33 must be an integer key so coset parses it as Label::Int(33).
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(final_sig),
+        ])),
+    );
+
+    // Parser requires at least one namespace entry.
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+
+    let raw = cbor(&issuer_signed);
+    Base64UrlUnpadded::encode_string(&raw)
+}
+
+/// Returns the MSO payload bytes as they appear inside the COSE_Sign1 `payload` field:
+/// `Tag(24, bstr(mso_cbor))` per ISO 18013-5 §9.1.2 MobileSecurityObjectBytes.
+fn minimal_mso_cbor() -> Vec<u8> {
+    let validity_info = Value::Map(vec![
+        (
+            Value::Text("signed".into()),
+            Value::Tag(0, Box::new(Value::Text("2024-01-01T00:00:00Z".into()))),
+        ),
+        (
+            Value::Text("validFrom".into()),
+            Value::Tag(0, Box::new(Value::Text("2024-01-01T00:00:00Z".into()))),
+        ),
+        (
+            Value::Text("validUntil".into()),
+            Value::Tag(0, Box::new(Value::Text("9998-01-01T00:00:00Z".into()))),
+        ),
+    ]);
+
+    let mso = Value::Map(vec![
+        (Value::Text("version".into()), Value::Text("1.0".into())),
+        (
+            Value::Text("digestAlgorithm".into()),
+            Value::Text("SHA-256".into()),
+        ),
+        // valueDigests must have at least one namespace with at least one digest (32 bytes for SHA-256).
+        (
+            Value::Text("valueDigests".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Map(vec![(
+                    Value::Integer(0.into()),
+                    Value::Bytes(vec![0u8; 32]),
+                )]),
+            )]),
+        ),
+        // deviceKeyInfo must contain a deviceKey entry.
+        (
+            Value::Text("deviceKeyInfo".into()),
+            Value::Map(vec![(
+                Value::Text("deviceKey".into()),
+                // Minimal COSE_Key: {1: 2, -1: 1} (kty=EC2, crv=P-256)
+                Value::Map(vec![
+                    (Value::Integer(1.into()), Value::Integer(2.into())),
+                    (
+                        Value::Integer(ciborium::value::Integer::from(-1i64)),
+                        Value::Integer(1.into()),
+                    ),
+                ]),
+            )]),
+        ),
+        (
+            Value::Text("docType".into()),
+            Value::Text("org.iso.18013.5.1.mDL".into()),
+        ),
+        (Value::Text("validityInfo".into()), validity_info),
+    ]);
+
+    cbor(&Value::Tag(24, Box::new(Value::Bytes(cbor(&mso)))))
+}
+
+#[test]
+fn verify_issuer_signature_accepts_valid_chain() {
+    // Arrange
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der.clone(), &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid issuer-signed mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "valid COSE_Sign1 with trusted chain must be accepted, got: {result:?}"
+    );
+    let info = result.unwrap();
+    assert_eq!(
+        info.cert_chain[0], dsc_der,
+        "cert_chain[0] must be the DSC leaf certificate"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_tampered_payload() {
+    // Arrange: sign normally, then corrupt the payload bytes so the signature
+    // covers different content than what the verifier sees.
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(
+        mso_bytes,
+        dsc_der,
+        &signing_key,
+        true, // tamper = true
+    );
+    let mdoc =
+        ParsedMdoc::parse(&raw).expect("tampered mdoc must still parse (parser is not a verifier)");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("tampered payload must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidIssuerSignature),
+        "expected InvalidIssuerSignature, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_untrusted_root() {
+    // Arrange: produce a valid chain but supply a *different* CA as trust anchor.
+    let (_, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+
+    let (unrelated_iaca_der, _, _) = build_chain(true);
+    let trust_store = StaticTrustStore::new(vec![unrelated_iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("chain not anchored to trusted root must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidCertificateChain { .. }),
+        "expected InvalidCertificateChain, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_missing_eku() {
+    // Arrange: DSC is validly signed by IACA but lacks the ISO 18013-5 EKU OID.
+    let (iaca_der, dsc_der, signing_key) = build_chain(false); // no EKU
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("DSC without ISO 18013-5 EKU must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MissingDocSignerEku),
+        "expected MissingDocSignerEku, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_missing_x5chain() {
+    // Arrange: build an IssuerSigned where the unprotected header has NO x5chain entry.
+    let (iaca_der, _dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x26];
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+    let sig_bytes = signing_key.sign_sha256(&tbs).expect("signing must succeed");
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            Value::Map(vec![]), // empty unprotected header
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+    let raw = Base64UrlUnpadded::encode_string(&cbor(&issuer_signed));
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc without x5chain must still parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("missing x5chain must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MissingX5Chain),
+        "expected MissingX5Chain, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_doctype_mismatch() {
+    // Arrange: MSO has docType "org.iso.18013.5.1.mDL" but outer_doc_type differs.
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act: pass a different outer_doc_type.
+    let err = verify_issuer_signature(&mdoc, "com.example.other.doctype", &trust_store)
+        .expect_err("docType mismatch must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DocTypeMismatch { .. }),
+        "expected DocTypeMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_signed_outside_dsc_validity() {
+    // Arrange: DSC valid 2025-01-01..2025-12-31 (365 days < 457-day max), but the MSO
+    // signed timestamp is "2024-01-01T00:00:00Z" — before the DSC notBefore.
+    let (iaca_der, dsc_der, signing_key) = build_chain_params(
+        true,
+        Some((
+            OffsetDateTime::parse("2025-01-01T00:00:00Z", &Rfc3339).expect("date must parse"),
+            OffsetDateTime::parse("2025-12-31T23:59:59Z", &Rfc3339).expect("date must parse"),
+        )),
+        None,
+        None,
+        None,
+        None,
+    );
+    let mso_bytes = minimal_mso_cbor(); // signed = "2024-01-01T00:00:00Z"
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("MSO signed before DSC notBefore must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::SignedOutsideDscValidity { .. }),
+        "expected SignedOutsideDscValidity, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_country_mismatch() {
+    // Arrange: IACA subject C=DE, DSC subject C=FR — country mismatch (ISO 18013-5 §9.3.3).
+    let (iaca_der, dsc_der, signing_key) =
+        build_chain_params(true, None, Some("DE"), Some("FR"), None, None);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("DSC/IACA country mismatch must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::CountryMismatch { .. }),
+        "expected CountryMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_dsc_validity_too_long() {
+    // Arrange: DSC notBefore=2024-01-01, notAfter=2025-04-04 → 459 days > 457-day maximum.
+    // MSO signed="2024-01-01T00:00:00Z" = DSC notBefore (would be within-window if allowed).
+    let (iaca_der, dsc_der, signing_key) = build_chain_params(
+        true,
+        Some((
+            OffsetDateTime::parse("2024-01-01T00:00:00Z", &Rfc3339).expect("date must parse"),
+            OffsetDateTime::parse("2025-04-04T00:00:00Z", &Rfc3339).expect("date must parse"),
+        )),
+        None,
+        None,
+        None,
+        None,
+    );
+    let mso_bytes = minimal_mso_cbor(); // signed = "2024-01-01T00:00:00Z"
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("DSC with 459-day validity must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidCertificateChain { .. }),
+        "expected InvalidCertificateChain (457-day limit exceeded), got: {err:?}"
+    );
+}
+
+/// Builds an IACA root and DSC cert chain backed by P-521 keys (ES512 / -36).
+///
+/// Returns `(iaca_der, dsc_der, dsc_signing_key)` where the signing key uses
+/// `cloud_wallet_crypto::ecdsa::Curve::P521`.
+fn build_chain_p521() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+
+    let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["IACA Root P521".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("self-signed IACA cert must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P521)
+            .expect("aws-lc-rs P-521 key generation must succeed");
+
+    let dsc_pkcs8 = dsc_aws_key.to_pkcs8_der();
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P521_SHA512,
+    )
+    .expect("loading P-521 key into rcgen must succeed");
+
+    let not_before =
+        OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse");
+    let not_after =
+        OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse");
+
+    let mut dsc_params = CertificateParams::new(vec!["DSC P521".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    dsc_params
+        .distinguished_name
+        .push(DnType::CommonName, "DSC P521");
+    dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .expect("DSC P-521 signing by IACA must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, dsc_der, dsc_aws_key)
+}
+
+/// Like [`build_issuer_signed_with_issuer_auth`] but uses the ES512 algorithm (-36).
+///
+/// Protected header encodes `{1: -36}` and the payload is signed with SHA-512.
+fn build_issuer_signed_with_issuer_auth_es512(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    signing_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> String {
+    // {1: -36} (ES512), CBOR-encoded: a1 01 38 23
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x38, 0x23];
+
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+
+    let sig_bytes = signing_key
+        .sign_sha512(&tbs)
+        .expect("ES512 COSE signing must succeed");
+
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+
+    let raw = cbor(&issuer_signed);
+    Base64UrlUnpadded::encode_string(&raw)
+}
+
+#[test]
+fn verify_issuer_signature_accepts_valid_es512() {
+    // Arrange: P-521 key pair, real ES512 signature, proper chain and EKU.
+    let (iaca_der, dsc_der, signing_key) = build_chain_p521();
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth_es512(mso_bytes, dsc_der.clone(), &signing_key);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid ES512 issuer-signed mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "valid ES512 COSE_Sign1 with trusted chain must be accepted, got: {result:?}"
+    );
+    let info = result.unwrap();
+    assert_eq!(
+        info.cert_chain[0], dsc_der,
+        "cert_chain[0] must be the DSC leaf certificate"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_state_mismatch() {
+    // Arrange: IACA subject ST=California, DSC subject ST=NewYork — state mismatch (ISO 18013-5 §9.3.3).
+    let (iaca_der, dsc_der, signing_key) =
+        build_chain_params(true, None, None, None, Some("California"), Some("NewYork"));
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("DSC/IACA state mismatch must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::StateMismatch { .. }),
+        "expected StateMismatch, got: {err:?}"
+    );
+}
+
+/// Builds a chain where the DSC has a Key Usage extension but the `digitalSignature`
+/// bit is NOT set (only `ContentCommitment`), exercising the key-usage rejection path.
+fn build_chain_dsc_wrong_key_usage() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+
+    let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["IACA Root".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("self-signed IACA cert must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("aws-lc-rs DSC key generation must succeed");
+
+    let dsc_pkcs8 = dsc_aws_key.to_pkcs8_der();
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading key into rcgen must succeed");
+
+    let not_before =
+        OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse");
+    let not_after =
+        OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse");
+
+    let mut dsc_params =
+        CertificateParams::new(vec!["DSC Wrong KU".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    // Key Usage extension IS present, but digitalSignature bit is NOT set.
+    dsc_params.key_usages = vec![KeyUsagePurpose::ContentCommitment];
+    dsc_params
+        .distinguished_name
+        .push(DnType::CommonName, "DSC Wrong KU");
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .expect("DSC signing must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, dsc_der, dsc_aws_key)
+}
+
+#[test]
+fn verify_issuer_signature_rejects_missing_key_usage() {
+    // Arrange: DSC carries a Key Usage extension but only ContentCommitment is set —
+    // the digitalSignature bit required by ISO 18013-5 Annex B Table B.3 is absent.
+    let (iaca_der, dsc_der, signing_key) = build_chain_dsc_wrong_key_usage();
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("DSC without digitalSignature key usage must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MissingDigitalSignatureKeyUsage),
+        "expected MissingDigitalSignatureKeyUsage, got: {err:?}"
+    );
+}
+
+// ── New helpers and tests added to improve coverage ─────────────────────────
+
+/// Builds an `IssuerSigned` where the x5chain unprotected header value is a
+/// single `bstr` rather than `[bstr]`.  Per RFC 9360 §2 both forms are valid.
+fn build_issuer_signed_single_bstr_x5chain(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    signing_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> String {
+    // {1: -7} (ES256)
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x26];
+
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+    let sig_bytes = signing_key
+        .sign_sha256(&tbs)
+        .expect("COSE signing must succeed");
+
+    // Single bstr — no wrapping array.
+    let unprotected_map = Value::Map(vec![(Value::Integer(33.into()), Value::Bytes(dsc_der))]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+/// Builds an `IssuerSigned` with a multi-cert x5chain `[dsc, …]` (leaf-first).
+///
+/// The protected header is fixed to ES256; the signature covers `mso_bytes`
+/// using `signing_key`.
+fn build_issuer_signed_with_chain_x5chain(
+    mso_bytes: Vec<u8>,
+    cert_chain: Vec<Vec<u8>>,
+    signing_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> String {
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x26];
+
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+    let sig_bytes = signing_key
+        .sign_sha256(&tbs)
+        .expect("COSE signing must succeed");
+
+    let chain_vals: Vec<Value> = cert_chain.into_iter().map(Value::Bytes).collect();
+    let unprotected_map = Value::Map(vec![(Value::Integer(33.into()), Value::Array(chain_vals))]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+/// Builds an `IssuerSigned` with an arbitrary raw protected-header CBOR blob and
+/// a dummy (zero-filled) COSE signature.  Intended for tests that verify errors
+/// that fire before signature verification (e.g. unsupported algorithm).
+fn build_issuer_signed_with_custom_alg(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    protected_header_bytes: Vec<u8>,
+) -> String {
+    // Dummy 64-byte signature — error fires in dispatch_verify before verification.
+    let dummy_sig = vec![0u8; 64];
+
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(dummy_sig),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+    Base64UrlUnpadded::encode_string(&cbor(&issuer_signed))
+}
+
+/// Builds a three-tier certificate chain: IACA root → Intermediate CA → DSC.
+///
+/// Returns `(iaca_der, intermediate_der, dsc_der, dsc_signing_key)`.
+fn build_three_cert_chain() -> (
+    Vec<u8>,
+    Vec<u8>,
+    Vec<u8>,
+    cloud_wallet_crypto::ecdsa::KeyPair,
+) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+
+    // IACA root (self-signed CA)
+    let iaca_key = rcgen::KeyPair::generate().expect("IACA key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["Three-tier IACA Root".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("IACA self-sign must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    // Intermediate CA (signed by IACA root)
+    let int_key = rcgen::KeyPair::generate().expect("Intermediate CA key generation must succeed");
+    let mut int_params =
+        CertificateParams::new(vec!["Three-tier Intermediate CA".to_string()]).expect("int params");
+    int_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let int_cert = int_params
+        .signed_by(&int_key, &iaca_cert, &iaca_key)
+        .expect("Intermediate CA signing must succeed");
+    let int_der: Vec<u8> = int_cert.der().to_vec();
+
+    // DSC (signed by Intermediate CA)
+    let dsc_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("aws-lc-rs DSC key generation must succeed");
+
+    let dsc_pkcs8 = dsc_aws_key.to_pkcs8_der();
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading aws-lc-rs key into rcgen must succeed");
+
+    let not_before =
+        OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse");
+    let not_after =
+        OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse");
+
+    let mut dsc_params =
+        CertificateParams::new(vec!["Three-tier DSC".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &int_cert, &int_key)
+        .expect("DSC signing by Intermediate CA must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, int_der, dsc_der, dsc_aws_key)
+}
+
+// ── BLOCKING-2: signed timestamp after DSC notAfter ──────────────────────────
+
+#[test]
+fn verify_issuer_signature_rejects_signed_after_dsc_expiry() {
+    // Arrange: DSC validity window 2023-01-01..2023-06-30 (170 days, well under the
+    // 457-day limit).  The minimal_mso_cbor() fixture has signed = "2024-01-01",
+    // which is after notAfter (2023-06-30), so check_signed_within_dsc_validity
+    // must reject the credential.
+    let (iaca_der, dsc_der, signing_key) = build_chain_params(
+        true,
+        Some((
+            OffsetDateTime::parse("2023-01-01T00:00:00Z", &Rfc3339).expect("fixed date must parse"),
+            OffsetDateTime::parse("2023-06-30T23:59:59Z", &Rfc3339).expect("fixed date must parse"),
+        )),
+        None,
+        None,
+        None,
+        None,
+    );
+    let mso_bytes = minimal_mso_cbor(); // signed = "2024-01-01" — after notAfter
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("MSO signed after DSC notAfter must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::SignedOutsideDscValidity { .. }),
+        "expected SignedOutsideDscValidity, got: {err:?}"
+    );
+}
+
+// ── NB-10: single-bstr x5chain ───────────────────────────────────────────────
+
+#[test]
+fn verify_issuer_signature_accepts_single_bstr_x5chain() {
+    // RFC 9360 §2 permits x5chain to be either a single bstr or an array of
+    // bstr.  Both forms must be accepted.
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_single_bstr_x5chain(mso_bytes, dsc_der, &signing_key);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "credential with single-bstr x5chain must be accepted: {result:?}"
+    );
+}
+
+// ── NB-11: multi-cert chain (IACA → IntCA → DSC) ─────────────────────────────
+
+#[test]
+fn verify_issuer_signature_accepts_intermediate_ca_chain() {
+    // x5chain = [dsc_der, int_der] (leaf first; IACA root not included per
+    // ISO 18013-5 Annex B §B.1).  validate_cert_chain must walk the full path.
+    let (iaca_der, int_der, dsc_der, signing_key) = build_three_cert_chain();
+    let mso_bytes = minimal_mso_cbor();
+    let raw =
+        build_issuer_signed_with_chain_x5chain(mso_bytes, vec![dsc_der, int_der], &signing_key);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "three-cert chain with valid intermediate must be accepted: {result:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_tampered_intermediate() {
+    // Replace the real intermediate with a fresh IACA root (different key).
+    // chain[0].verify_signature(chain[1].public_key()) will fail because the
+    // DSC was signed by the real intermediate, not by the replacement.
+    let (iaca_der, _int_der, dsc_der, signing_key) = build_three_cert_chain();
+
+    // A fresh IACA cert has a different key — use it as the "wrong intermediate".
+    let (wrong_cert_der, _, _) = build_chain(true);
+
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_chain_x5chain(
+        mso_bytes,
+        vec![dsc_der, wrong_cert_der],
+        &signing_key,
+    );
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc must still parse structurally");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("chain with wrong intermediate must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidCertificateChain { .. }),
+        "expected InvalidCertificateChain, got: {err:?}"
+    );
+}
+
+// ── NB-12: empty trust store ──────────────────────────────────────────────────
+
+#[test]
+fn verify_issuer_signature_rejects_empty_trust_store() {
+    // An empty trust store cannot anchor any chain.
+    let (_iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_with_issuer_auth(mso_bytes, dsc_der, &signing_key, false);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![]); // empty
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("empty trust store must reject all chains");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidCertificateChain { .. }),
+        "expected InvalidCertificateChain, got: {err:?}"
+    );
+}
+
+// ── NB-13: Brainpool P-256/P-384/P-512 algorithm identifiers ─────────────────
+//
+// Algorithm IDs -38, -47, -48 (Brainpool) must be recognised by read_cose_alg
+// and reach dispatch_verify, which returns UnsupportedAlgorithm immediately.
+// The credential structure must otherwise be valid (chain, EKU, etc.) so the
+// error comes from dispatch_verify, not from an earlier check.
+//
+// CBOR protected header encoding:
+//   {1: -38} = a1 01 38 25   (Brainpool P-256r1)
+//   {1: -47} = a1 01 38 2e   (Brainpool P-384r1)
+//   {1: -48} = a1 01 38 2f   (Brainpool P-512r1)
+
+#[test]
+fn verify_issuer_signature_rejects_brainpool_p256_algorithm() {
+    let (iaca_der, dsc_der, _) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -38} CBOR = a1 01 38 25
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x38, 0x25]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with Brainpool P-256 alg must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("Brainpool P-256 must be rejected as unsupported");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedAlgorithm { alg: -38 }),
+        "expected UnsupportedAlgorithm {{ alg: -38 }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_brainpool_p384_algorithm() {
+    let (iaca_der, dsc_der, _) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -47} CBOR = a1 01 38 2e
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x38, 0x2e]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with Brainpool P-384 alg must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("Brainpool P-384 must be rejected as unsupported");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedAlgorithm { alg: -47 }),
+        "expected UnsupportedAlgorithm {{ alg: -47 }}, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_issuer_signature_rejects_brainpool_p512_algorithm() {
+    let (iaca_der, dsc_der, _) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -48} CBOR = a1 01 38 2f
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x38, 0x2f]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with Brainpool P-512 alg must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("Brainpool P-512 must be rejected as unsupported");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedAlgorithm { alg: -48 }),
+        "expected UnsupportedAlgorithm {{ alg: -48 }}, got: {err:?}"
+    );
+}
+
+// ── NB-4: IACA root present in x5chain ────────────────────────────────────────
+
+#[test]
+fn verify_issuer_signature_rejects_iaca_root_in_x5chain() {
+    // ISO 18013-5 Annex B §B.1: the IACA root must NOT appear in x5chain.
+    // Placing it as the second entry causes validate_cert_chain to find the
+    // trusted root inside the chain and reject the credential.
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+    // chain = [dsc_der, iaca_der] — IACA root is present as the second entry.
+    let raw = build_issuer_signed_with_chain_x5chain(
+        mso_bytes,
+        vec![dsc_der, iaca_der.clone()],
+        &signing_key,
+    );
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with IACA root in chain must still parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("IACA root present in x5chain must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::InvalidCertificateChain { .. }),
+        "expected InvalidCertificateChain, got: {err:?}"
+    );
+}
+
+// ── NB-5: Ed448 public key rejected ──────────────────────────────────────────
+
+/// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
+/// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
+///
+/// `rcgen 0.13` does not support Ed448 key generation, so the certificate is built from
+/// raw DER.  The public key payload is all-zeros (57 bytes) — sufficient for the Ed448
+/// OID check in `verify_issuer_signature`, which fires before any key-payload check.
+fn build_ed448_dsc_manual(
+    iaca_cert_der: &[u8],
+    iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> Vec<u8> {
+    use x509_parser::prelude::{FromDer as _, X509Certificate};
+
+    // Extract the IACA subject DER bytes — these become the DSC issuer field.
+    let (_, iaca_x509) =
+        X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
+    let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
+
+    // ── Minimal DER helpers ──────────────────────────────────────────────────
+    fn len_bytes(n: usize) -> Vec<u8> {
+        if n < 128 {
+            vec![n as u8]
+        } else if n < 256 {
+            vec![0x81, n as u8]
+        } else {
+            vec![0x82, (n >> 8) as u8, (n & 0xff) as u8]
+        }
+    }
+    fn tlv(tag: u8, body: Vec<u8>) -> Vec<u8> {
+        let mut v = vec![tag];
+        v.extend(len_bytes(body.len()));
+        v.extend(body);
+        v
+    }
+    fn seq(body: Vec<u8>) -> Vec<u8> {
+        tlv(0x30, body)
+    }
+    fn set(body: Vec<u8>) -> Vec<u8> {
+        tlv(0x31, body)
+    }
+    fn ctx_explicit(n: u8, body: Vec<u8>) -> Vec<u8> {
+        tlv(0xa0 | n, body)
+    }
+    fn oid(components: &[u64]) -> Vec<u8> {
+        fn base128(mut n: u64) -> Vec<u8> {
+            if n == 0 {
+                return vec![0];
+            }
+            let mut b = Vec::new();
+            while n > 0 {
+                b.push((n & 0x7f) as u8);
+                n >>= 7;
+            }
+            b.reverse();
+            for i in 0..b.len() - 1 {
+                b[i] |= 0x80;
+            }
+            b
+        }
+        let mut bytes = base128(components[0] * 40 + components[1]);
+        for &c in &components[2..] {
+            bytes.extend(base128(c));
+        }
+        tlv(0x06, bytes)
+    }
+    fn integer_pos(b: Vec<u8>) -> Vec<u8> {
+        let mut content = b;
+        if content.first().map_or(false, |&x| x & 0x80 != 0) {
+            content.insert(0, 0);
+        }
+        tlv(0x02, content)
+    }
+    fn bit_str(data: Vec<u8>) -> Vec<u8> {
+        let mut c = vec![0x00]; // 0 unused bits
+        c.extend(data);
+        tlv(0x03, c)
+    }
+    fn octet_str(b: Vec<u8>) -> Vec<u8> {
+        tlv(0x04, b)
+    }
+    fn bool_true() -> Vec<u8> {
+        vec![0x01, 0x01, 0xff]
+    }
+    fn utc_time(s: &'static str) -> Vec<u8> {
+        tlv(0x17, s.as_bytes().to_vec())
+    }
+
+    // ── Build TBSCertificate ─────────────────────────────────────────────────
+    let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
+    let serial = integer_pos(vec![0x01]); // serialNumber = 1
+    let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
+    let validity = seq({
+        let mut b = utc_time("231201000000Z");
+        b.extend(utc_time("241231235959Z"));
+        b
+    });
+    let subject = seq(set(seq({
+        let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
+        b.extend(tlv(0x0c, b"Ed448DSC".to_vec())); // UTF8String
+        b
+    })));
+    let spki = seq({
+        let mut b = seq(oid(&[1, 3, 101, 113])); // id-Ed448, no params
+        b.extend(bit_str(vec![0u8; 57])); // fake 57-byte public key
+        b
+    });
+    // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
+    let eku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 37]);
+        b.extend(bool_true());
+        // ExtKeyUsageSyntax ::= SEQUENCE SIZE (1..MAX) OF KeyPurposeId
+        b.extend(octet_str(seq(oid(&[1, 0, 18013, 5, 1, 2]))));
+        b
+    });
+    // keyUsage (2.5.29.15), critical, digitalSignature bit set
+    let ku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 15]);
+        b.extend(bool_true());
+        b.extend(octet_str(tlv(0x03, vec![0x07, 0x80]))); // BIT STRING: 7 unused, bit 0
+        b
+    });
+    let extensions = ctx_explicit(
+        3,
+        seq({
+            let mut b = eku_ext;
+            b.extend(ku_ext);
+            b
+        }),
+    );
+    let tbs = seq({
+        let mut b = version;
+        b.extend(serial);
+        b.extend(sig_alg_id.clone());
+        b.extend(issuer_raw);
+        b.extend(validity);
+        b.extend(subject);
+        b.extend(spki);
+        b.extend(extensions);
+        b
+    });
+
+    // Sign TBSCertificate with the IACA's P-256 key (ASN.1 DER encoding for X.509).
+    let mut sig_buf = [0u8; 80]; // P-256 ASN.1 ECDSA signature is at most ~72 bytes
+    let sig = iaca_key
+        .sign_sha256_asn1(&tbs, &mut sig_buf)
+        .expect("ECDSA-P256 signing of TBSCertificate must succeed");
+
+    // Assemble full Certificate = SEQUENCE { TBSCertificate, AlgorithmIdentifier, BIT STRING }
+    seq({
+        let mut b = tbs;
+        b.extend(sig_alg_id);
+        b.extend(bit_str(sig.to_vec()));
+        b
+    })
+}
+
+/// Builds a P-256 IACA root and a minimal Ed448 DSC signed by that root.
+///
+/// `rcgen 0.13` does not support Ed448 key generation; the DSC is assembled from raw
+/// DER via [`build_ed448_dsc_manual`].  The DSC's SPKI holds OID `1.3.101.113`
+/// (id-Ed448) with a fake public key — sufficient to exercise the OID rejection check.
+fn build_ed448_dsc_chain() -> (Vec<u8>, Vec<u8>) {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa};
+
+    // Use cloud_wallet_crypto key so we can sign the TBSCertificate for the DSC.
+    let iaca_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("P-256 IACA key generation must succeed");
+
+    let iaca_pkcs8 = iaca_aws_key.to_pkcs8_der();
+    let iaca_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            iaca_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading P-256 key into rcgen must succeed");
+
+    let mut iaca_params =
+        CertificateParams::new(vec!["Ed448 Test IACA".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_rcgen_key)
+        .expect("IACA self-sign must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_der = build_ed448_dsc_manual(&iaca_der, &iaca_aws_key);
+
+    (iaca_der, dsc_der)
+}
+
+#[test]
+fn verify_issuer_signature_rejects_ed448_algorithm() {
+    // Ed448 (OID 1.3.101.113) is not supported even when the COSE alg field is
+    // EdDSA (-8). The check fires after chain validation but before the crypto
+    // backend, so a dummy signature is sufficient to reach the rejection.
+    let (iaca_der, dsc_der) = build_ed448_dsc_chain();
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -8} (EdDSA) protected header: a1 01 27
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x27]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with Ed448 DSC must still parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let err = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store)
+        .expect_err("Ed448 DSC must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedAlgorithm { alg: -8 }),
+        "expected UnsupportedAlgorithm {{ alg: -8 }}, got: {err:?}"
+    );
+}
+
+// ── NB-6: ES384 and Ed25519 happy-path tests ──────────────────────────────────
+
+/// Builds an IACA root (P-256) and a DSC backed by a P-384 key (ES384 / -35).
+///
+/// Returns `(iaca_der, dsc_der, dsc_signing_key)`.
+fn build_chain_p384() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ecdsa::KeyPair) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+
+    let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["IACA Root P384".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("self-signed IACA cert must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P384)
+            .expect("aws-lc-rs P-384 key generation must succeed");
+
+    let dsc_pkcs8 = dsc_aws_key.to_pkcs8_der();
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P384_SHA384,
+    )
+    .expect("loading P-384 key into rcgen must succeed");
+
+    let not_before =
+        OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse");
+    let not_after =
+        OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse");
+
+    let mut dsc_params = CertificateParams::new(vec!["DSC P384".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .expect("DSC P-384 signing by IACA must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, dsc_der, dsc_aws_key)
+}
+
+/// Like [`build_issuer_signed_with_issuer_auth`] but uses the ES384 algorithm (-35).
+///
+/// Protected header encodes `{1: -35}` and the payload is signed with SHA-384.
+fn build_issuer_signed_es384(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    signing_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> String {
+    // {1: -35} (ES384), CBOR-encoded: a1 01 38 22
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x38, 0x22];
+
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+
+    let sig_bytes = signing_key
+        .sign_sha384(&tbs)
+        .expect("ES384 COSE signing must succeed");
+
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+
+    let raw = cbor(&issuer_signed);
+    Base64UrlUnpadded::encode_string(&raw)
+}
+
+#[test]
+fn verify_issuer_signature_accepts_valid_es384() {
+    // Arrange: P-384 key pair, real ES384 signature, proper chain and EKU.
+    let (iaca_der, dsc_der, signing_key) = build_chain_p384();
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_es384(mso_bytes, dsc_der.clone(), &signing_key);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid ES384 issuer-signed mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "valid ES384 COSE_Sign1 with trusted chain must be accepted, got: {result:?}"
+    );
+    let info = result.unwrap();
+    assert_eq!(
+        info.cert_chain[0], dsc_der,
+        "cert_chain[0] must be the DSC leaf certificate"
+    );
+}
+
+/// Builds an IACA root (P-256) and a DSC backed by an Ed25519 key.
+///
+/// Returns `(iaca_der, dsc_der, dsc_signing_key)`.
+fn build_chain_ed25519() -> (Vec<u8>, Vec<u8>, cloud_wallet_crypto::ed25519::KeyPair) {
+    use rcgen::{
+        BasicConstraints, CertificateParams, ExtendedKeyUsagePurpose, IsCa, KeyUsagePurpose,
+    };
+
+    let iaca_key = rcgen::KeyPair::generate().expect("rcgen key generation must succeed");
+    let mut iaca_params =
+        CertificateParams::new(vec!["IACA Root Ed25519".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_key)
+        .expect("self-signed IACA cert must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_aws_key = cloud_wallet_crypto::ed25519::KeyPair::generate()
+        .expect("aws-lc-rs Ed25519 key generation must succeed");
+
+    let mut pkcs8_buf = [0u8; 128];
+    let dsc_pkcs8 = dsc_aws_key
+        .to_pkcs8_der(&mut pkcs8_buf)
+        .expect("Ed25519 PKCS#8 export must succeed");
+    let dsc_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            dsc_pkcs8.to_vec(),
+        )),
+        &rcgen::PKCS_ED25519,
+    )
+    .expect("loading Ed25519 key into rcgen must succeed");
+
+    let not_before =
+        OffsetDateTime::parse("2023-12-01T00:00:00Z", &Rfc3339).expect("fixed date must parse");
+    let not_after =
+        OffsetDateTime::parse("2024-12-31T23:59:59Z", &Rfc3339).expect("fixed date must parse");
+
+    let mut dsc_params =
+        CertificateParams::new(vec!["DSC Ed25519".to_string()]).expect("dsc params");
+    dsc_params.is_ca = IsCa::NoCa;
+    dsc_params.not_before = not_before;
+    dsc_params.not_after = not_after;
+    dsc_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::Other(DSC_EKU_OID.to_vec())];
+    dsc_params.key_usages = vec![KeyUsagePurpose::DigitalSignature];
+    let dsc_cert = dsc_params
+        .signed_by(&dsc_rcgen_key, &iaca_cert, &iaca_key)
+        .expect("DSC Ed25519 signing by IACA must succeed");
+    let dsc_der: Vec<u8> = dsc_cert.der().to_vec();
+
+    (iaca_der, dsc_der, dsc_aws_key)
+}
+
+/// Like [`build_issuer_signed_with_issuer_auth`] but uses the EdDSA algorithm (-8)
+/// with an Ed25519 signing key.
+///
+/// Protected header encodes `{1: -8}` and the TBS is signed directly by `signing_key`.
+fn build_issuer_signed_ed25519(
+    mso_bytes: Vec<u8>,
+    dsc_der: Vec<u8>,
+    signing_key: &cloud_wallet_crypto::ed25519::KeyPair,
+) -> String {
+    // {1: -8} (EdDSA), CBOR-encoded: a1 01 27
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x27];
+
+    let tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]),
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+
+    let sig_bytes = signing_key.sign(&tbs);
+
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+
+    let cose_sign1 = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1),
+    ]);
+
+    let raw = cbor(&issuer_signed);
+    Base64UrlUnpadded::encode_string(&raw)
+}
+
+#[test]
+fn verify_issuer_signature_accepts_valid_ed25519() {
+    // Arrange: Ed25519 key pair, real EdDSA signature, proper chain and EKU.
+    let (iaca_der, dsc_der, signing_key) = build_chain_ed25519();
+    let mso_bytes = minimal_mso_cbor();
+    let raw = build_issuer_signed_ed25519(mso_bytes, dsc_der.clone(), &signing_key);
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid Ed25519 issuer-signed mdoc must parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    // Act
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "valid EdDSA/Ed25519 COSE_Sign1 with trusted chain must be accepted, got: {result:?}"
+    );
+    let info = result.unwrap();
+    assert_eq!(
+        info.cert_chain[0], dsc_der,
+        "cert_chain[0] must be the DSC leaf certificate"
     );
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -3053,3 +3053,83 @@ fn verify_issuer_signature_accepts_valid_ed25519() {
         "cert_chain[0] must be the DSC leaf certificate"
     );
 }
+
+#[test]
+fn tbs_data_preserves_original_protected_header_bytes() {
+    // Arrange
+    let (iaca_der, dsc_der, signing_key) = build_chain(true);
+    let mso_bytes = minimal_mso_cbor();
+
+    // {1: -7} (ES256), CBOR-encoded: a1 01 26 — these are the exact bytes the parser
+    // will store as CoseSign1::protected::original_data.
+    let protected_header_bytes: Vec<u8> = vec![0xa1, 0x01, 0x26];
+
+    // RFC 9052 §4.4 Sig_Structure: ["Signature1", protected_bstr, external_aad, payload]
+    let expected_tbs = cbor(&Value::Array(vec![
+        Value::Text("Signature1".into()),
+        Value::Bytes(protected_header_bytes.clone()),
+        Value::Bytes(vec![]), // external AAD = b""
+        Value::Bytes(mso_bytes.clone()),
+    ]));
+
+    let sig_bytes = signing_key
+        .sign_sha256(&expected_tbs)
+        .expect("signing must succeed in tests");
+
+    let unprotected_map = Value::Map(vec![(
+        Value::Integer(33.into()),
+        Value::Array(vec![Value::Bytes(dsc_der)]),
+    )]);
+    let cose_sign1_val = Value::Tag(
+        18,
+        Box::new(Value::Array(vec![
+            Value::Bytes(protected_header_bytes),
+            unprotected_map,
+            Value::Bytes(mso_bytes),
+            Value::Bytes(sig_bytes.to_vec()),
+        ])),
+    );
+    let item = Value::Map(vec![
+        (Value::Text("digestID".into()), Value::Integer(0u64.into())),
+        (Value::Text("random".into()), Value::Bytes(vec![0u8; 16])),
+        (
+            Value::Text("elementIdentifier".into()),
+            Value::Text("family_name".into()),
+        ),
+        (
+            Value::Text("elementValue".into()),
+            Value::Text("Doe".into()),
+        ),
+    ]);
+    let item_tag24 = Value::Tag(24, Box::new(Value::Bytes(cbor(&item))));
+    let issuer_signed = Value::Map(vec![
+        (
+            Value::Text("nameSpaces".into()),
+            Value::Map(vec![(
+                Value::Text("org.iso.18013.5.1".into()),
+                Value::Array(vec![item_tag24]),
+            )]),
+        ),
+        (Value::Text("issuerAuth".into()), cose_sign1_val),
+    ]);
+    let raw = Base64UrlUnpadded::encode_string(&cbor(&issuer_signed));
+    let mdoc = ParsedMdoc::parse(&raw).expect("valid mdoc must parse");
+
+    // Act: ask coset for the Sig_Structure it will use for verification.
+    let actual_tbs = mdoc.cose_sign1.tbs_data(b"");
+
+    // Assert: byte-exact match confirms no re-encoding occurred between parse and verify.
+    assert_eq!(
+        actual_tbs, expected_tbs,
+        "tbs_data() must return the same byte sequence as the manually-constructed Sig_Structure"
+    );
+
+    // End-to-end confirmation: the signature was created over `expected_tbs`; if
+    // tbs_data() had re-encoded the header, verification would fail with InvalidIssuerSignature.
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+    let result = verify_issuer_signature(&mdoc, "org.iso.18013.5.1.mDL", &trust_store);
+    assert!(
+        result.is_ok(),
+        "signature over original protected-header bytes must verify: {result:?}"
+    );
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -2625,7 +2625,7 @@ fn build_ed448_dsc_manual(
     }
     fn integer_pos(b: Vec<u8>) -> Vec<u8> {
         let mut content = b;
-        if content.first().map_or(false, |&x| x & 0x80 != 0) {
+        if content.first().is_some_and(|&x| x & 0x80 != 0) {
             content.insert(0, 0);
         }
         tlv(0x02, content)

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -1,39 +1,45 @@
-//! Digest integrity verification for ISO 18013-5 mDoc credentials.
+//! Digest integrity and issuer signature verification for ISO 18013-5 mDoc credentials.
 //!
-//! This module implements the `valueDigests` check described in ISO/IEC 18013-5 §9.1.2:
-//! every `IssuerSignedItem` must hash (under the algorithm named in the MSO
-//! `digestAlgorithm` field) to the corresponding entry in `valueDigests`.
-//!
-//! # Crypto backend
-//!
-//! Hashing is performed via [`cloud_wallet_crypto::digest::HashAlg`], which delegates to
-//! `aws_lc_rs::digest`. No separate `sha2` crate is used.
-//!
-//! # Constant-time comparison
-//!
-//! The computed digest is compared against the stored value with
-//! [`subtle::ConstantTimeEq`] to prevent timing-oracle attacks (OWASP A02).
+//! Implements [`verify_digests`] (MSO digest check) and [`verify_issuer_signature`]
+//! (COSE_Sign1 + certificate chain validation) as required by ISO/IEC 18013-5 §9.1.2.
 
+use ciborium::Value;
+use coset::Label;
+use coset::iana::EnumI64 as _;
 use subtle::ConstantTimeEq as _;
 
 use cloud_wallet_crypto::digest::HashAlg;
+use cloud_wallet_crypto::ecdsa::VerifyingKey as EcdsaKey;
+use cloud_wallet_crypto::ed25519::VerifyingKey as Ed25519Key;
+use x509_parser::prelude::{FromDer as _, X509Certificate};
 
+use super::cert_chain::{
+    check_country_consistency, check_dsc_eku, check_dsc_key_usage, check_dsc_validity_period,
+    check_signed_within_dsc_validity, extract_spki, validate_cert_chain,
+};
 use super::error::{MdocError, Result};
 use super::parser::ParsedMdoc;
 
+/// COSE unprotected header label for the X.509 certificate chain (RFC 9360).
+const X5CHAIN_LABEL: i64 = 33;
+
+/// COSE algorithm identifier for ES256 (ECDSA P-256 + SHA-256).
+const ALG_ES256: i64 = -7;
+/// COSE algorithm identifier for ES384 (ECDSA P-384 + SHA-384).
+const ALG_ES384: i64 = -35;
+/// COSE algorithm identifier for ES512 (ECDSA P-521 + SHA-512).
+const ALG_ES512: i64 = -36;
+/// COSE algorithm identifier for EdDSA / Ed25519.
+const ALG_EDDSA: i64 = -8;
+/// COSE algorithm identifier for ECDSA on Brainpool P-256r1 (ISO 18013-5 Annex B).
+const ALG_BRAINPOOL_P256: i64 = -38;
+/// COSE algorithm identifier for ECDSA on Brainpool P-384r1 (ISO 18013-5 Annex B).
+const ALG_BRAINPOOL_P384: i64 = -47;
+/// COSE algorithm identifier for ECDSA on Brainpool P-512r1 (ISO 18013-5 Annex B).
+const ALG_BRAINPOOL_P512: i64 = -48;
+
 /// Verifies that every `IssuerSignedItem` in `parsed` hashes to its corresponding
 /// entry in the MSO `valueDigests` map (ISO/IEC 18013-5 §9.1.2).
-///
-/// # Algorithm selection
-///
-/// The algorithm is determined by [`ParsedMdoc::digest_algorithm`], which the parser
-/// has already validated. The conversion to [`HashAlg`] is infallible.
-///
-/// # Selective disclosure
-///
-/// Only items present in `name_spaces` (the disclosed set) are checked.
-/// Entries in `value_digests` with no corresponding disclosed item are intentionally
-/// skipped — selective disclosure is explicitly permitted by ISO/IEC 18013-5 §9.1.2.
 ///
 /// # Errors
 ///
@@ -57,12 +63,8 @@ pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
                     digest_id: item.digest_id,
                 })?;
 
-            // `parse_value_digests` enforces that every stored digest has exactly
-            // `digest_algorithm.digest_size()` bytes; `aws_lc_rs::digest` always
-            // produces the same fixed output length. Both slices are therefore
-            // guaranteed equal-length, so `ct_eq` runs in unconditional constant
-            // time over all N content bytes — `subtle` only provides constant-time
-            // behaviour when both slices have the same length.
+            // Both slices are guaranteed equal-length, so ct_eq runs in constant
+            // time over all bytes (subtle only guarantees this for equal-length inputs).
             let digest_ok: bool = computed.as_ref().ct_eq(stored.as_slice()).into();
             if !digest_ok {
                 return Err(MdocError::DigestMismatch {
@@ -74,4 +76,264 @@ pub fn verify_digests(parsed: &ParsedMdoc) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// A source of trusted IACA root certificates used to validate the `issuerAuth`
+/// certificate chain (ISO 18013-5 §9.1.2).
+///
+/// Implement this trait to plug in any trust store backend: a static list of DER
+/// bytes loaded at startup, a database-backed store, or a per-tenant store.
+///
+/// The `Send + Sync` bounds allow the trust store to be shared across threads and
+/// passed as `&dyn IacaTrustStore` through async contexts.
+pub trait IacaTrustStore: Send + Sync {
+    /// Returns the DER-encoded trusted IACA root certificates.
+    fn trusted_roots(&self) -> &[Vec<u8>];
+}
+
+/// A simple trust store backed by an in-memory list of DER-encoded root certificates.
+///
+/// Suitable for tests and deployments where roots are known at compile time or loaded
+/// from disk at startup.
+#[derive(Clone, Debug)]
+pub struct StaticTrustStore {
+    roots: Vec<Vec<u8>>,
+}
+
+impl StaticTrustStore {
+    /// Creates a new [`StaticTrustStore`] from a list of DER-encoded root certificates.
+    pub fn new(roots: Vec<Vec<u8>>) -> Self {
+        Self { roots }
+    }
+}
+
+impl IacaTrustStore for StaticTrustStore {
+    fn trusted_roots(&self) -> &[Vec<u8>] {
+        &self.roots
+    }
+}
+
+/// Information about the issuer extracted from a successfully verified `issuerAuth`.
+///
+/// Returned by [`verify_issuer_signature`] after the full verification pipeline
+/// (chain validation, EKU check, signature check) succeeds.
+#[derive(Debug)]
+pub struct IssuerInfo {
+    /// Full certificate chain as DER bytes, leaf-first (index 0 is the DSC).
+    pub cert_chain: Vec<Vec<u8>>,
+
+    /// Subject distinguished name of the Document Signer Certificate as a
+    /// human-readable string (e.g. `"C=DE, O=Example Issuer, CN=DSC-01"`).
+    pub issuer_subject: String,
+
+    /// ISO 3166-1 alpha-2 country code from the DSC subject `CountryName` attribute,
+    /// or an empty string if the attribute is absent.
+    pub issuer_country: String,
+}
+
+/// Verifies the `issuerAuth` COSE_Sign1 signature against a trusted IACA certificate chain
+/// (ISO/IEC 18013-5 §9.1.2): chain validation, EKU/key-usage check, docType match,
+/// validity-window check, and signature verification.
+///
+/// The DSC (`chain[0]`) is parsed once and the parsed certificate is passed to all
+/// per-certificate helpers, avoiding redundant DER parsing.
+///
+/// # Parameters
+///
+/// - `outer_doc_type`: the `docType` from the enclosing document structure, checked
+///   against the MSO `docType` field (§9.3.1 step 4).
+///
+/// # Errors
+///
+/// - [`MdocError::MissingAlgorithm`] — algorithm field is absent or is not an integer label.
+/// - [`MdocError::UnsupportedAlgorithm`] — alg is not ES256 (-7), ES384 (-35),
+///   ES512 (-36), or EdDSA/Ed25519 (-8).
+/// - [`MdocError::MissingX5Chain`] — COSE unprotected header label 33 is absent.
+/// - [`MdocError::InvalidCertificateChain`] — chain is malformed, untrusted, the IACA
+///   root appears in the chain, or the DSC validity period exceeds 457 days.
+/// - [`MdocError::CountryMismatch`] — DSC and IACA have different country codes.
+/// - [`MdocError::MissingDocSignerEku`] — DSC does not carry OID 1.0.18013.5.1.2.
+/// - [`MdocError::DocTypeMismatch`] — outer `docType` differs from MSO `docType`.
+/// - [`MdocError::SignedOutsideDscValidity`] — MSO `signed` is outside DSC validity.
+/// - [`MdocError::InvalidIssuerSignature`] — signature does not verify.
+///
+/// # Known Limitations
+///
+/// Certificate revocation (CRL / OCSP) is not checked. A credential signed by a revoked
+/// DSC will pass all current checks.
+#[must_use = "issuer signature verification failure must be handled"]
+pub fn verify_issuer_signature(
+    parsed: &ParsedMdoc,
+    outer_doc_type: &str,
+    trust_store: &dyn IacaTrustStore,
+) -> Result<IssuerInfo> {
+    let alg = read_cose_alg(parsed)?;
+
+    // x5chain is a leaf-first CBOR bstr array (RFC 9360 §2); chain[0] is the DSC.
+    let chain = extract_x5chain(parsed)?;
+
+    // validate_cert_chain returns the specific anchoring root DER so that subsequent
+    // checks (e.g. country-code consistency) are performed against that root alone,
+    // not against every root in the trust store (which would incorrectly fail in a
+    // multi-country trust store).
+    let anchoring_root_der = validate_cert_chain(&chain, trust_store.trusted_roots())?;
+
+    // Parse the DSC exactly once and pass the parsed certificate to all helpers.
+    let (_, dsc) =
+        X509Certificate::from_der(&chain[0]).map_err(|e| MdocError::InvalidCertificateChain {
+            reason: format!("failed to parse DSC: {e}"),
+        })?;
+
+    // DSC validity period must not exceed 457 days (ISO 18013-5 Annex B Table B.3).
+    check_dsc_validity_period(&dsc)?;
+
+    // DSC subject country must match the anchoring IACA country (ISO 18013-5 §9.3.3).
+    check_country_consistency(&dsc, &anchoring_root_der)?;
+
+    check_dsc_eku(&dsc)?;
+
+    // digitalSignature key usage bit required by ISO 18013-5 Annex B Table B.3.
+    check_dsc_key_usage(&dsc)?;
+
+    if parsed.doc_type != outer_doc_type {
+        return Err(MdocError::DocTypeMismatch {
+            mso: parsed.doc_type.clone(),
+            document: outer_doc_type.to_owned(),
+        });
+    }
+
+    // tbs_data uses the wire bytes of the protected header (original_data) so we
+    // never re-encode and silently change the byte sequence that was signed.
+    let tbs = parsed.cose_sign1.tbs_data(b"");
+
+    // MSO signed timestamp must fall within the DSC validity window (ISO 18013-5 §9.3.1).
+    check_signed_within_dsc_validity(&dsc, parsed.signed_at)?;
+
+    let spki = extract_spki(&dsc);
+    let sig = &parsed.cose_sign1.signature;
+
+    // Reject Ed448 (OID 1.3.101.113) before dispatch; only Ed25519 (OID 1.3.101.112)
+    // is supported.  Checking the OID via the properly-parsed SubjectPublicKeyInfo
+    // (already available in `dsc`) is safe against SPKI byte patterns that happen to
+    // contain the OID bytes at a non-OID position.
+    const ED448_OID: &str = "1.3.101.113";
+    if alg == ALG_EDDSA && dsc.public_key().algorithm.algorithm.to_id_string() == ED448_OID {
+        return Err(MdocError::UnsupportedAlgorithm { alg });
+    }
+
+    dispatch_verify(alg, &spki, &tbs, sig)?;
+
+    let issuer_subject = dsc.subject().to_string();
+    let issuer_country = dsc
+        .subject()
+        .iter_country()
+        .next()
+        .and_then(|a| a.as_str().ok())
+        .unwrap_or("")
+        .to_owned();
+
+    Ok(IssuerInfo {
+        cert_chain: chain,
+        issuer_subject,
+        issuer_country,
+    })
+}
+
+/// Reads the COSE algorithm integer from the `issuerAuth` protected header.
+fn read_cose_alg(parsed: &ParsedMdoc) -> Result<i64> {
+    use coset::RegisteredLabelWithPrivate;
+
+    let alg = parsed
+        .cose_sign1
+        .protected
+        .header
+        .alg
+        .as_ref()
+        .ok_or(MdocError::MissingAlgorithm)?;
+
+    let alg_i64 = match alg {
+        RegisteredLabelWithPrivate::Assigned(a) => a.to_i64(),
+        RegisteredLabelWithPrivate::PrivateUse(i) => *i,
+        RegisteredLabelWithPrivate::Text(_) => {
+            // A text-label algorithm cannot be an integer COSE algorithm identifier.
+            return Err(MdocError::MissingAlgorithm);
+        }
+    };
+
+    match alg_i64 {
+        ALG_ES256 | ALG_ES384 | ALG_ES512 | ALG_EDDSA | ALG_BRAINPOOL_P256 | ALG_BRAINPOOL_P384
+        | ALG_BRAINPOOL_P512 => Ok(alg_i64),
+        other => Err(MdocError::UnsupportedAlgorithm { alg: other }),
+    }
+}
+
+/// Extracts the DER-encoded certificate chain from COSE unprotected header label 33.
+///
+/// Per RFC 9360 §2, the value is either a single bstr (single cert) or an array of
+/// bstr (chain, leaf first).  We normalise both forms to `Vec<Vec<u8>>`.
+fn extract_x5chain(parsed: &ParsedMdoc) -> Result<Vec<Vec<u8>>> {
+    let x5chain_val = parsed
+        .cose_sign1
+        .unprotected
+        .rest
+        .iter()
+        .find(|(label, _)| *label == Label::Int(X5CHAIN_LABEL))
+        .map(|(_, v)| v)
+        .ok_or(MdocError::MissingX5Chain)?;
+
+    match x5chain_val {
+        // Single certificate (bstr).
+        Value::Bytes(der) => Ok(vec![der.clone()]),
+
+        // Certificate chain: array of bstr, leaf first.
+        Value::Array(entries) => {
+            let chain: Option<Vec<Vec<u8>>> = entries
+                .iter()
+                .map(|v| match v {
+                    Value::Bytes(b) => Some(b.clone()),
+                    _ => None,
+                })
+                .collect();
+            chain.ok_or(MdocError::MissingX5Chain)
+        }
+
+        _ => Err(MdocError::MissingX5Chain),
+    }
+}
+
+/// Dispatches the COSE signature verification to the correct crypto backend.
+fn dispatch_verify(alg: i64, spki: &[u8], tbs: &[u8], signature: &[u8]) -> Result<()> {
+    match alg {
+        ALG_ES256 => {
+            let key =
+                EcdsaKey::from_spki_der(spki).map_err(|_| MdocError::InvalidIssuerSignature)?;
+            key.verify_sha256(tbs, signature)
+                .map_err(|_| MdocError::InvalidIssuerSignature)
+        }
+        ALG_ES384 => {
+            let key =
+                EcdsaKey::from_spki_der(spki).map_err(|_| MdocError::InvalidIssuerSignature)?;
+            key.verify_sha384(tbs, signature)
+                .map_err(|_| MdocError::InvalidIssuerSignature)
+        }
+        ALG_ES512 => {
+            let key =
+                EcdsaKey::from_spki_der(spki).map_err(|_| MdocError::InvalidIssuerSignature)?;
+            key.verify_sha512(tbs, signature)
+                .map_err(|_| MdocError::InvalidIssuerSignature)
+        }
+        ALG_EDDSA => {
+            // Ed448 is rejected earlier in `verify_issuer_signature` via the parsed OID.
+            // By the time we reach here the key is guaranteed to be Ed25519.
+            let key =
+                Ed25519Key::from_spki_der(spki).map_err(|_| MdocError::InvalidIssuerSignature)?;
+            key.verify(tbs, signature)
+                .map_err(|_| MdocError::InvalidIssuerSignature)
+        }
+        // TODO: Brainpool P-256r1/P-384r1/P-512r1 (ISO 18013-5 Annex B) — not yet supported.
+        ALG_BRAINPOOL_P256 | ALG_BRAINPOOL_P384 | ALG_BRAINPOOL_P512 => {
+            Err(MdocError::UnsupportedAlgorithm { alg })
+        }
+        _ => unreachable!("dispatch_verify received alg={alg} — not handled in read_cose_alg"),
+    }
 }


### PR DESCRIPTION
Implements the full ISO/IEC 18013-5 §9.3.1 issuer authentication pipeline for
`mso_mdoc` credentials. Verification Pipeline

```
algorithm check → x5chain extraction → cert chain validation → DSC checks
→ docType match → Sig_Structure → timestamp check → signature verification
```

## Tests

56 tests, all passing. Covers: ES256/ES384/ES512/Ed25519 happy paths,
tampered payload, untrusted root, missing EKU, missing key usage, missing x5chain,
docType mismatch, country/state mismatch, DSC validity too long, signed before
notBefore, signed after notAfter, single-bstr x5chain, three-cert chain,
tampered intermediate, empty trust store, IACA root in x5chain, Ed448 rejection,
Brainpool P-256/P-384/P-512 stubs.

## Known Gaps (tracked, not blocking)

- **Brainpool** — mandatory per Table 22, blocked on `aws-lc-rs`. Required for EU/eIDAS. #242 
- **Ed448** — mandatory per Table 22, `aws-lc-rs` supports it, deferred. 
- **CRL/OCSP revocation** — §9.3.3 says "shall have access to" (not per-call check). Deferred.
