### PR TITLE
Feat/device key holder binding verification for iso mdoc credentials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,14 +74,8 @@ async-stream = "0.3"
 async-trait.workspace = true
 axum = { version = "0.8", features = ["macros"] }
 base64.workspace = true
-cloud-wallet-crypto = {
-  path = "crates/cloud-wallet-crypto",
-  features = ["jwk"]
-}
-cloud-wallet-kms = {
-  path = "crates/cloud-wallet-kms",
-  features = ["local-kms"]
-}
+cloud-wallet-crypto = { path = "crates/cloud-wallet-crypto", features = ["jwk"] }
+cloud-wallet-kms = { path = "crates/cloud-wallet-kms", features = ["local-kms"] }
 cloud-wallet-openid4vc = { path = "crates/cloud-wallet-openid4vc" }
 color-eyre.workspace = true
 config = "0.15"
@@ -98,10 +92,7 @@ serde_qs = "1.1"
 serde_with.workspace = true
 thiserror.workspace = true
 time = { workspace = true, features = ["formatting", "serde"] }
-tokio = {
-  version = "1",
-  features = ["macros", "net", "rt-multi-thread", "time"]
-}
+tokio = { version = "1", features = ["macros", "net", "rt-multi-thread", "time"] }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
@@ -132,10 +123,7 @@ features = [
 rcgen.workspace = true
 reqwest = { version = "0.13", features = ["json"] }
 serde_json = { workspace = true }
-testcontainers-modules = {
-  version = "0.15",
-  features = ["mysql", "postgres", "redis"]
-}
+testcontainers-modules = { version = "0.15", features = ["mysql", "postgres", "redis"] }
 tower = { version = "0.5", features = ["util"] }
 webpki.workspace = true
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
@@ -304,4 +304,64 @@ pub enum MdocError {
         /// The `docType` string from the outer document.
         document: String,
     },
+
+    /// The CBOR bytes in `deviceKeyInfo.deviceKey` could not be decoded as a valid COSE_Key.
+    ///
+    /// Covers: the bytes are not valid CBOR; the top-level value is not a map; a required
+    /// integer label (kty=1, crv=−1, x=−2, y=−3) is absent; or a label's value has the
+    /// wrong CBOR type (e.g. x is not a bstr).
+    ///
+    /// ISO/IEC 18013-5 §9.1.2.4 — `DeviceKeyInfo.deviceKey` structure.
+    /// RFC 8152 §13.1 — EC2 COSE_Key parameters.
+    #[error("malformed COSE_Key in deviceKeyInfo: {reason}")]
+    MalformedDeviceKey {
+        /// Human-readable description of the structural defect.
+        reason: String,
+    },
+
+    /// The COSE_Key `kty`/`crv` combination is not supported for device-key binding,
+    /// or the proof JWK carries an incompatible key type.
+    ///
+    /// Specific cases that trigger this variant:
+    /// - `kty` is not `2` (EC2) and not `1` (OKP).
+    /// - `kty=2` (EC2) but `crv` is not P-256 (1), P-384 (2), or P-521 (3).
+    /// - `kty=1` (OKP) but `crv` is not Ed25519 (6).
+    /// - `kty=2` (EC2) and the `y` parameter is a `bool` (compressed EC2 point); direct
+    ///   byte comparison requires the uncompressed form.
+    /// - The proof JWK `key` variant is not `Key::Ec` or `Key::Okp { crv: Ed25519 }`.
+    ///
+    /// RFC 8152 §13.1 (EC2), §13.2 (OKP).
+    /// ISO/IEC 18013-5 §9.1.5.2 Table 22 — permitted device-key curves.
+    #[error("unsupported device key type or curve")]
+    UnsupportedDeviceKeyType,
+
+    /// The curve identified in the COSE_Key does not match the curve in the proof JWK.
+    ///
+    /// Both keys must name the same curve; a mismatch means the credential was issued
+    /// for a different key type than the holder presented in their proof JWT.
+    ///
+    /// OID4VCI Appendix A.2 — holder binding via proof JWT.
+    #[error("device key curve mismatch: COSE key uses {cose_crv}, proof JWK uses {jwk_crv}")]
+    CurveMismatch {
+        /// Curve name from the COSE_Key `crv` parameter (e.g. `"P-256"`).
+        cose_crv: String,
+        /// Curve name from the proof JWK (e.g. `"P-384"`).
+        jwk_crv: String,
+    },
+
+    /// The public key embedded in the MSO `deviceKeyInfo` does not match the holder's
+    /// proof JWK.
+    ///
+    /// Both keys parsed correctly and their curves agree, but the constant-time comparison
+    /// of one or more coordinates (x, or x and y for EC2) failed. This indicates either a
+    /// key-substitution attack by the issuer or a logic error — the credential must be
+    /// rejected.
+    ///
+    /// Comparison is performed with `subtle::ConstantTimeEq` to prevent timing side channels.
+    /// Which coordinate failed is intentionally not reported.
+    ///
+    /// ISO/IEC 18013-5 §9.1.2.4 — `DeviceKeyInfo.deviceKey`.
+    /// OID4VCI Appendix A.2 — holder binding via proof JWT.
+    #[error("MSO device key does not match proof JWK")]
+    DeviceKeyMismatch,
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -21,8 +21,8 @@ pub mod verifier;
 pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
 pub use verifier::{
-    IacaTrustStore, IssuerInfo, StaticTrustStore,
-    verify_device_key_binding, verify_digests, verify_issuer_signature,
+    IacaTrustStore, IssuerInfo, StaticTrustStore, verify_device_key_binding, verify_digests,
+    verify_issuer_signature,
 };
 
 use cloud_wallet_crypto::digest::HashAlg;

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/mod.rs
@@ -21,7 +21,8 @@ pub mod verifier;
 pub use error::{MdocError, Result};
 pub use parser::{IssuerSignedItem, ParsedMdoc};
 pub use verifier::{
-    IacaTrustStore, IssuerInfo, StaticTrustStore, verify_digests, verify_issuer_signature,
+    IacaTrustStore, IssuerInfo, StaticTrustStore,
+    verify_device_key_binding, verify_digests, verify_issuer_signature,
 };
 
 use cloud_wallet_crypto::digest::HashAlg;

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -1,4 +1,4 @@
-use base64ct::{Base64UrlUnpadded, Encoding as _};
+﻿use base64ct::{Base64UrlUnpadded, Encoding as _};
 use ciborium::Value;
 use cloud_wallet_crypto::digest::HashAlg;
 use cloud_wallet_crypto::jwk::{B64, Curve, Ec, Jwk, Key, Okp, OkpCurve, Parameters};
@@ -2352,6 +2352,8 @@ fn verify_issuer_signature_rejects_signed_after_dsc_expiry() {
     );
 }
 
