### PR TITLE
Feat/credential matching selection engine

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,7 +2,10 @@
 ignore = [
     # Present in rsa crate. As there is currently no available fix for this vulnerability,
     # this change temporarily ignores the advisory to allow CI/CD pipelines to pass
-    "RUSTSEC-2023-0071"
+    "RUSTSEC-2023-0071",
+    # This is caused by `proc-macro-error2`, which is a dependency of the `validator` crate and is currently unmaintained.
+    # This advisory will be ignored until the validator crate is updated to use a maintained version of proc-macro-error.
+    "RUSTSEC-2026-0173"
 ]  # advisory IDs to ignore
 
 informational_warnings = ["unmaintained"]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/dcql/query.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/dcql/query.rs
@@ -234,6 +234,12 @@ impl CredentialMeta {
     fn validate(&self, idx: usize, format: &CredentialFormat) -> Result<()> {
         match (self, format) {
             // W3C formats (jwt_vc_json, jwt_vc_json-ld, ldp_vc) use type_values
+            (
+                CredentialMeta::W3CFormat { type_values },
+                CredentialFormat::JwtVcJson | CredentialFormat::LdpVc,
+            ) => {
+                validate_type_values(idx, type_values)?;
+            }
             (CredentialMeta::W3CFormat { type_values }, CredentialFormat::Other(fmt)) => {
                 // Only allow W3CFormat for known W3C credential formats
                 if !is_w3c_format(fmt) {
@@ -241,25 +247,7 @@ impl CredentialMeta {
                         "'dcql_query.credentials[{idx}].meta' has W3C format structure but format '{fmt}' is not a recognized W3C VC format"
                     )));
                 }
-                if type_values.is_empty() {
-                    return Err(invalid_dcql(format!(
-                        "'dcql_query.credentials[{idx}].meta.type_values' must be a non-empty array"
-                    )));
-                }
-                for (vi, values) in type_values.iter().enumerate() {
-                    if values.is_empty() {
-                        return Err(invalid_dcql(format!(
-                            "'dcql_query.credentials[{idx}].meta.type_values[{vi}]' must be a non-empty array"
-                        )));
-                    }
-                    for (ti, t) in values.iter().enumerate() {
-                        if t.trim().is_empty() {
-                            return Err(invalid_dcql(format!(
-                                "'dcql_query.credentials[{idx}].meta.type_values[{vi}][{ti}]' must not be empty"
-                            )));
-                        }
-                    }
-                }
+                validate_type_values(idx, type_values)?;
             }
             (CredentialMeta::W3CFormat { .. }, CredentialFormat::DcSdJwt) => {
                 return Err(invalid_dcql(format!(
@@ -291,6 +279,14 @@ impl CredentialMeta {
                     "'dcql_query.credentials[{idx}].meta' has dc+sd-jwt structure (vct_values) but format is 'mso_mdoc' which requires 'doctype_value'"
                 )));
             }
+            (
+                CredentialMeta::SdJwt { .. },
+                CredentialFormat::JwtVcJson | CredentialFormat::LdpVc,
+            ) => {
+                return Err(invalid_dcql(format!(
+                    "'dcql_query.credentials[{idx}].meta' has dc+sd-jwt structure (vct_values) but format requires 'type_values'"
+                )));
+            }
             (CredentialMeta::SdJwt { .. }, CredentialFormat::Other(fmt)) => {
                 return Err(invalid_dcql(format!(
                     "'dcql_query.credentials[{idx}].meta' has dc+sd-jwt structure (vct_values) but format is '{fmt}'"
@@ -309,6 +305,14 @@ impl CredentialMeta {
                     "'dcql_query.credentials[{idx}].meta' has mso_mdoc structure (doctype_value) but format is 'dc+sd-jwt' which requires 'vct_values'"
                 )));
             }
+            (
+                CredentialMeta::MsoMdoc { .. },
+                CredentialFormat::JwtVcJson | CredentialFormat::LdpVc,
+            ) => {
+                return Err(invalid_dcql(format!(
+                    "'dcql_query.credentials[{idx}].meta' has mso_mdoc structure (doctype_value) but format requires 'type_values'"
+                )));
+            }
             (CredentialMeta::MsoMdoc { .. }, CredentialFormat::Other(fmt)) => {
                 return Err(invalid_dcql(format!(
                     "'dcql_query.credentials[{idx}].meta' has mso_mdoc structure (doctype_value) but format is '{fmt}'"
@@ -317,6 +321,29 @@ impl CredentialMeta {
         }
         Ok(())
     }
+}
+
+fn validate_type_values(idx: usize, type_values: &[Vec<String>]) -> Result<()> {
+    if type_values.is_empty() {
+        return Err(invalid_dcql(format!(
+            "'dcql_query.credentials[{idx}].meta.type_values' must be a non-empty array"
+        )));
+    }
+    for (vi, values) in type_values.iter().enumerate() {
+        if values.is_empty() {
+            return Err(invalid_dcql(format!(
+                "'dcql_query.credentials[{idx}].meta.type_values[{vi}]' must be a non-empty array"
+            )));
+        }
+        for (ti, t) in values.iter().enumerate() {
+            if t.trim().is_empty() {
+                return Err(invalid_dcql(format!(
+                    "'dcql_query.credentials[{idx}].meta.type_values[{vi}][{ti}]' must not be empty"
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Checks if a format string is a recognized W3C VC format.
@@ -330,6 +357,10 @@ fn is_w3c_format(fmt: &str) -> bool {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CredentialFormat {
+    /// VC signed as a JWT, not using JSON-LD as defined in Section B.1.3.1.
+    JwtVcJson,
+    /// LDP VC format as defined in Section B.1.3.2.
+    LdpVc,
     /// SD-JWT VC format as defined in Section B.3.1.
     #[serde(rename = "dc+sd-jwt")]
     DcSdJwt,
@@ -343,6 +374,8 @@ pub enum CredentialFormat {
 impl std::fmt::Display for CredentialFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::JwtVcJson => write!(f, "jwt_vc_json"),
+            Self::LdpVc => write!(f, "ldp_vc"),
             Self::DcSdJwt => write!(f, "dc+sd-jwt"),
             Self::MsoMdoc => write!(f, "mso_mdoc"),
             Self::Other(s) => write!(f, "{s}"),

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -8,5 +8,6 @@ pub mod client_id;
 pub mod dcql;
 pub mod error;
 pub mod metadata;
+pub mod selection;
 
 pub use error::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
@@ -1,0 +1,504 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::core::claim_path_pointer::{ClaimPathPointer, ClaimValue};
+use crate::oid4vp::dcql::{
+    ClaimsQuery, CredentialFormat, CredentialMeta, CredentialQuery, CredentialSet, DcqlQuery,
+    TrustedAuthorityQuery, TrustedAuthorityType,
+};
+
+/// The result of matching a full [`DcqlQuery`] against the Wallet's credentials.
+#[derive(Debug, Clone)]
+pub struct SelectionResult {
+    /// All matching candidates, grouped by credential query ID.
+    ///
+    /// Each key is a `CredentialQuery::id`; the value is the (possibly empty)
+    /// list of wallet credentials that satisfy that query.
+    pub candidates: HashMap<String, Vec<CredentialCandidate>>,
+
+    /// Credential query IDs for which no matching credential was found.
+    pub unsatisfied_queries: Vec<String>,
+
+    /// Whether the full DCQL query can be satisfied.
+    pub satisfies_query: bool,
+
+    /// Credential query IDs selected by the default credential-set logic.
+    pub selected_credential_query_ids: Vec<String>,
+
+    /// Whether each credential query allows returning multiple credentials.
+    pub multiple_allowed_by_query_id: HashMap<String, bool>,
+}
+
+impl SelectionResult {
+    /// Returns `true` when the DCQL query can be fully satisfied.
+    ///
+    /// If `credential_sets` are present, satisfaction is evaluated against the
+    /// set logic.  Otherwise every credential query must have at least one
+    /// candidate.
+    pub fn is_satisfied(&self) -> bool {
+        self.satisfies_query
+    }
+
+    /// Picks credentials for the selected credential query IDs, preferring the
+    /// candidate with the most matched claims unless `multiple` is true.
+    ///
+    /// Returns an empty vec if the query is not satisfiable.
+    pub fn select(&self) -> Vec<CredentialCandidate> {
+        if !self.is_satisfied() {
+            return vec![];
+        }
+
+        self.selected_credential_query_ids
+            .iter()
+            .flat_map(|id| {
+                let Some(candidates) = self.candidates.get(id) else {
+                    return vec![];
+                };
+
+                if self
+                    .multiple_allowed_by_query_id
+                    .get(id)
+                    .copied()
+                    .unwrap_or(false)
+                {
+                    let mut selected = candidates.clone();
+                    selected
+                        .sort_by_key(|candidate| std::cmp::Reverse(candidate.matched_claims.len()));
+                    selected
+                } else {
+                    candidates
+                        .iter()
+                        .max_by_key(|c| c.matched_claims.len())
+                        .cloned()
+                        .into_iter()
+                        .collect()
+                }
+            })
+            .collect()
+    }
+}
+
+/// A credential that matched a single [`CredentialQuery`].
+#[derive(Debug, Clone)]
+pub struct CredentialCandidate {
+    /// Identifier of the [`CredentialQuery`] that this credential satisfies.
+    pub credential_query_id: String,
+
+    /// Identifier of the wallet credential (mirrors [`CredentialView::id`]).
+    pub credential_id: String,
+
+    /// Claims that matched the query. Empty when the query did not specify a
+    /// `claims` filter; presentation builders must still disclose only the
+    /// format's mandatory presentation material in that case.
+    pub matched_claims: Vec<MatchedClaim>,
+
+    /// Index of the chosen claim set within `CredentialQuery::claim_sets`,
+    /// if claim sets were used.  `None` when claim sets are absent.
+    pub matched_claim_set_index: Option<usize>,
+}
+
+/// A claim that was matched by a [`ClaimsQuery`].
+#[derive(Debug, Clone)]
+pub struct MatchedClaim {
+    /// The claim query that produced this match.
+    pub claim_query_id: Option<String>,
+
+    /// The Claims Path Pointer that was matched.
+    pub path: ClaimPathPointer,
+
+    /// The concrete values selected by the path pointer.
+    pub selected_values: Vec<Value>,
+}
+
+/// A format-agnostic view of a credential stored in the Wallet.
+///
+/// Callers construct this from their domain `Credential` model before passing
+/// it into the matching engine.
+#[derive(Debug, Clone)]
+pub struct CredentialView {
+    /// Opaque identifier for this credential (e.g., UUID string).
+    pub id: String,
+
+    /// The DCQL format identifier for this credential (e.g., `dc+sd-jwt`, `mso_mdoc`).
+    pub format: CredentialFormat,
+
+    /// Verifiable Credential Type URI — present for `dc+sd-jwt` credentials.
+    pub vct: Option<String>,
+
+    /// Document type — present for `mso_mdoc` credentials
+    /// (e.g., `"org.iso.18013.5.1.mDL"`).
+    pub doctype: Option<String>,
+
+    /// W3C VC `type` values — present for `jwt_vc_json` / `ldp_vc` credentials.
+    pub credential_types: Vec<String>,
+
+    /// Decoded credential claims as a JSON value.
+    ///
+    /// For SD-JWT VC: the fully disclosed payload (all disclosures applied,
+    /// metadata claims stripped).  For mdoc: a JSON object keyed by namespace,
+    /// each value an object of data-element → value pairs.
+    pub claims: Value,
+
+    /// The credential issuer identifier (e.g., DID or URL).
+    pub issuer: Option<String>,
+
+    /// Type-specific trusted authority references extracted during validation.
+    pub trusted_authorities: Vec<CredentialAuthority>,
+
+    /// Whether the credential can produce cryptographic holder binding proof.
+    pub holder_binding_supported: bool,
+}
+
+/// A trusted authority reference associated with a stored credential.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialAuthority {
+    pub authority_type: TrustedAuthorityType,
+    pub value: String,
+}
+
+/// Matches a full DCQL query against the Wallet's credentials.
+///
+/// This is the main entry point of the credential selection engine.  It
+/// evaluates each [`CredentialQuery`] against every credential in the wallet,
+/// then (if present) evaluates [`CredentialSet`] logic to determine overall
+/// satisfiability.
+pub fn match_dcql_query(query: &DcqlQuery, credentials: &[CredentialView]) -> SelectionResult {
+    let mut candidates: HashMap<String, Vec<CredentialCandidate>> = HashMap::new();
+    let multiple_allowed_by_query_id: HashMap<String, bool> = query
+        .credentials
+        .iter()
+        .map(|credential_query| {
+            (
+                credential_query.id.clone(),
+                credential_query.multiple.unwrap_or(false),
+            )
+        })
+        .collect();
+
+    // match each credential query independently.
+    for cred_query in &query.credentials {
+        let matches: Vec<CredentialCandidate> = credentials
+            .iter()
+            .filter_map(|wc| match_credential_query(cred_query, wc))
+            .collect();
+
+        candidates.insert(cred_query.id.clone(), matches);
+    }
+
+    // determine satisfaction and default selection.
+    let (unsatisfied_queries, selected_credential_query_ids) =
+        if let Some(ref credential_sets) = query.credential_sets {
+            // With credential_sets, satisfaction is determined by the set logic.
+            evaluate_credential_sets(credential_sets, &candidates)
+        } else {
+            // Without credential_sets, every credential query must have ≥ 1 match.
+            let unsatisfied_queries: Vec<String> = candidates
+                .iter()
+                .filter(|(_, v)| v.is_empty())
+                .map(|(k, _)| k.clone())
+                .collect();
+            let selected_credential_query_ids = if unsatisfied_queries.is_empty() {
+                query.credentials.iter().map(|q| q.id.clone()).collect()
+            } else {
+                vec![]
+            };
+            (unsatisfied_queries, selected_credential_query_ids)
+        };
+
+    SelectionResult {
+        candidates,
+        satisfies_query: unsatisfied_queries.is_empty(),
+        unsatisfied_queries,
+        selected_credential_query_ids,
+        multiple_allowed_by_query_id,
+    }
+}
+
+/// Matches a single credential query against a single wallet credential.
+///
+/// Returns `Some(CredentialCandidate)` if the credential satisfies the query,
+/// `None` otherwise.
+///
+/// # Matching rules (§6.4.2)
+///
+/// 1. **Format** — the credential's format must equal the query's format.
+/// 2. **Meta** — if `meta` is present, the credential must match the
+///    format-specific metadata (e.g., `vct_values` for SD-JWT VC).
+/// 3. **Claims** — if `claims` is present, the credential must contain the
+///    requested claims.  If `values` is specified on a claims query, at least
+///    one selected value must be in the allowed set.
+/// 4. **Claim sets** — if `claim_sets` is present, at least one claim set
+///    must be fully satisfiable.
+/// 5. **Trusted authorities** — if `trusted_authorities` is present, the
+///    credential must contain a matching type-specific authority reference.
+/// 6. **Holder binding** — if required, the credential must support producing
+///    a cryptographic holder binding proof.
+pub fn match_credential_query(
+    query: &CredentialQuery,
+    credential: &CredentialView,
+) -> Option<CredentialCandidate> {
+    if credential.format != query.format {
+        return None;
+    }
+
+    if !matches_meta(&query.meta, credential) {
+        return None;
+    }
+
+    if let Some(ref authorities) = query.trusted_authorities {
+        if !matches_any_authority(authorities, credential) {
+            return None;
+        }
+    }
+
+    // Holder binding match. Per §6.1, absence defaults to true.
+    if query.require_cryptographic_holder_binding.unwrap_or(true)
+        && !credential.holder_binding_supported
+    {
+        return None;
+    }
+
+    // Claims + claim sets match
+    let (matched_claims, matched_claim_set_index) = match_claims(query, &credential.claims)?;
+
+    Some(CredentialCandidate {
+        credential_query_id: query.id.clone(),
+        credential_id: credential.id.clone(),
+        matched_claims,
+        matched_claim_set_index,
+    })
+}
+
+/// Checks whether a credential satisfies the format-specific `meta` constraint.
+fn matches_meta(meta: &CredentialMeta, credential: &CredentialView) -> bool {
+    match meta {
+        CredentialMeta::SdJwt { vct_values } => {
+            // §B.3.5: the credential's `vct` must be one of the listed values.
+            credential
+                .vct
+                .as_ref()
+                .is_some_and(|vct| vct_values.iter().any(|v| v == vct))
+        }
+        CredentialMeta::MsoMdoc { doctype_value } => {
+            // §B.2.3: the credential's `doctype` must match the value.
+            credential
+                .doctype
+                .as_ref()
+                .is_some_and(|dt| dt == doctype_value)
+        }
+        CredentialMeta::W3CFormat { type_values } => {
+            // §B.1.1: the credential must match at least one type combination.
+            // Each inner array represents an AND of required types.
+            let cred_types = &credential.credential_types;
+            type_values
+                .iter()
+                .any(|required| required.iter().all(|t| cred_types.contains(t)))
+        }
+    }
+}
+
+/// Returns `true` if the credential has a type-specific trusted authority
+/// reference matching at least one query entry.
+///
+/// Per §6.1.1, if multiple entries are present, a credential is accepted
+/// if it matches any of the authority queries.
+fn matches_any_authority(
+    authorities: &[TrustedAuthorityQuery],
+    credential: &CredentialView,
+) -> bool {
+    authorities.iter().any(|authority| {
+        credential.trusted_authorities.iter().any(|credential_ref| {
+            credential_ref.authority_type == authority.authority_type
+                && authority
+                    .values
+                    .iter()
+                    .any(|value| value == &credential_ref.value)
+        })
+    })
+}
+
+/// Evaluates the `claims` and optional `claim_sets` constraints of a
+/// credential query against the credential's decoded claims.
+///
+/// Returns `None` if the claims constraint cannot be satisfied, otherwise
+/// returns the list of matched claims and the optional claim set index.
+fn match_claims(
+    query: &CredentialQuery,
+    claims_value: &Value,
+) -> Option<(Vec<MatchedClaim>, Option<usize>)> {
+    let Some(ref claims_queries) = query.claims else {
+        // No selectively disclosable claims were requested. The credential can
+        // still satisfy the query, but presentation code must disclose only
+        // mandatory claims for the credential format.
+        return Some((vec![], None));
+    };
+
+    if let Some(ref claim_sets) = query.claim_sets {
+        // §6.4.1: When claim_sets is present, the Wallet MUST find at least
+        // one claim set (an array of claim query IDs) where every referenced
+        // claim query is satisfiable.
+        match_with_claim_sets(claims_queries, claim_sets, claims_value)
+    } else {
+        // Without claim_sets, every claim query must be satisfiable.
+        let matched = match_all_claims(claims_queries, claims_value)?;
+        Some((matched, None))
+    }
+}
+
+/// Matches all claim queries against the credential.  Returns `None` if any
+/// required claim query fails to match.
+fn match_all_claims(
+    claims_queries: &[ClaimsQuery],
+    claims_value: &Value,
+) -> Option<Vec<MatchedClaim>> {
+    let mut matched = Vec::with_capacity(claims_queries.len());
+    for cq in claims_queries {
+        matched.push(match_single_claim(cq, claims_value)?);
+    }
+    Some(matched)
+}
+
+/// Evaluates claim sets: tries each claim set in order and returns the first
+/// one that is fully satisfiable.
+fn match_with_claim_sets(
+    claims_queries: &[ClaimsQuery],
+    claim_sets: &[Vec<String>],
+    claims_value: &Value,
+) -> Option<(Vec<MatchedClaim>, Option<usize>)> {
+    // Build a lookup from claim query ID -> claim query.
+    let claims_by_id: HashMap<&str, &ClaimsQuery> = claims_queries
+        .iter()
+        .filter_map(|cq| cq.id.as_deref().map(|id| (id, cq)))
+        .collect();
+
+    for (set_idx, set) in claim_sets.iter().enumerate() {
+        let mut matched = Vec::with_capacity(set.len());
+        let mut all_satisfied = true;
+
+        for claim_id in set {
+            if let Some(cq) = claims_by_id.get(claim_id.as_str()) {
+                if let Some(m) = match_single_claim(cq, claims_value) {
+                    matched.push(m);
+                } else {
+                    all_satisfied = false;
+                    break;
+                }
+            } else {
+                // Unknown claim id in claim set — treat as unsatisfiable.
+                all_satisfied = false;
+                break;
+            }
+        }
+
+        if all_satisfied {
+            return Some((matched, Some(set_idx)));
+        }
+    }
+    None
+}
+
+/// Matches a single [`ClaimsQuery`] against the credential's claims.
+///
+/// A claim query is satisfied when:
+/// 1. The [`ClaimPathPointer`] selects at least one value from the claims.
+/// 2. If `values` is specified, at least one selected value equals one of the
+///    allowed values.
+fn match_single_claim(cq: &ClaimsQuery, claims_value: &Value) -> Option<MatchedClaim> {
+    let selected = cq.path.select(claims_value);
+
+    if selected.is_empty() {
+        return None;
+    }
+
+    // If values constraint is present, at least one selected value must match.
+    if let Some(ref allowed) = cq.values {
+        let has_match = selected.iter().any(|sv| value_matches_any(sv, allowed));
+        if !has_match {
+            return None;
+        }
+    }
+
+    Some(MatchedClaim {
+        claim_query_id: cq.id.clone(),
+        path: cq.path.clone(),
+        selected_values: selected,
+    })
+}
+
+/// Checks whether a JSON `Value` is equal to any of the allowed `ClaimValue`s.
+///
+/// Type-aware comparison per §6.3:
+/// - `ClaimValue::String` matches `Value::String`
+/// - `ClaimValue::Integer` matches `Value::Number`
+/// - `ClaimValue::Boolean` matches `Value::Bool`
+fn value_matches_any(value: &Value, allowed: &[ClaimValue]) -> bool {
+    allowed.iter().any(|cv| claim_value_eq(cv, value))
+}
+
+/// Compares a [`ClaimValue`] to a [`serde_json::Value`] for equality.
+fn claim_value_eq(cv: &ClaimValue, v: &Value) -> bool {
+    match (cv, v) {
+        (ClaimValue::String(s), Value::String(vs)) => s == vs,
+        (ClaimValue::Integer(i), Value::Number(n)) => n.as_i64() == Some(*i),
+        (ClaimValue::Boolean(b), Value::Bool(vb)) => b == vb,
+        _ => false,
+    }
+}
+
+/// Evaluates credential sets and returns unsatisfied required query IDs plus
+/// the default credential query IDs to present.
+///
+/// Per §6.2, a credential set defines `options` — an array of arrays.  Each
+/// inner array is an AND group of credential query IDs.  The options form an
+/// OR — at least one option must be fully satisfiable.
+///
+/// When `required` is omitted, it defaults to `true`. Optional sets do not make
+/// the query unsatisfied and are not selected by default.
+fn evaluate_credential_sets(
+    credential_sets: &[CredentialSet],
+    candidates: &HashMap<String, Vec<CredentialCandidate>>,
+) -> (Vec<String>, Vec<String>) {
+    let mut unsatisfied = vec![];
+    let mut selected = vec![];
+
+    for set in credential_sets {
+        let is_required = set.required.unwrap_or(true);
+
+        // Select the first option (OR branch) that is fully satisfiable.
+        let satisfied_option = set.options.iter().find(|option| {
+            // An option is satisfied when every credential query ID in it has
+            // at least one candidate.
+            option
+                .iter()
+                .all(|cq_id| candidates.get(cq_id).is_some_and(|c| !c.is_empty()))
+        });
+
+        if let Some(option) = satisfied_option {
+            if is_required {
+                for cq_id in option {
+                    if !selected.contains(cq_id) {
+                        selected.push(cq_id.clone());
+                    }
+                }
+            }
+        } else if is_required {
+            // Collect the credential query IDs that are referenced by this set
+            // and have no candidates.
+            for option in &set.options {
+                for cq_id in option {
+                    let is_empty = candidates.get(cq_id).is_none_or(|c| c.is_empty());
+                    if is_empty && !unsatisfied.contains(cq_id) {
+                        unsatisfied.push(cq_id.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if !unsatisfied.is_empty() {
+        selected.clear();
+    }
+
+    (unsatisfied, selected)
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
@@ -483,12 +483,11 @@ fn evaluate_credential_sets(
                 }
             }
         } else if is_required {
-            // Collect the credential query IDs that are referenced by this set
-            // and have no candidates.
-            for option in &set.options {
-                for cq_id in option {
-                    let is_empty = candidates.get(cq_id).is_none_or(|c| c.is_empty());
-                    if is_empty && !unsatisfied.contains(cq_id) {
+            // No OR branch satisfies this required set. Report the first
+            // branch as the deterministic minimum requirement that failed.
+            if let Some(first_option) = set.options.first() {
+                for cq_id in first_option {
+                    if !unsatisfied.contains(cq_id) {
                         unsatisfied.push(cq_id.clone());
                     }
                 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
@@ -246,10 +246,10 @@ pub fn match_credential_query(
         return None;
     }
 
-    if let Some(ref authorities) = query.trusted_authorities {
-        if !matches_any_authority(authorities, credential) {
-            return None;
-        }
+    if let Some(ref authorities) = query.trusted_authorities
+        && !matches_any_authority(authorities, credential)
+    {
+        return None;
     }
 
     // Holder binding match. Per §6.1, absence defaults to true.

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/mod.rs
@@ -1,0 +1,28 @@
+//! Credential matching and selection engine for OID4VP.
+//!
+//! Implements the Wallet-side logic described in [OpenID4VP §6.4] for matching
+//! stored credentials against a DCQL query and selecting which credentials and
+//! claims to present to the Verifier.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use cloud_wallet_openid4vc::oid4vp::selection::*;
+//!
+//! let query: DcqlQuery = /* parsed from authorization request */;
+//! let credentials: Vec<CredentialView> = /* loaded from wallet store */;
+//!
+//! let result = match_dcql_query(&query, &credentials);
+//! if result.is_satisfied() {
+//!     let selected = result.select();
+//!     // build VP token from `selected`
+//! }
+//! ```
+//!
+//! [OpenID4VP §6.4]: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-6.4
+
+mod matching;
+#[cfg(test)]
+mod tests;
+
+pub use matching::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/tests.rs
@@ -357,6 +357,25 @@ fn dcql_without_credential_sets_requires_every_credential_query() {
 }
 
 #[test]
+fn empty_wallet_reports_all_queries_unsatisfied() {
+    let query = DcqlQuery {
+        credentials: vec![
+            sd_jwt_query("pid", "https://example.com/pid"),
+            mdoc_query("mdl", "org.iso.18013.5.1.mDL"),
+        ],
+        credential_sets: None,
+    };
+
+    let result = match_dcql_query(&query, &[]);
+
+    assert!(!result.is_satisfied());
+    assert_eq!(result.unsatisfied_queries.len(), 2);
+    assert!(result.unsatisfied_queries.contains(&"pid".to_string()));
+    assert!(result.unsatisfied_queries.contains(&"mdl".to_string()));
+    assert!(result.select().is_empty());
+}
+
+#[test]
 fn credential_sets_use_first_satisfiable_required_option_and_skip_optional_by_default() {
     let query = DcqlQuery {
         credentials: vec![

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/tests.rs
@@ -1,0 +1,457 @@
+use serde_json::{Value, json};
+
+use crate::core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer, ClaimValue};
+use crate::oid4vp::dcql::{
+    ClaimsQuery, CredentialFormat, CredentialMeta, CredentialQuery, CredentialSet, DcqlQuery,
+    TrustedAuthorityQuery, TrustedAuthorityType,
+};
+use crate::oid4vp::selection::matching::*;
+
+fn sd_jwt_credential(id: &str, vct: &str, claims: Value) -> CredentialView {
+    CredentialView {
+        id: id.to_string(),
+        format: CredentialFormat::DcSdJwt,
+        vct: Some(vct.to_string()),
+        doctype: None,
+        credential_types: vec![],
+        claims,
+        issuer: Some("https://issuer.example.com".to_string()),
+        trusted_authorities: vec![CredentialAuthority {
+            authority_type: TrustedAuthorityType::Aki,
+            value: "issuer-aki".to_string(),
+        }],
+        holder_binding_supported: true,
+    }
+}
+
+fn mdoc_credential(id: &str, doctype: &str, claims: Value) -> CredentialView {
+    CredentialView {
+        id: id.to_string(),
+        format: CredentialFormat::MsoMdoc,
+        vct: None,
+        doctype: Some(doctype.to_string()),
+        credential_types: vec![],
+        claims,
+        issuer: Some("https://issuer.example.com".to_string()),
+        trusted_authorities: vec![CredentialAuthority {
+            authority_type: TrustedAuthorityType::Aki,
+            value: "issuer-aki".to_string(),
+        }],
+        holder_binding_supported: true,
+    }
+}
+
+fn sd_jwt_query(id: &str, vct: &str) -> CredentialQuery {
+    CredentialQuery {
+        id: id.to_string(),
+        format: CredentialFormat::DcSdJwt,
+        multiple: None,
+        meta: CredentialMeta::SdJwt {
+            vct_values: vec![vct.to_string()],
+        },
+        claims: None,
+        claim_sets: None,
+        trusted_authorities: None,
+        require_cryptographic_holder_binding: None,
+    }
+}
+
+fn mdoc_query(id: &str, doctype: &str) -> CredentialQuery {
+    CredentialQuery {
+        id: id.to_string(),
+        format: CredentialFormat::MsoMdoc,
+        multiple: None,
+        meta: CredentialMeta::MsoMdoc {
+            doctype_value: doctype.to_string(),
+        },
+        claims: None,
+        claim_sets: None,
+        trusted_authorities: None,
+        require_cryptographic_holder_binding: None,
+    }
+}
+
+fn claim(path: ClaimPathPointer) -> ClaimsQuery {
+    ClaimsQuery {
+        path,
+        id: None,
+        values: None,
+    }
+}
+
+fn path(elements: &[&str]) -> ClaimPathPointer {
+    ClaimPathPointer::new(
+        elements
+            .iter()
+            .map(|element| ClaimPathElement::from(*element))
+            .collect(),
+    )
+}
+
+#[test]
+fn credential_query_matches_format_and_meta_constraints() {
+    let sd_query = sd_jwt_query("pid", "https://example.com/pid");
+    let sd_credential = sd_jwt_credential("c1", "https://example.com/pid", json!({}));
+    let mdoc = mdoc_credential("c2", "org.iso.18013.5.1.mDL", json!({}));
+
+    let candidate = match_credential_query(&sd_query, &sd_credential).unwrap();
+    assert_eq!(candidate.credential_query_id, "pid");
+    assert_eq!(candidate.credential_id, "c1");
+    assert!(match_credential_query(&sd_query, &mdoc).is_none());
+
+    let wrong_vct = sd_jwt_credential("c3", "https://example.com/other", json!({}));
+    assert!(match_credential_query(&sd_query, &wrong_vct).is_none());
+
+    let mdoc_query = mdoc_query("mdl", "org.iso.18013.5.1.mDL");
+    assert!(match_credential_query(&mdoc_query, &mdoc).is_some());
+
+    let wrong_doctype = mdoc_credential("c4", "org.iso.18013.5.1.mID", json!({}));
+    assert!(match_credential_query(&mdoc_query, &wrong_doctype).is_none());
+}
+
+#[test]
+fn w3c_type_values_match_required_type_combinations() {
+    let query = CredentialQuery {
+        id: "vc".to_string(),
+        format: CredentialFormat::JwtVcJson,
+        multiple: None,
+        meta: CredentialMeta::W3CFormat {
+            type_values: vec![vec![
+                "VerifiableCredential".to_string(),
+                "UniversityDegreeCredential".to_string(),
+            ]],
+        },
+        claims: None,
+        claim_sets: None,
+        trusted_authorities: None,
+        require_cryptographic_holder_binding: None,
+    };
+
+    let credential = CredentialView {
+        id: "c1".to_string(),
+        format: CredentialFormat::JwtVcJson,
+        vct: None,
+        doctype: None,
+        credential_types: vec![
+            "VerifiableCredential".to_string(),
+            "UniversityDegreeCredential".to_string(),
+        ],
+        claims: json!({}),
+        issuer: None,
+        trusted_authorities: vec![],
+        holder_binding_supported: true,
+    };
+    assert!(match_credential_query(&query, &credential).is_some());
+
+    let partial_credential = CredentialView {
+        credential_types: vec!["VerifiableCredential".to_string()],
+        ..credential
+    };
+    assert!(match_credential_query(&query, &partial_credential).is_none());
+}
+
+#[test]
+fn claim_path_matching_selects_nested_index_and_array_values() {
+    let mut query = sd_jwt_query("pid", "vct");
+    query.claims = Some(vec![
+        claim(path(&["address", "city"])),
+        claim(ClaimPathPointer::new(vec![
+            ClaimPathElement::from("nationalities"),
+            ClaimPathElement::Index(0),
+        ])),
+        claim(ClaimPathPointer::new(vec![
+            ClaimPathElement::from("emails"),
+            ClaimPathElement::Null,
+        ])),
+    ]);
+
+    let credential = sd_jwt_credential(
+        "c1",
+        "vct",
+        json!({
+            "address": { "city": "Berlin" },
+            "nationalities": ["DE", "FR"],
+            "emails": ["a@example.com", "b@example.com"]
+        }),
+    );
+
+    let candidate = match_credential_query(&query, &credential).unwrap();
+    assert_eq!(
+        candidate.matched_claims[0].selected_values,
+        vec![json!("Berlin")]
+    );
+    assert_eq!(
+        candidate.matched_claims[1].selected_values,
+        vec![json!("DE")]
+    );
+    assert_eq!(candidate.matched_claims[2].selected_values.len(), 2);
+
+    let missing_claim = sd_jwt_credential("c2", "vct", json!({ "address": {} }));
+    assert!(match_credential_query(&query, &missing_claim).is_none());
+}
+
+#[test]
+fn mdoc_claim_path_uses_namespace_and_data_element() {
+    let mut query = mdoc_query("mdl", "org.iso.18013.5.1.mDL");
+    query.claims = Some(vec![claim(ClaimPathPointer::new(vec![
+        ClaimPathElement::from("org.iso.18013.5.1"),
+        ClaimPathElement::from("family_name"),
+    ]))]);
+
+    let credential = mdoc_credential(
+        "c1",
+        "org.iso.18013.5.1.mDL",
+        json!({ "org.iso.18013.5.1": { "family_name": "Doe" } }),
+    );
+
+    let candidate = match_credential_query(&query, &credential).unwrap();
+    assert_eq!(
+        candidate.matched_claims[0].selected_values,
+        vec![json!("Doe")]
+    );
+}
+
+#[test]
+fn value_filters_are_type_aware() {
+    for (claim_name, allowed, matching, non_matching) in [
+        (
+            "country",
+            ClaimValue::String("DE".to_string()),
+            json!("DE"),
+            json!("US"),
+        ),
+        ("age", ClaimValue::Integer(18), json!(18), json!("18")),
+        (
+            "active",
+            ClaimValue::Boolean(true),
+            json!(true),
+            json!(false),
+        ),
+    ] {
+        let mut query = sd_jwt_query("pid", "vct");
+        query.claims = Some(vec![ClaimsQuery {
+            path: path(&[claim_name]),
+            id: None,
+            values: Some(vec![allowed]),
+        }]);
+
+        let matching = sd_jwt_credential("c1", "vct", json!({ claim_name: matching }));
+        let non_matching = sd_jwt_credential("c2", "vct", json!({ claim_name: non_matching }));
+
+        assert!(match_credential_query(&query, &matching).is_some());
+        assert!(match_credential_query(&query, &non_matching).is_none());
+    }
+}
+
+#[test]
+fn trusted_authorities_require_matching_typed_reference() {
+    let mut query = sd_jwt_query("pid", "vct");
+    query.trusted_authorities = Some(vec![
+        TrustedAuthorityQuery {
+            authority_type: TrustedAuthorityType::Aki,
+            values: vec!["untrusted-aki".to_string()],
+        },
+        TrustedAuthorityQuery {
+            authority_type: TrustedAuthorityType::EtsiTl,
+            values: vec!["issuer-etsi".to_string()],
+        },
+    ]);
+
+    let mut credential = sd_jwt_credential("c1", "vct", json!({}));
+    assert!(match_credential_query(&query, &credential).is_none());
+
+    credential.trusted_authorities.push(CredentialAuthority {
+        authority_type: TrustedAuthorityType::EtsiTl,
+        value: "issuer-etsi".to_string(),
+    });
+    assert!(match_credential_query(&query, &credential).is_some());
+}
+
+#[test]
+fn holder_binding_is_required_by_default_unless_explicitly_disabled() {
+    let query = sd_jwt_query("pid", "vct");
+    let mut credential = sd_jwt_credential("c1", "vct", json!({}));
+    credential.holder_binding_supported = false;
+    assert!(match_credential_query(&query, &credential).is_none());
+
+    let mut query_without_binding = query;
+    query_without_binding.require_cryptographic_holder_binding = Some(false);
+    assert!(match_credential_query(&query_without_binding, &credential).is_some());
+}
+
+#[test]
+fn claim_sets_use_first_satisfiable_set_and_reject_when_none_match() {
+    let mut query = sd_jwt_query("pid", "vct");
+    query.claims = Some(vec![
+        ClaimsQuery {
+            path: path(&["given_name"]),
+            id: Some("gn".to_string()),
+            values: None,
+        },
+        ClaimsQuery {
+            path: path(&["family_name"]),
+            id: Some("fn".to_string()),
+            values: None,
+        },
+        ClaimsQuery {
+            path: path(&["date_of_birth"]),
+            id: Some("dob".to_string()),
+            values: None,
+        },
+    ]);
+    query.claim_sets = Some(vec![
+        vec!["gn".to_string(), "fn".to_string(), "dob".to_string()],
+        vec!["gn".to_string()],
+    ]);
+
+    let credential = sd_jwt_credential("c1", "vct", json!({ "given_name": "Alice" }));
+    let candidate = match_credential_query(&query, &credential).unwrap();
+    assert_eq!(candidate.matched_claim_set_index, Some(1));
+    assert_eq!(candidate.matched_claims.len(), 1);
+
+    query.claim_sets = Some(vec![vec!["gn".to_string(), "fn".to_string()]]);
+    assert!(match_credential_query(&query, &credential).is_none());
+}
+
+#[test]
+fn no_claims_filter_matches_without_selecting_disclosed_claims() {
+    let query = sd_jwt_query("pid", "vct");
+    let credential = sd_jwt_credential("c1", "vct", json!({ "anything": "works" }));
+
+    let candidate = match_credential_query(&query, &credential).unwrap();
+    assert!(candidate.matched_claims.is_empty());
+    assert!(candidate.matched_claim_set_index.is_none());
+}
+
+#[test]
+fn dcql_without_credential_sets_requires_every_credential_query() {
+    let query = DcqlQuery {
+        credentials: vec![
+            sd_jwt_query("pid", "https://example.com/pid"),
+            mdoc_query("mdl", "org.iso.18013.5.1.mDL"),
+        ],
+        credential_sets: None,
+    };
+
+    let result = match_dcql_query(
+        &query,
+        &[sd_jwt_credential(
+            "c1",
+            "https://example.com/pid",
+            json!({}),
+        )],
+    );
+    assert!(!result.is_satisfied());
+    assert_eq!(result.unsatisfied_queries, vec!["mdl"]);
+
+    let result = match_dcql_query(
+        &query,
+        &[
+            sd_jwt_credential("c1", "https://example.com/pid", json!({})),
+            mdoc_credential("c2", "org.iso.18013.5.1.mDL", json!({})),
+        ],
+    );
+    assert!(result.is_satisfied());
+    assert_eq!(result.candidates["pid"].len(), 1);
+    assert_eq!(result.candidates["mdl"].len(), 1);
+}
+
+#[test]
+fn credential_sets_use_first_satisfiable_required_option_and_skip_optional_by_default() {
+    let query = DcqlQuery {
+        credentials: vec![
+            sd_jwt_query("pid", "https://example.com/pid"),
+            sd_jwt_query("alt_pid", "https://example.com/alt-pid"),
+            sd_jwt_query("bonus", "https://example.com/bonus"),
+        ],
+        credential_sets: Some(vec![
+            CredentialSet {
+                options: vec![vec!["pid".to_string()], vec!["alt_pid".to_string()]],
+                required: None,
+            },
+            CredentialSet {
+                options: vec![vec!["bonus".to_string()]],
+                required: Some(false),
+            },
+        ]),
+    };
+
+    let credentials = vec![
+        sd_jwt_credential("c1", "https://example.com/pid", json!({})),
+        sd_jwt_credential("c2", "https://example.com/alt-pid", json!({})),
+        sd_jwt_credential("c3", "https://example.com/bonus", json!({})),
+    ];
+
+    let result = match_dcql_query(&query, &credentials);
+    assert!(result.is_satisfied());
+    assert_eq!(result.selected_credential_query_ids, vec!["pid"]);
+
+    let selected = result.select();
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].credential_query_id, "pid");
+    assert_eq!(selected[0].credential_id, "c1");
+}
+
+#[test]
+fn credential_sets_report_required_unsatisfied_option() {
+    let query = DcqlQuery {
+        credentials: vec![
+            sd_jwt_query("pid", "https://example.com/pid"),
+            mdoc_query("mdl", "org.iso.18013.5.1.mDL"),
+        ],
+        credential_sets: Some(vec![CredentialSet {
+            options: vec![vec!["pid".to_string(), "mdl".to_string()]],
+            required: Some(true),
+        }]),
+    };
+
+    let result = match_dcql_query(
+        &query,
+        &[sd_jwt_credential(
+            "c1",
+            "https://example.com/pid",
+            json!({}),
+        )],
+    );
+
+    assert!(!result.is_satisfied());
+    assert!(result.unsatisfied_queries.contains(&"mdl".to_string()));
+    assert!(result.select().is_empty());
+}
+
+#[test]
+fn selection_prefers_specific_candidate_and_honors_multiple() {
+    let mut query = sd_jwt_query("pid", "vct");
+    query.claims = Some(vec![
+        claim(path(&["given_name"])),
+        claim(path(&["family_name"])),
+    ]);
+    let query = DcqlQuery {
+        credentials: vec![query],
+        credential_sets: None,
+    };
+    let credentials = vec![
+        sd_jwt_credential("c1", "vct", json!({ "given_name": "Alice" })),
+        sd_jwt_credential(
+            "c2",
+            "vct",
+            json!({ "given_name": "Bob", "family_name": "Smith" }),
+        ),
+    ];
+
+    let selected = match_dcql_query(&query, &credentials).select();
+    assert_eq!(selected.len(), 1);
+    assert_eq!(selected[0].credential_id, "c2");
+
+    let mut query = sd_jwt_query("pid", "vct");
+    query.multiple = Some(true);
+    let selected = match_dcql_query(
+        &DcqlQuery {
+            credentials: vec![query],
+            credential_sets: None,
+        },
+        &credentials,
+    )
+    .select();
+    assert_eq!(selected.len(), 2);
+}

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,15 @@ no-default-features = false
 [output]
 feature-depth = 1
 
+[advisories]
+# The lint level for unmaintained crates
+unmaintained = "workspace"
+ignore = [
+  # Present in rsa crate. As there is currently no available fix for this vulnerability,
+  # this change temporarily ignores the advisory to allow CI/CD pipelines to pass
+  "RUSTSEC-2023-0071"
+]
+
 [bans]
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -14,13 +14,6 @@ no-default-features = false
 [output]
 feature-depth = 1
 
-[advisories]
-ignore = [
-  # Present in rsa crate. As there is currently no available fix for this vulnerability,
-  # this change temporarily ignores the advisory to allow CI/CD pipelines to pass
-  "RUSTSEC-2023-0071"
-]
-
 [bans]
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"


### PR DESCRIPTION
This PR implements the engine that matches stored wallet credentials against a DCQL query and selects which credentials and claims to present. This is the core decision logic of the Wallet, given a Verifier's DCQL query and the user's stored credentials, determine which credentials satisfy the query and which claims to disclose.

## Acceptance Criteria

- DCQL queries are matched against wallet credentials correctly
- Claim-level matching uses the existing `ClaimPathPointer::select()`
- Credential set logic (optional/required, OR of AND groups) is implemented
- Selection picks optimal candidates when multiple match

## Spec References

- [Section 6.4 — Selecting Claims and Credentials](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-6.4)