+
+
 #[test]
 fn verify_issuer_signature_accepts_single_bstr_x5chain() {
     // RFC 9360 §2 permits x5chain to be either a single bstr or an array of
@@ -2371,6 +2373,8 @@ fn verify_issuer_signature_accepts_single_bstr_x5chain() {
         "credential with single-bstr x5chain must be accepted: {result:?}"
     );
 }
+
+─
 
 #[test]
 fn verify_issuer_signature_accepts_intermediate_ca_chain() {
@@ -2423,6 +2427,7 @@ fn verify_issuer_signature_rejects_tampered_intermediate() {
     );
 }
 
+
 #[test]
 fn verify_issuer_signature_rejects_empty_trust_store() {
     // An empty trust store cannot anchor any chain.
@@ -2443,6 +2448,8 @@ fn verify_issuer_signature_rejects_empty_trust_store() {
     );
 }
 
+
+//
 // Algorithm IDs -38, -47, -48 (Brainpool) must be recognised by read_cose_alg
 // and reach dispatch_verify, which returns UnsupportedAlgorithm immediately.
 // The credential structure must otherwise be valid (chain, EKU, etc.) so the
@@ -2540,6 +2547,8 @@ fn verify_issuer_signature_rejects_iaca_root_in_x5chain() {
     );
 }
 
+──
+
 /// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
 /// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
 ///
@@ -2625,6 +2634,7 @@ fn build_ed448_dsc_manual(
         tlv(0x17, s.as_bytes().to_vec())
     }
 
+ 
     let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
     let serial = integer_pos(vec![0x01]); // serialNumber = 1
     let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
@@ -2750,6 +2760,8 @@ fn verify_issuer_signature_rejects_ed448_algorithm() {
         "expected UnsupportedAlgorithm {{ alg: -8 }}, got: {err:?}"
     );
 }
+
+
 
 /// Builds an IACA root (P-256) and a DSC backed by a P-384 key (ES384 / -35).
 ///
@@ -3111,7 +3123,7 @@ fn tbs_data_preserves_original_protected_header_bytes() {
     );
 }
 
-// ── device-key binding tests ─────────────────────────────────────────────────
+
 
 /// Builds a fresh `ParsedMdoc` and overwrites its `device_key` with `cose_key`,
 /// keeping the rest of the document valid and within its validity window.
@@ -3423,5 +3435,4 @@ fn verify_device_key_binding_rejects_mismatched_ed25519_x() {
         "expected DeviceKeyMismatch, got: {err:?}"
     );
 }
-    );
-}
+   

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -1,13 +1,14 @@
 use base64ct::{Base64UrlUnpadded, Encoding as _};
 use ciborium::Value;
 use cloud_wallet_crypto::digest::HashAlg;
+use cloud_wallet_crypto::jwk::{B64, Curve, Ec, Jwk, Key, Okp, OkpCurve, Parameters};
 use time::OffsetDateTime;
 use time::format_description::well_known::Rfc3339;
 
 use super::DigestAlgorithm;
 use super::error::MdocError;
 use super::parser::ParsedMdoc;
-use super::verifier::{StaticTrustStore, verify_digests, verify_issuer_signature};
+use super::verifier::{StaticTrustStore, verify_device_key_binding, verify_digests, verify_issuer_signature};
 
 // CBOR construction helpers
 
@@ -3107,5 +3108,320 @@ fn tbs_data_preserves_original_protected_header_bytes() {
     assert!(
         result.is_ok(),
         "signature over original protected-header bytes must verify: {result:?}"
+    );
+}
+
+// ── device-key binding tests ─────────────────────────────────────────────────
+
+/// Builds a fresh `ParsedMdoc` and overwrites its `device_key` with `cose_key`,
+/// keeping the rest of the document valid and within its validity window.
+fn parsed_with_device_key(cose_key: Value) -> ParsedMdoc {
+    let mut parsed =
+        ParsedMdoc::parse(&build_issuer_signed("2020-01-01T00:00:00Z", "9998-01-01T00:00:00Z"))
+            .expect("base mdoc must parse");
+    parsed.device_key = cbor(&cose_key);
+    parsed
+}
+
+#[test]
+fn verify_device_key_binding_passes_matching_p256_key() {
+    // Arrange
+    let x_bytes = vec![1u8; 32];
+    let y_bytes = vec![2u8; 32];
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(x_bytes.clone())),
+        (Value::Integer((-3i64).into()), Value::Bytes(y_bytes.clone())),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(x_bytes),
+            y: B64::new(y_bytes),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let result = verify_device_key_binding(&parsed, &proof_jwk);
+
+    // Assert
+    assert!(result.is_ok(), "matching P-256 keys must pass, got: {result:?}");
+}
+
+#[test]
+fn verify_device_key_binding_rejects_mismatched_x_coordinate() {
+    // Arrange
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![9u8; 32]), // different x
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("mismatched x must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DeviceKeyMismatch),
+        "expected DeviceKeyMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_mismatched_y_coordinate() {
+    // Arrange
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![9u8; 32]), // different y
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("mismatched y must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DeviceKeyMismatch),
+        "expected DeviceKeyMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_different_key_entirely() {
+    // Arrange
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![3u8; 32]),
+            y: B64::new(vec![4u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("completely different key must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DeviceKeyMismatch),
+        "expected DeviceKeyMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_curve_mismatch() {
+    // Arrange: COSE_Key uses P-384 (crv=2, 48-byte coordinates).
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(2i64.into())), // P-384
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 48])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 48])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    // JWK claims P-256 — curve mismatch.
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("curve mismatch must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::CurveMismatch { .. }),
+        "expected CurveMismatch, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_malformed_cose_key() {
+    // Arrange: `device_key` contains invalid CBOR bytes.
+    let mut parsed =
+        ParsedMdoc::parse(&build_issuer_signed("2020-01-01T00:00:00Z", "9998-01-01T00:00:00Z"))
+            .expect("base mdoc must parse");
+    parsed.device_key = vec![0xffu8]; // 0xff is not valid initial CBOR
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![0u8; 32]),
+            y: B64::new(vec![0u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("malformed COSE_Key bytes must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MalformedDeviceKey { .. }),
+        "expected MalformedDeviceKey, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_malformed_jwk() {
+    // Arrange: COSE_Key is EC2/P-256 but the proof JWK is an OKP X25519 key — incompatible.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Okp(Okp {
+            crv: OkpCurve::X25519,
+            x: B64::new(vec![1u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("EC2 COSE_Key against non-EC proof JWK must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedDeviceKeyType),
+        "expected UnsupportedDeviceKeyType, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_unknown_curve() {
+    // Arrange: COSE_Key has kty=2 (EC2) but crv=99 — an unrecognised curve integer.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(99i64.into())), // unknown crv
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("unknown COSE_Key curve must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedDeviceKeyType),
+        "expected UnsupportedDeviceKeyType, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_passes_matching_ed25519_key() {
+    // Arrange: COSE_Key kty=1 (OKP), crv=6 (Ed25519), x=[5u8;32].
+    let x_bytes = vec![5u8; 32];
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(1i64.into())), // kty=OKP
+        (Value::Integer((-1i64).into()), Value::Integer(6i64.into())), // crv=Ed25519
+        (Value::Integer((-2i64).into()), Value::Bytes(x_bytes.clone())),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Okp(Okp {
+            crv: OkpCurve::Ed25519,
+            x: B64::new(x_bytes),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let result = verify_device_key_binding(&parsed, &proof_jwk);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "matching Ed25519 keys must pass, got: {result:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_mismatched_ed25519_x() {
+    // Arrange: COSE x=[5u8;32] but JWK x=[9u8;32].
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(1i64.into())),
+        (Value::Integer((-1i64).into()), Value::Integer(6i64.into())),
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![5u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Okp(Okp {
+            crv: OkpCurve::Ed25519,
+            x: B64::new(vec![9u8; 32]), // different x
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("mismatched Ed25519 x must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::DeviceKeyMismatch),
+        "expected DeviceKeyMismatch, got: {err:?}"
+    );
+}
     );
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests.rs
@@ -1,4 +1,4 @@
-﻿use base64ct::{Base64UrlUnpadded, Encoding as _};
+use base64ct::{Base64UrlUnpadded, Encoding as _};
 use ciborium::Value;
 use cloud_wallet_crypto::digest::HashAlg;
 use cloud_wallet_crypto::jwk::{B64, Curve, Ec, Jwk, Key, Okp, OkpCurve, Parameters};
@@ -8,7 +8,9 @@ use time::format_description::well_known::Rfc3339;
 use super::DigestAlgorithm;
 use super::error::MdocError;
 use super::parser::ParsedMdoc;
-use super::verifier::{StaticTrustStore, verify_device_key_binding, verify_digests, verify_issuer_signature};
+use super::verifier::{
+    StaticTrustStore, verify_device_key_binding, verify_digests, verify_issuer_signature,
+};
 
 // CBOR construction helpers
 
@@ -2352,8 +2354,6 @@ fn verify_issuer_signature_rejects_signed_after_dsc_expiry() {
     );
 }
 
-
-
 #[test]
 fn verify_issuer_signature_accepts_single_bstr_x5chain() {
     // RFC 9360 §2 permits x5chain to be either a single bstr or an array of
@@ -2373,8 +2373,6 @@ fn verify_issuer_signature_accepts_single_bstr_x5chain() {
         "credential with single-bstr x5chain must be accepted: {result:?}"
     );
 }
-
-─
 
 #[test]
 fn verify_issuer_signature_accepts_intermediate_ca_chain() {
@@ -2427,7 +2425,6 @@ fn verify_issuer_signature_rejects_tampered_intermediate() {
     );
 }
 
-
 #[test]
 fn verify_issuer_signature_rejects_empty_trust_store() {
     // An empty trust store cannot anchor any chain.
@@ -2447,7 +2444,6 @@ fn verify_issuer_signature_rejects_empty_trust_store() {
         "expected InvalidCertificateChain, got: {err:?}"
     );
 }
-
 
 //
 // Algorithm IDs -38, -47, -48 (Brainpool) must be recognised by read_cose_alg
@@ -2547,8 +2543,6 @@ fn verify_issuer_signature_rejects_iaca_root_in_x5chain() {
     );
 }
 
-──
-
 /// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
 /// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
 ///
@@ -2634,7 +2628,6 @@ fn build_ed448_dsc_manual(
         tlv(0x17, s.as_bytes().to_vec())
     }
 
- 
     let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
     let serial = integer_pos(vec![0x01]); // serialNumber = 1
     let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
@@ -2760,8 +2753,6 @@ fn verify_issuer_signature_rejects_ed448_algorithm() {
         "expected UnsupportedAlgorithm {{ alg: -8 }}, got: {err:?}"
     );
 }
-
-
 
 /// Builds an IACA root (P-256) and a DSC backed by a P-384 key (ES384 / -35).
 ///
@@ -3123,14 +3114,14 @@ fn tbs_data_preserves_original_protected_header_bytes() {
     );
 }
 
-
-
 /// Builds a fresh `ParsedMdoc` and overwrites its `device_key` with `cose_key`,
 /// keeping the rest of the document valid and within its validity window.
 fn parsed_with_device_key(cose_key: Value) -> ParsedMdoc {
-    let mut parsed =
-        ParsedMdoc::parse(&build_issuer_signed("2020-01-01T00:00:00Z", "9998-01-01T00:00:00Z"))
-            .expect("base mdoc must parse");
+    let mut parsed = ParsedMdoc::parse(&build_issuer_signed(
+        "2020-01-01T00:00:00Z",
+        "9998-01-01T00:00:00Z",
+    ))
+    .expect("base mdoc must parse");
     parsed.device_key = cbor(&cose_key);
     parsed
 }
@@ -3143,8 +3134,14 @@ fn verify_device_key_binding_passes_matching_p256_key() {
     let cose_key = Value::Map(vec![
         (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
         (Value::Integer((-1i64).into()), Value::Integer(1i64.into())),
-        (Value::Integer((-2i64).into()), Value::Bytes(x_bytes.clone())),
-        (Value::Integer((-3i64).into()), Value::Bytes(y_bytes.clone())),
+        (
+            Value::Integer((-2i64).into()),
+            Value::Bytes(x_bytes.clone()),
+        ),
+        (
+            Value::Integer((-3i64).into()),
+            Value::Bytes(y_bytes.clone()),
+        ),
     ]);
     let parsed = parsed_with_device_key(cose_key);
     let proof_jwk = Jwk {
@@ -3161,7 +3158,10 @@ fn verify_device_key_binding_passes_matching_p256_key() {
     let result = verify_device_key_binding(&parsed, &proof_jwk);
 
     // Assert
-    assert!(result.is_ok(), "matching P-256 keys must pass, got: {result:?}");
+    assert!(
+        result.is_ok(),
+        "matching P-256 keys must pass, got: {result:?}"
+    );
 }
 
 #[test]
@@ -3185,8 +3185,8 @@ fn verify_device_key_binding_rejects_mismatched_x_coordinate() {
     };
 
     // Act
-    let err = verify_device_key_binding(&parsed, &proof_jwk)
-        .expect_err("mismatched x must be rejected");
+    let err =
+        verify_device_key_binding(&parsed, &proof_jwk).expect_err("mismatched x must be rejected");
 
     // Assert
     assert!(
@@ -3216,8 +3216,8 @@ fn verify_device_key_binding_rejects_mismatched_y_coordinate() {
     };
 
     // Act
-    let err = verify_device_key_binding(&parsed, &proof_jwk)
-        .expect_err("mismatched y must be rejected");
+    let err =
+        verify_device_key_binding(&parsed, &proof_jwk).expect_err("mismatched y must be rejected");
 
     // Assert
     assert!(
@@ -3292,9 +3292,11 @@ fn verify_device_key_binding_rejects_curve_mismatch() {
 #[test]
 fn verify_device_key_binding_rejects_malformed_cose_key() {
     // Arrange: `device_key` contains invalid CBOR bytes.
-    let mut parsed =
-        ParsedMdoc::parse(&build_issuer_signed("2020-01-01T00:00:00Z", "9998-01-01T00:00:00Z"))
-            .expect("base mdoc must parse");
+    let mut parsed = ParsedMdoc::parse(&build_issuer_signed(
+        "2020-01-01T00:00:00Z",
+        "9998-01-01T00:00:00Z",
+    ))
+    .expect("base mdoc must parse");
     parsed.device_key = vec![0xffu8]; // 0xff is not valid initial CBOR
     let proof_jwk = Jwk {
         key: Key::Ec(Ec {
@@ -3318,7 +3320,7 @@ fn verify_device_key_binding_rejects_malformed_cose_key() {
 }
 
 #[test]
-fn verify_device_key_binding_rejects_malformed_jwk() {
+fn verify_device_key_binding_rejects_incompatible_jwk_type() {
     // Arrange: COSE_Key is EC2/P-256 but the proof JWK is an OKP X25519 key — incompatible.
     let cose_key = Value::Map(vec![
         (Value::Integer(1i64.into()), Value::Integer(2i64.into())),
@@ -3385,7 +3387,10 @@ fn verify_device_key_binding_passes_matching_ed25519_key() {
     let cose_key = Value::Map(vec![
         (Value::Integer(1i64.into()), Value::Integer(1i64.into())), // kty=OKP
         (Value::Integer((-1i64).into()), Value::Integer(6i64.into())), // crv=Ed25519
-        (Value::Integer((-2i64).into()), Value::Bytes(x_bytes.clone())),
+        (
+            Value::Integer((-2i64).into()),
+            Value::Bytes(x_bytes.clone()),
+        ),
     ]);
     let parsed = parsed_with_device_key(cose_key);
     let proof_jwk = Jwk {
@@ -3435,4 +3440,239 @@ fn verify_device_key_binding_rejects_mismatched_ed25519_x() {
         "expected DeviceKeyMismatch, got: {err:?}"
     );
 }
-   
+
+#[test]
+fn verify_device_key_binding_rejects_compressed_ec2_y() {
+    // Arrange: y is a bool — RFC 8152 §13.1 permits this for compressed EC2 points,
+    // but comparing a compressed COSE y against an uncompressed JWK y requires EC
+    // decompression which is not implemented. Reject explicitly.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())), // kty=EC2
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())), // crv=P-256
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])),
+        (Value::Integer((-3i64).into()), Value::Bool(true)), // compressed y
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("compressed y (bool) must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedDeviceKeyType),
+        "expected UnsupportedDeviceKeyType, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_passes_matching_p384_key() {
+    // Arrange: COSE_Key kty=2 (EC2), crv=2 (P-384), 48-byte coordinates.
+    let x_bytes = vec![7u8; 48];
+    let y_bytes = vec![8u8; 48];
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())), // kty=EC2
+        (Value::Integer((-1i64).into()), Value::Integer(2i64.into())), // crv=P-384
+        (
+            Value::Integer((-2i64).into()),
+            Value::Bytes(x_bytes.clone()),
+        ),
+        (
+            Value::Integer((-3i64).into()),
+            Value::Bytes(y_bytes.clone()),
+        ),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P384,
+            x: B64::new(x_bytes),
+            y: B64::new(y_bytes),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let result = verify_device_key_binding(&parsed, &proof_jwk);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "matching P-384 keys must pass, got: {result:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_okp_x25519_cose_crv() {
+    // Arrange: COSE_Key kty=1 (OKP) but crv=4 (X25519) — only Ed25519 (crv=6) is supported.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(1i64.into())), // kty=OKP
+        (Value::Integer((-1i64).into()), Value::Integer(4i64.into())), // crv=X25519
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![5u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Okp(Okp {
+            crv: OkpCurve::Ed25519,
+            x: B64::new(vec![5u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("OKP X25519 COSE crv must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::UnsupportedDeviceKeyType),
+        "expected UnsupportedDeviceKeyType, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_passes_matching_p521_key() {
+    // Arrange: COSE_Key kty=2 (EC2), crv=3 (P-521), 66-byte coordinates.
+    let x_bytes = vec![3u8; 66];
+    let y_bytes = vec![4u8; 66];
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())), // kty=EC2
+        (Value::Integer((-1i64).into()), Value::Integer(3i64.into())), // crv=P-521
+        (
+            Value::Integer((-2i64).into()),
+            Value::Bytes(x_bytes.clone()),
+        ),
+        (
+            Value::Integer((-3i64).into()),
+            Value::Bytes(y_bytes.clone()),
+        ),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P521,
+            x: B64::new(x_bytes),
+            y: B64::new(y_bytes),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let result = verify_device_key_binding(&parsed, &proof_jwk);
+
+    // Assert
+    assert!(
+        result.is_ok(),
+        "matching P-521 keys must pass, got: {result:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_duplicate_cose_key_label() {
+    // Arrange: COSE_Key has two entries with label -2 (duplicate x coordinate).
+    // RFC 7049 §3.1 forbids duplicate map keys; accepting them could enable
+    // split-key constructions where the first x matches but the second does not.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())), // kty=EC2
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())), // crv=P-256
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 32])), // x (first)
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![9u8; 32])), // x (duplicate)
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("duplicate COSE_Key label must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MalformedDeviceKey { .. }),
+        "expected MalformedDeviceKey, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_ec2_coordinate_wrong_length() {
+    // Arrange: COSE_Key claims P-256 (expected 32-byte coords) but x is only 31 bytes.
+    // The coordinate-length gate must catch this before ct_eq is called; if it did not,
+    // subtle::ConstantTimeEq would short-circuit on the length difference (non-constant-time).
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(2i64.into())), // kty=EC2
+        (Value::Integer((-1i64).into()), Value::Integer(1i64.into())), // crv=P-256
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![1u8; 31])), // x: 31 bytes (wrong)
+        (Value::Integer((-3i64).into()), Value::Bytes(vec![2u8; 32])),
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Ec(Ec {
+            crv: Curve::P256,
+            x: B64::new(vec![1u8; 32]),
+            y: B64::new(vec![2u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("EC2 coordinate with wrong length must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MalformedDeviceKey { .. }),
+        "expected MalformedDeviceKey, got: {err:?}"
+    );
+}
+
+#[test]
+fn verify_device_key_binding_rejects_ed25519_x_wrong_length() {
+    // Arrange: OKP Ed25519 COSE_Key with a 31-byte x (Ed25519 requires exactly 32 bytes).
+    // The length gate must catch this before ct_eq; subtle does not guarantee constant-time
+    // comparison for unequal-length slices.
+    let cose_key = Value::Map(vec![
+        (Value::Integer(1i64.into()), Value::Integer(1i64.into())), // kty=OKP
+        (Value::Integer((-1i64).into()), Value::Integer(6i64.into())), // crv=Ed25519
+        (Value::Integer((-2i64).into()), Value::Bytes(vec![5u8; 31])), // x: 31 bytes (wrong)
+    ]);
+    let parsed = parsed_with_device_key(cose_key);
+    let proof_jwk = Jwk {
+        key: Key::Okp(Okp {
+            crv: OkpCurve::Ed25519,
+            x: B64::new(vec![5u8; 32]),
+            d: None,
+        }),
+        prm: Parameters::default(),
+    };
+
+    // Act
+    let err = verify_device_key_binding(&parsed, &proof_jwk)
+        .expect_err("Ed25519 x with wrong length must be rejected");
+
+    // Assert
+    assert!(
+        matches!(err, MdocError::MalformedDeviceKey { .. }),
+        "expected MalformedDeviceKey, got: {err:?}"
+    );
+}

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -367,16 +367,25 @@ pub fn verify_device_key_binding(parsed: &ParsedMdoc, proof_jwk: &Jwk) -> Result
         }
     };
 
-    // Helper: find an integer-labelled entry and return its Value.
-    let get_val = |label: i64| -> Option<&Value> {
-        entries.iter().find_map(|(k, v)| match k {
-            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
-            _ => None,
-        })
-    };
+    // RFC 7049 §3.1 forbids duplicate keys in CBOR maps. Reject to prevent
+    // split-key constructions where the same integer label appears twice.
+    // COSE_Keys have at most ~6 entries; the O(n²) scan avoids a heap allocation.
+    for i in 0..entries.len() {
+        if let Value::Integer(a) = &entries[i].0 {
+            for item in entries.iter().skip(i + 1) {
+                if let Value::Integer(b) = &item.0
+                    && i128::from(*a) == i128::from(*b)
+                {
+                    return Err(MdocError::MalformedDeviceKey {
+                        reason: "COSE_Key map contains duplicate integer label".to_owned(),
+                    });
+                }
+            }
+        }
+    }
 
     // kty (label 1) — determines EC2 vs OKP dispatch.
-    let kty: i128 = match get_val(1) {
+    let kty: i128 = match cose_key_get(&entries, 1) {
         Some(Value::Integer(n)) => i128::from(*n),
         Some(_) => {
             return Err(MdocError::MalformedDeviceKey {
@@ -399,15 +408,8 @@ pub fn verify_device_key_binding(parsed: &ParsedMdoc, proof_jwk: &Jwk) -> Result
 
 /// EC2 device-key binding check (kty=2, ISO 18013-5 Table 22 NIST curves).
 fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()> {
-    let get_val = |label: i64| -> Option<&Value> {
-        entries.iter().find_map(|(k, v)| match k {
-            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
-            _ => None,
-        })
-    };
-
     // crv (label -1): map integer to (curve name string, JWK Curve variant).
-    let (cose_crv_name, jwk_curve) = match get_val(-1) {
+    let (cose_crv_name, jwk_curve) = match cose_key_get(entries, -1) {
         Some(Value::Integer(n)) => match i128::from(*n) {
             1 => ("P-256", cloud_wallet_crypto::jwk::Curve::P256),
             2 => ("P-384", cloud_wallet_crypto::jwk::Curve::P384),
@@ -427,7 +429,7 @@ fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
     };
 
     // x (label -2): must be bytes.
-    let cose_x = match get_val(-2) {
+    let cose_x = match cose_key_get(entries, -2) {
         Some(Value::Bytes(b)) => b.as_slice(),
         Some(_) => {
             return Err(MdocError::MalformedDeviceKey {
@@ -442,7 +444,7 @@ fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
     };
 
     // y (label -3): bytes (uncompressed) or bool (compressed — explicitly unsupported).
-    let cose_y = match get_val(-3) {
+    let cose_y = match cose_key_get(entries, -3) {
         Some(Value::Bytes(b)) => b.as_slice(),
         // RFC 8152 §13.1 permits y as a bool for compressed EC2 points. We cannot
         // compare compressed-only keys against the uncompressed JWK y without EC
@@ -482,7 +484,26 @@ fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
         });
     }
 
-    // Constant-time comparison — both run unconditionally to avoid timing side channels.
+    // Validate coordinate byte lengths match the curve before ct_eq: subtle's
+    // ConstantTimeEq for &[u8] short-circuits (non-constant-time) on length
+    // mismatch; an equal-length gate here guarantees the comparison is always
+    // constant-time over the full coordinate.
+    let expected_coord_len: usize = match jwk_curve {
+        cloud_wallet_crypto::jwk::Curve::P256 => 32,
+        cloud_wallet_crypto::jwk::Curve::P384 => 48,
+        cloud_wallet_crypto::jwk::Curve::P521 => 66,
+        _ => unreachable!("jwk_curve was matched from a P-256/P-384/P-521 COSE crv"),
+    };
+    if cose_x.len() != expected_coord_len
+        || cose_y.len() != expected_coord_len
+        || ec.x.as_ref().len() != expected_coord_len
+        || ec.y.as_ref().len() != expected_coord_len
+    {
+        return Err(MdocError::MalformedDeviceKey {
+            reason: "coordinate length does not match curve".to_owned(),
+        });
+    }
+    // Both slices are guaranteed equal-length; ct_eq runs in constant time over all bytes.
     let x_eq: bool = cose_x.ct_eq(ec.x.as_ref()).into();
     let y_eq: bool = cose_y.ct_eq(ec.y.as_ref()).into();
     if !x_eq || !y_eq {
@@ -494,15 +515,8 @@ fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
 
 /// OKP Ed25519 device-key binding check (kty=1, crv=6, x-only, RFC 8152 §13.2).
 fn verify_okp_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()> {
-    let get_val = |label: i64| -> Option<&Value> {
-        entries.iter().find_map(|(k, v)| match k {
-            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
-            _ => None,
-        })
-    };
-
     // crv (label -1): must be 6 (Ed25519). All other OKP curves are unsupported.
-    match get_val(-1) {
+    match cose_key_get(entries, -1) {
         Some(Value::Integer(n)) => match i128::from(*n) {
             6 => {} // Ed25519 — proceed
             _ => return Err(MdocError::UnsupportedDeviceKeyType),
@@ -520,7 +534,7 @@ fn verify_okp_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
     }
 
     // x (label -2): must be bytes. OKP has no y (RFC 8152 §13.2).
-    let cose_x = match get_val(-2) {
+    let cose_x = match cose_key_get(entries, -2) {
         Some(Value::Bytes(b)) => b.as_slice(),
         Some(_) => {
             return Err(MdocError::MalformedDeviceKey {
@@ -537,15 +551,31 @@ fn verify_okp_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()>
     // Match proof JWK — must be OKP Ed25519.
     let okp = match &proof_jwk.key {
         Key::Okp(okp) if okp.crv == OkpCurve::Ed25519 => okp,
-        Key::Okp(_) => return Err(MdocError::UnsupportedDeviceKeyType),
         _ => return Err(MdocError::UnsupportedDeviceKeyType),
     };
 
-    // Constant-time comparison on x (the sole coordinate for OKP).
+    // Ed25519 x must be exactly 32 bytes; validate before ct_eq to ensure the
+    // constant-time property holds for equal-length slices.
+    if cose_x.len() != 32 || okp.x.as_ref().len() != 32 {
+        return Err(MdocError::MalformedDeviceKey {
+            reason: "Ed25519 x coordinate must be 32 bytes".to_owned(),
+        });
+    }
+    // Both slices are guaranteed 32 bytes; ct_eq runs in constant time over all bytes.
     let x_eq: bool = cose_x.ct_eq(okp.x.as_ref()).into();
     if !x_eq {
         return Err(MdocError::DeviceKeyMismatch);
     }
 
     Ok(())
+}
+
+/// Returns the value associated with the given integer label in a COSE_Key map,
+/// or `None` if no entry with that label is present.
+#[inline]
+fn cose_key_get(entries: &[(Value, Value)], label: i64) -> Option<&Value> {
+    entries.iter().find_map(|(k, v)| match k {
+        Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
+        _ => None,
+    })
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -11,6 +11,7 @@ use subtle::ConstantTimeEq as _;
 use cloud_wallet_crypto::digest::HashAlg;
 use cloud_wallet_crypto::ecdsa::VerifyingKey as EcdsaKey;
 use cloud_wallet_crypto::ed25519::VerifyingKey as Ed25519Key;
+use cloud_wallet_crypto::jwk::{Jwk, Key, OkpCurve};
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::cert_chain::{
@@ -336,4 +337,215 @@ fn dispatch_verify(alg: i64, spki: &[u8], tbs: &[u8], signature: &[u8]) -> Resul
         }
         _ => unreachable!("dispatch_verify received alg={alg} — not handled in read_cose_alg"),
     }
+}
+
+/// Verifies that the holder public key embedded in the MSO `deviceKeyInfo.deviceKey`
+/// matches the key presented in the OID4VCI proof JWT (ISO/IEC 18013-5 §9.1.2.4).
+///
+/// # Errors
+///
+/// - [`MdocError::MalformedDeviceKey`] — COSE_Key CBOR is invalid or missing required fields.
+/// - [`MdocError::UnsupportedDeviceKeyType`] — unsupported kty/crv, compressed EC2 y, or
+///   non-EC/non-OKP proof JWK.
+/// - [`MdocError::CurveMismatch`] — COSE curve differs from proof JWK curve.
+/// - [`MdocError::DeviceKeyMismatch`] — constant-time coordinate comparison failed.
+#[must_use = "device key binding failure must be handled"]
+pub fn verify_device_key_binding(parsed: &ParsedMdoc, proof_jwk: &Jwk) -> Result<()> {
+    let cose_key_val: Value =
+        ciborium::de::from_reader(parsed.device_key.as_slice()).map_err(|_| {
+            MdocError::MalformedDeviceKey {
+                reason: "invalid CBOR".to_owned(),
+            }
+        })?;
+
+    let entries = match cose_key_val {
+        Value::Map(m) => m,
+        _ => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "COSE_Key must be a CBOR map".to_owned(),
+            });
+        }
+    };
+
+    // Helper: find an integer-labelled entry and return its Value.
+    let get_val = |label: i64| -> Option<&Value> {
+        entries.iter().find_map(|(k, v)| match k {
+            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
+            _ => None,
+        })
+    };
+
+    // kty (label 1) — determines EC2 vs OKP dispatch.
+    let kty: i128 = match get_val(1) {
+        Some(Value::Integer(n)) => i128::from(*n),
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "kty (label 1) must be an integer".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing kty (label 1)".to_owned(),
+            });
+        }
+    };
+
+    match kty {
+        2 => verify_ec2_binding(&entries, proof_jwk),
+        1 => verify_okp_binding(&entries, proof_jwk),
+        _ => Err(MdocError::UnsupportedDeviceKeyType),
+    }
+}
+
+/// EC2 device-key binding check (kty=2, ISO 18013-5 Table 22 NIST curves).
+fn verify_ec2_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()> {
+    let get_val = |label: i64| -> Option<&Value> {
+        entries.iter().find_map(|(k, v)| match k {
+            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
+            _ => None,
+        })
+    };
+
+    // crv (label -1): map integer to (curve name string, JWK Curve variant).
+    let (cose_crv_name, jwk_curve) = match get_val(-1) {
+        Some(Value::Integer(n)) => match i128::from(*n) {
+            1 => ("P-256", cloud_wallet_crypto::jwk::Curve::P256),
+            2 => ("P-384", cloud_wallet_crypto::jwk::Curve::P384),
+            3 => ("P-521", cloud_wallet_crypto::jwk::Curve::P521),
+            _ => return Err(MdocError::UnsupportedDeviceKeyType),
+        },
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "crv (label -1) must be an integer".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing crv (label -1)".to_owned(),
+            });
+        }
+    };
+
+    // x (label -2): must be bytes.
+    let cose_x = match get_val(-2) {
+        Some(Value::Bytes(b)) => b.as_slice(),
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "x coordinate (label -2) must be bytes".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing x coordinate (label -2)".to_owned(),
+            });
+        }
+    };
+
+    // y (label -3): bytes (uncompressed) or bool (compressed — explicitly unsupported).
+    let cose_y = match get_val(-3) {
+        Some(Value::Bytes(b)) => b.as_slice(),
+        // RFC 8152 §13.1 permits y as a bool for compressed EC2 points. We cannot
+        // compare compressed-only keys against the uncompressed JWK y without EC
+        // decompression. Reject explicitly rather than silently skipping.
+        Some(Value::Bool(_)) => return Err(MdocError::UnsupportedDeviceKeyType),
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "y coordinate (label -3) must be bytes or bool".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing y coordinate (label -3)".to_owned(),
+            });
+        }
+    };
+
+    // Match proof JWK against Key::Ec.
+    let ec = match &proof_jwk.key {
+        Key::Ec(ec) => ec,
+        _ => return Err(MdocError::UnsupportedDeviceKeyType),
+    };
+
+    // Curve consistency check.
+    let jwk_crv_name = match ec.crv {
+        cloud_wallet_crypto::jwk::Curve::P256 => "P-256",
+        cloud_wallet_crypto::jwk::Curve::P384 => "P-384",
+        cloud_wallet_crypto::jwk::Curve::P521 => "P-521",
+        cloud_wallet_crypto::jwk::Curve::P256K1 => "secp256k1",
+        // Curve is #[non_exhaustive]; future variants are unsupported.
+        _ => return Err(MdocError::UnsupportedDeviceKeyType),
+    };
+    if ec.crv != jwk_curve {
+        return Err(MdocError::CurveMismatch {
+            cose_crv: cose_crv_name.to_owned(),
+            jwk_crv: jwk_crv_name.to_owned(),
+        });
+    }
+
+    // Constant-time comparison — both run unconditionally to avoid timing side channels.
+    let x_eq: bool = cose_x.ct_eq(ec.x.as_ref()).into();
+    let y_eq: bool = cose_y.ct_eq(ec.y.as_ref()).into();
+    if !x_eq || !y_eq {
+        return Err(MdocError::DeviceKeyMismatch);
+    }
+
+    Ok(())
+}
+
+/// OKP Ed25519 device-key binding check (kty=1, crv=6, x-only, RFC 8152 §13.2).
+fn verify_okp_binding(entries: &[(Value, Value)], proof_jwk: &Jwk) -> Result<()> {
+    let get_val = |label: i64| -> Option<&Value> {
+        entries.iter().find_map(|(k, v)| match k {
+            Value::Integer(n) if i128::from(*n) == i128::from(label) => Some(v),
+            _ => None,
+        })
+    };
+
+    // crv (label -1): must be 6 (Ed25519). All other OKP curves are unsupported.
+    match get_val(-1) {
+        Some(Value::Integer(n)) => match i128::from(*n) {
+            6 => {} // Ed25519 — proceed
+            _ => return Err(MdocError::UnsupportedDeviceKeyType),
+        },
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "crv (label -1) must be an integer".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing crv (label -1)".to_owned(),
+            });
+        }
+    }
+
+    // x (label -2): must be bytes. OKP has no y (RFC 8152 §13.2).
+    let cose_x = match get_val(-2) {
+        Some(Value::Bytes(b)) => b.as_slice(),
+        Some(_) => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "x (label -2) must be bytes".to_owned(),
+            });
+        }
+        None => {
+            return Err(MdocError::MalformedDeviceKey {
+                reason: "missing x (label -2)".to_owned(),
+            });
+        }
+    };
+
+    // Match proof JWK — must be OKP Ed25519.
+    let okp = match &proof_jwk.key {
+        Key::Okp(okp) if okp.crv == OkpCurve::Ed25519 => okp,
+        Key::Okp(_) => return Err(MdocError::UnsupportedDeviceKeyType),
+        _ => return Err(MdocError::UnsupportedDeviceKeyType),
+    };
+
+    // Constant-time comparison on x (the sole coordinate for OKP).
+    let x_eq: bool = cose_x.ct_eq(okp.x.as_ref()).into();
+    if !x_eq {
+        return Err(MdocError::DeviceKeyMismatch);
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
The MSO (Mobile Security Object) inside every mdoc credential embeds the holder's public key (`DeviceKeyInfo.deviceKey`). During OID4VCI issuance the wallet sends its public key in the proof JWT. These two keys must match. Without this check, a malicious issuer could substitute a different public key into the MSO, binding the credential to a key the wallet does not control.

**Acceptance Criteria**

- [ ] `verify_device_key_binding(parsed, proof_jwk)` implemented in `verifier.rs`
- [ ] COSE_Key `kty`, `crv`, `x`, `y` extracted without `unwrap` or `expect`
- [ ] `y` as `bool` (compressed EC2 point) handled explicitly — not silently skipped
- [ ] Coordinate comparison uses `subtle::ConstantTimeEq` throughout
- [ ] Four new error variants added to `MdocError`
- [ ] `verify_device_key_binding` re-exported from `mdoc/mod.rs`
- [ ] All existing tests still pass
- [ ] New tests added (see below)

**Required tests:**
- `verify_device_key_binding_passes_matching_p256_key`
- `verify_device_key_binding_rejects_mismatched_x_coordinate`
- `verify_device_key_binding_rejects_mismatched_y_coordinate`
- `verify_device_key_binding_rejects_different_key_entirely`
- `verify_device_key_binding_rejects_curve_mismatch`
- `verify_device_key_binding_rejects_malformed_cose_key`
- `rejects_incompatible_jwk_type`

---

**References**
- ISO/IEC 18013-5 §9.1.2.4 - `DeviceKeyInfo` and `DeviceKey` definition
- ISO/IEC 18013-5 §9.1.5.2 -  COSE_Key structure (kty, crv, x, y params)
- RFC 8152 §13.1 - EC2 key parameters (`-1`=crv, `-2`=x, `-3`=y)
- RFC 8152 §13.2 - OKP key parameters (`-1`=crv, `-2`=x)
- OID4VCI Appendix A.2  - holder binding via proof JWT
