### PR TITLE
Verifier attestation

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
@@ -146,6 +146,59 @@ pub enum AuthorizationErrorCode {
     WalletUnavailable,
 }
 
+/// Error type for Verifier Attestation JWT validation failures.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum VerifierAttestationError {
+    /// The JWT format is invalid or malformed.
+    #[error("invalid JWT format: {0}")]
+    InvalidFormat(String),
+
+    /// The `typ` header parameter is missing or has an unexpected value.
+    #[error("invalid 'typ' header: expected '{expected}', got '{actual}")]
+    InvalidTyp { expected: String, actual: String },
+
+    /// The issuer is not in the list of trusted attestation issuers.
+    #[error("untrusted issuer: '{0}'")]
+    UntrustedIssuer(String),
+
+    /// The `sub` claim does not match the expected client_id.
+    #[error("subject mismatch: expected '{expected}', got '{actual}'")]
+    SubjectMismatch { expected: String, actual: String },
+
+    /// The attestation JWT has expired.
+    #[error("attestation JWT has expired")]
+    Expired,
+
+    /// The attestation JWT is not yet valid (nbf claim is in the future).
+    #[error("attestation JWT is not yet valid")]
+    NotYetValid,
+
+    /// The `cnf` claim is missing or invalid.
+    #[error("missing or invalid 'cnf' claim: {0}")]
+    MissingCnf(String),
+
+    /// The `cnf.jwk` claim is missing (required for Verifier's public key).
+    #[error("missing 'cnf.jwk' claim")]
+    MissingCnfJwk,
+
+    /// The `response_uri` is not in the allowed list (`response_uris` claim).
+    #[error("response_uri not allowed: '{0}'")]
+    ResponseUriNotAllowed(String),
+
+    /// JWT signature verification failed.
+    #[error("signature verification failed: {0}")]
+    SignatureVerificationFailed(String),
+
+    /// The JWT claims could not be decoded.
+    #[error("failed to decode JWT claims: {0}")]
+    DecodingFailed(String),
+
+    /// An error occurred during validation.
+    #[error("validation error: {0}")]
+    ValidationError(String),
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
@@ -207,6 +207,14 @@ pub enum VerifierAttestationError {
     /// An error occurred during validation.
     #[error("validation error: {0}")]
     ValidationError(String),
+
+    /// The specified key ID (kid) is not found in the issuer's JWKS.
+    #[error("unknown key ID: '{0}'")]
+    UnknownKeyId(String),
+
+    /// The JWK is not a valid public key type for signature verification.
+    #[error("invalid key type for signature verification: {0}")]
+    InvalidKeyType(String),
 }
 
 #[cfg(test)]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
@@ -173,6 +173,10 @@ pub enum VerifierAttestationError {
     #[error("attestation JWT is not yet valid")]
     NotYetValid,
 
+    /// The attestation JWT has an `iat` claim in the future.
+    #[error("attestation JWT has iat claim in the future")]
+    IssuedInFuture,
+
     /// The `cnf` claim is missing or invalid.
     #[error("missing or invalid 'cnf' claim: {0}")]
     MissingCnf(String),

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/error.rs
@@ -198,7 +198,6 @@ pub enum VerifierAttestationError {
     ValidationError(String),
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -8,8 +8,8 @@ pub mod client_id;
 pub mod dcql;
 pub mod error;
 pub mod metadata;
-pub mod verifier_attestation;
 pub mod selection;
 pub mod transaction_data;
+pub mod verifier_attestation;
 
 pub use error::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -8,5 +8,6 @@ pub mod client_id;
 pub mod dcql;
 pub mod error;
 pub mod metadata;
+pub mod verifier_attestation;
 
 pub use error::*;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -1,0 +1,835 @@
+use std::collections::HashSet;
+
+use cloud_wallet_crypto::jwk::Jwk;
+use jsonwebtoken::{DecodingKey, Validation, decode, jwk::Jwk as JwtJwk};
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+
+use crate::oid4vp::VerifierAttestationError;
+
+/// Claims of a Verifier Attestation JWT.
+#[skip_serializing_none]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifierAttestationClaims {
+    pub iss: String,
+
+    pub sub: String,
+
+    pub aud: Option<String>,
+
+    pub iat: i64,
+
+    pub exp: i64,
+
+    pub nbf: Option<i64>,
+
+    pub jti: Option<String>,
+
+    pub cnf: CnfClaim,
+
+    pub response_uris: Option<Vec<String>>,
+
+    pub nonce: Option<String>,
+}
+
+/// A validated Verifier Attestation JWT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifierAttestationJwt {
+    claims: VerifierAttestationClaims,
+
+    raw: String,
+}
+
+impl VerifierAttestationJwt {
+    /// The expected `typ` header value for Verifier Attestation JWTs.
+    pub const EXPECTED_TYP: &'static str = "verifier-attestation+jwt";
+
+    /// Decodes and validates a Verifier Attestation JWT.
+    pub fn decode_and_validate(
+        jwt: &str,
+        client_id: &str,
+        trusted_issuers: &[TrustedAttestationIssuer],
+    ) -> Result<Self, VerifierAttestationError> {
+        let header = Self::decode_header(jwt)?;
+
+        Self::validate_typ(&header)?;
+
+        // Find the trusted issuer based on the 'iss' claim
+        // We need to get the issuer from the claims first
+        let unverified_claims = Self::decode_unverified_claims(jwt)?;
+
+        let trusted_issuer = Self::find_trusted_issuer(&unverified_claims.iss, trusted_issuers)?;
+
+        // Now perform full signature verification with the issuer's key
+        let claims = Self::verify_signature(jwt, &header, trusted_issuer)?;
+
+        // Validate the subject matches the expected client_id
+        Self::validate_subject(&claims, client_id)?;
+
+        // Validate temporal claims
+        Self::validate_temporal(&claims)?;
+
+        // Validate that cnf.jwk is present
+        Self::validate_cnf(&claims)?;
+
+        Ok(Self {
+            claims,
+            raw: jwt.to_string(),
+        })
+    }
+
+    /// Decodes just the header to extract algorithm and key ID.
+    fn decode_header(jwt: &str) -> Result<jsonwebtoken::Header, VerifierAttestationError> {
+        jsonwebtoken::decode_header(jwt).map_err(|e| {
+            VerifierAttestationError::InvalidFormat(format!("failed to decode header: {e}"))
+        })
+    }
+
+    /// Decodes claims without signature verification.
+    ///
+    /// This is used to extract the issuer before we have the verification key.
+    fn decode_unverified_claims(
+        jwt: &str,
+    ) -> Result<VerifierAttestationClaims, VerifierAttestationError> {
+        use jsonwebtoken::dangerous::insecure_decode;
+
+        let token_data = insecure_decode::<VerifierAttestationClaims>(jwt).map_err(|e| {
+            VerifierAttestationError::DecodingFailed(format!("failed to decode claims: {e}"))
+        })?;
+
+        Ok(token_data.claims)
+    }
+
+    /// Validates the `typ` header parameter.
+    fn validate_typ(header: &jsonwebtoken::Header) -> Result<(), VerifierAttestationError> {
+        let actual_typ = header.typ.as_deref().unwrap_or("");
+        if actual_typ != Self::EXPECTED_TYP {
+            return Err(VerifierAttestationError::InvalidTyp {
+                expected: Self::EXPECTED_TYP.to_string(),
+                actual: actual_typ.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Finds the trusted issuer configuration for the given issuer ID.
+    fn find_trusted_issuer<'a>(
+        issuer_id: &str,
+        trusted_issuers: &'a [TrustedAttestationIssuer],
+    ) -> Result<&'a TrustedAttestationIssuer, VerifierAttestationError> {
+        trusted_issuers
+            .iter()
+            .find(|issuer| issuer.issuer_id == issuer_id)
+            .ok_or_else(|| VerifierAttestationError::UntrustedIssuer(issuer_id.to_string()))
+    }
+
+    /// Verifies the JWT signature using the trusted issuer's keys.
+    fn verify_signature(
+        jwt: &str,
+        header: &jsonwebtoken::Header,
+        trusted_issuer: &TrustedAttestationIssuer,
+    ) -> Result<VerifierAttestationClaims, VerifierAttestationError> {
+        // Find the appropriate key based on header (kid) or try all keys
+        let key = Self::resolve_verification_key(header, &trusted_issuer.jwks)?;
+
+        // Configure validation - we validate exp and iat here, others manually
+        let mut validation = Validation::new(header.alg);
+        validation.validate_exp = false;
+        validation.validate_nbf = false;
+        validation.validate_aud = false; // Audience is optional per spec, validate manually if needed
+        validation.required_spec_claims.clear();
+
+        let token_data = decode::<VerifierAttestationClaims>(jwt, &key, &validation)
+            .map_err(|e| VerifierAttestationError::SignatureVerificationFailed(e.to_string()))?;
+
+        Ok(token_data.claims)
+    }
+
+    /// Resolves the verification key from the JWKS based on the header.
+    fn resolve_verification_key(
+        header: &jsonwebtoken::Header,
+        jwks: &[Jwk],
+    ) -> Result<DecodingKey, VerifierAttestationError> {
+        // If there's a kid in the header, find the matching key
+        if let Some(ref kid) = header.kid {
+            let key = jwks.iter().find(|k| k.prm.kid.as_deref() == Some(kid));
+            if let Some(key) = key {
+                return Self::jwk_to_decoding_key(key);
+            }
+        }
+
+        // If no kid or no matching key found, try the first key (if only one)
+        if jwks.len() == 1 {
+            return Self::jwk_to_decoding_key(&jwks[0]);
+        }
+
+        if !jwks.is_empty() {
+            // Return the first key - the decode function will fail if it doesn't match
+            return Self::jwk_to_decoding_key(&jwks[0]);
+        }
+
+        Err(VerifierAttestationError::SignatureVerificationFailed(
+            "no verification keys available".to_string(),
+        ))
+    }
+
+    /// Converts a JWK to a jsonwebtoken DecodingKey.
+    fn jwk_to_decoding_key(jwk: &Jwk) -> Result<DecodingKey, VerifierAttestationError> {
+        // Convert our Jwk type to jsonwebtoken's Jwk type
+        let jwt_jwk = serde_json::to_value(jwk)
+            .and_then(serde_json::from_value::<JwtJwk>)
+            .map_err(|e| {
+                VerifierAttestationError::SignatureVerificationFailed(format!(
+                    "failed to convert JWK: {e}"
+                ))
+            })?;
+
+        DecodingKey::from_jwk(&jwt_jwk).map_err(|e| {
+            VerifierAttestationError::SignatureVerificationFailed(format!(
+                "failed to create decoding key from JWK: {e}"
+            ))
+        })
+    }
+
+    /// Validates that the `sub` claim matches the expected client_id.
+    fn validate_subject(
+        claims: &VerifierAttestationClaims,
+        expected_client_id: &str,
+    ) -> Result<(), VerifierAttestationError> {
+        if claims.sub != expected_client_id {
+            return Err(VerifierAttestationError::SubjectMismatch {
+                expected: expected_client_id.to_string(),
+                actual: claims.sub.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Validates temporal claims (exp, iat, nbf).
+    fn validate_temporal(
+        claims: &VerifierAttestationClaims,
+    ) -> Result<(), VerifierAttestationError> {
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+
+        // Check expiration
+        if claims.exp < now {
+            return Err(VerifierAttestationError::Expired);
+        }
+
+        // Check not-before if present
+        if let Some(nbf) = claims.nbf
+            && nbf > now
+        {
+            return Err(VerifierAttestationError::NotYetValid);
+        }
+
+        Ok(())
+    }
+
+    /// Validate that the `cnf` claim contains a valid `jwk`.
+    fn validate_cnf(claims: &VerifierAttestationClaims) -> Result<(), VerifierAttestationError> {
+        // Check that the cnf claim exists (it's required by struct definition)
+        // and that the JWK contains valid key material
+        match &claims.cnf.jwk.key {
+            cloud_wallet_crypto::jwk::Key::Ec(ec) => {
+                // Validate that EC key has non-empty coordinates
+                if ec.x.is_empty() || ec.y.is_empty() {
+                    return Err(VerifierAttestationError::MissingCnfJwk);
+                }
+            }
+            cloud_wallet_crypto::jwk::Key::Rsa(rsa) => {
+                // Validate that RSA key has non-empty modulus and exponent
+                if rsa.n.is_empty() || rsa.e.is_empty() {
+                    return Err(VerifierAttestationError::MissingCnfJwk);
+                }
+            }
+            cloud_wallet_crypto::jwk::Key::Oct(oct) => {
+                // Validate that octet key has non-empty value
+                if oct.k.is_empty() {
+                    return Err(VerifierAttestationError::MissingCnfJwk);
+                }
+            }
+            cloud_wallet_crypto::jwk::Key::Okp(okp) => {
+                // Validate that OKP key has non-empty public key
+                if okp.x.is_empty() {
+                    return Err(VerifierAttestationError::MissingCnfJwk);
+                }
+            }
+            // Handle non-exhaustive enum - any future key types are considered invalid
+            _ => {
+                return Err(VerifierAttestationError::MissingCnfJwk);
+            }
+        }
+        Ok(())
+    }
+
+    /// Validates that a responseuri is in the allowed list.
+    pub fn validate_response_uri(
+        &self,
+        response_uri: &str,
+    ) -> Result<(), VerifierAttestationError> {
+        if let Some(ref allowed_uris) = self.claims.response_uris {
+            let allowed_set: HashSet<&str> = allowed_uris.iter().map(String::as_str).collect();
+            if !allowed_set.contains(response_uri) {
+                return Err(VerifierAttestationError::ResponseUriNotAllowed(
+                    response_uri.to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Returns the decoded claims of the attestation JWT.
+    pub fn claims(&self) -> &VerifierAttestationClaims {
+        &self.claims
+    }
+
+    /// Returns the Verifier's public key from the `cnf.jwk` claim.
+
+    pub fn verifier_public_key(&self) -> &Jwk {
+        &self.claims.cnf.jwk
+    }
+
+    /// Returns the issuer of the attestation (the trusted attestation issuer).
+    pub fn issuer(&self) -> &str {
+        &self.claims.iss
+    }
+
+    /// Returns the subject of the attestation (the Verifier's identifier).
+    pub fn subject(&self) -> &str {
+        &self.claims.sub
+    }
+
+    /// Returns the raw JWT string.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    /// Returns the list of allowed response URIs, if specified.
+    pub fn allowed_response_uris(&self) -> Option<&[String]> {
+        self.claims.response_uris.as_deref()
+    }
+}
+
+/// Confirmation claim (`cnf`) containing the Verifier's public key.
+///
+/// The `cnf` claim is defined in [RFC 7800](https://datatracker.ietf.org/doc/html/rfc7800)
+/// and is used to confirm the binding between the attestation and the key.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CnfClaim {
+    /// The JSON Web Key representing the Verifier's public key.
+    pub jwk: Jwk,
+}
+
+/// Configuration for trusted attestation issuers.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TrustedAttestationIssuer {
+    /// The issuer identifier (value of the `iss` claim).
+    pub issuer_id: String,
+
+    /// The JWKS or single JWK used to verify the attestation JWTs from this issuer.
+    pub jwks: Vec<Jwk>,
+}
+
+#[cfg(test)]
+mod tests {
+    use cloud_wallet_crypto::jwk::Jwk;
+    use jsonwebtoken::{Algorithm, EncodingKey};
+
+    use super::*;
+
+    const TEST_ISSUER: &str = "https://attestation.example.com";
+    const TEST_CLIENT_ID: &str = "verifier_attestation:verifier123";
+
+    /// Helper struct to manage test keys for creating and validating JWTs.
+    struct TestKeys {
+        issuer_key_pair: cloud_wallet_crypto::ecdsa::KeyPair,
+        verifier_key_pair: cloud_wallet_crypto::ecdsa::KeyPair,
+    }
+
+    impl TestKeys {
+        fn generate() -> Self {
+            Self {
+                issuer_key_pair: cloud_wallet_crypto::ecdsa::KeyPair::generate(
+                    cloud_wallet_crypto::ecdsa::Curve::P256,
+                )
+                .expect("failed to generate issuer key"),
+                verifier_key_pair: cloud_wallet_crypto::ecdsa::KeyPair::generate(
+                    cloud_wallet_crypto::ecdsa::Curve::P256,
+                )
+                .expect("failed to generate verifier key"),
+            }
+        }
+
+        fn issuer_jwk(&self) -> Jwk {
+            Jwk::try_from(&self.issuer_key_pair).expect("failed to convert issuer key to JWK")
+        }
+
+        fn verifier_jwk(&self) -> Jwk {
+            Jwk::try_from(&self.verifier_key_pair).expect("failed to convert verifier key to JWK")
+        }
+
+        fn issuer_encoding_key(&self) -> EncodingKey {
+            // Get the PKCS#8 DER encoded private key bytes from the key pair
+            let secret = self.issuer_key_pair.to_pkcs8_der();
+            EncodingKey::from_ec_der(secret)
+        }
+    }
+
+    /// Creates a signed Verifier Attestation JWT with the given claims.
+    fn create_test_jwt(keys: &TestKeys, claims: &VerifierAttestationClaims, typ: &str) -> String {
+        let header = jsonwebtoken::Header {
+            typ: Some(typ.to_string()),
+            alg: Algorithm::ES256,
+            kid: None,
+            ..Default::default()
+        };
+
+        let encoding_key = keys.issuer_encoding_key();
+        jsonwebtoken::encode(&header, claims, &encoding_key).expect("failed to encode JWT")
+    }
+
+    /// Creates a standard valid set of claims.
+    fn valid_claims(keys: &TestKeys) -> VerifierAttestationClaims {
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: Some("https://wallet.example.com".to_string()),
+            iat: now,
+            exp: now + 3600, // Valid for 1 hour
+            nbf: None,
+            jti: Some("test-jti".to_string()),
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: Some(vec![
+                "https://verifier.example.com/cb1".to_string(),
+                "https://verifier.example.com/cb2".to_string(),
+            ]),
+            nonce: Some("test-nonce".to_string()),
+        }
+    }
+
+    fn trusted_issuer(keys: &TestKeys) -> TrustedAttestationIssuer {
+        TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(),
+            jwks: vec![keys.issuer_jwk()],
+        }
+    }
+
+    #[test]
+    fn test_decode_and_validate_success() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(
+            result.is_ok(),
+            "expected success but got: {:?}",
+            result.err()
+        );
+        let attestation = result.unwrap();
+        assert_eq!(attestation.issuer(), TEST_ISSUER);
+        assert_eq!(attestation.subject(), TEST_CLIENT_ID);
+        assert!(attestation.allowed_response_uris().is_some());
+    }
+
+    #[test]
+    fn test_valid_jwt_without_optional_claims() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: None, // Optional
+            iat: now,
+            exp: now + 3600,
+            nbf: None, // Optional
+            jti: None, // Optional
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: None, // Optional - no restrictions
+            nonce: None,         // Optional
+        };
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_ok());
+        let attestation = result.unwrap();
+        assert!(attestation.allowed_response_uris().is_none());
+    }
+
+    #[test]
+    fn test_wrong_typ_header_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, "JWT"); // Wrong typ header
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidTyp { .. }
+        ));
+    }
+
+    #[test]
+    fn test_missing_typ_header_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, ""); // Empty typ header
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidTyp { .. }
+        ));
+    }
+
+    #[test]
+    fn test_untrusted_issuer_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+
+        // Use a different issuer (not matching the JWT's iss claim)
+        let other_keys = TestKeys::generate();
+        let wrong_issuer = TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(), // Same ID but different key
+            jwks: vec![other_keys.issuer_jwk()],
+        };
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &[wrong_issuer]);
+
+        assert!(result.is_err());
+        // Signature verification will fail because the key doesn't match
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::SignatureVerificationFailed(_)
+        ));
+    }
+
+    #[test]
+    fn test_unknown_issuer_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+
+        // Empty trusted issuers list
+        let result = VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &[]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::UntrustedIssuer(iss) if iss == TEST_ISSUER
+        ));
+    }
+
+    #[test]
+    fn test_subject_client_id_mismatch_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result = VerifierAttestationJwt::decode_and_validate(
+            &jwt,
+            "verifier_attestation:wrong-client", // Different client_id
+            &trusted_issuers,
+        );
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::SubjectMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn test_expired_attestation_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: None,
+            iat: now - 7200, // Issued 2 hours ago
+            exp: now - 3600, // Expired 1 hour ago
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: None,
+            nonce: None,
+        };
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::Expired
+        ));
+    }
+
+    #[test]
+    fn test_not_yet_valid_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: None,
+            iat: now,
+            exp: now + 7200,
+            nbf: Some(now + 3600), // Not valid for another hour
+            jti: None,
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: None,
+            nonce: None,
+        };
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::NotYetValid
+        ));
+    }
+
+    #[test]
+    fn test_invalid_jwt_format_rejection() {
+        let result =
+            VerifierAttestationJwt::decode_and_validate("not.a.valid.jwt", TEST_CLIENT_ID, &[]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidFormat(_)
+        ));
+    }
+
+    #[test]
+    fn test_verifier_attestation_jwt_accessors() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let attestation =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+                .expect("should succeed");
+
+        assert_eq!(attestation.issuer(), TEST_ISSUER);
+        assert_eq!(attestation.subject(), TEST_CLIENT_ID);
+        assert_eq!(attestation.raw(), jwt);
+
+        // Check that verifier_public_key returns the key from cnf.jwk
+        let verifier_jwk = keys.verifier_jwk();
+        assert_eq!(
+            serde_json::to_string(attestation.verifier_public_key()).unwrap(),
+            serde_json::to_string(&verifier_jwk).unwrap()
+        );
+
+        let allowed_uris = attestation.allowed_response_uris().unwrap();
+        assert_eq!(allowed_uris.len(), 2);
+        assert!(allowed_uris.contains(&"https://verifier.example.com/cb1".to_string()));
+    }
+
+    #[test]
+    fn test_validate_response_uri_allowed() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let attestation =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+                .expect("should succeed");
+
+        // Both URIs from the allowlist should be valid
+        assert!(
+            attestation
+                .validate_response_uri("https://verifier.example.com/cb1")
+                .is_ok()
+        );
+        assert!(
+            attestation
+                .validate_response_uri("https://verifier.example.com/cb2")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_validate_response_uri_not_allowed() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let attestation =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+                .expect("should succeed");
+
+        let result = attestation.validate_response_uri("https://evil.com/cb");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::ResponseUriNotAllowed(uri) if uri == "https://evil.com/cb"
+        ));
+    }
+
+    #[test]
+    fn test_validate_response_uri_no_restrictions() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: None,
+            iat: now,
+            exp: now + 3600,
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: None, // No restrictions
+            nonce: None,
+        };
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let attestation =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+                .expect("should succeed");
+
+        // Any URI should be allowed when response_uris is not set
+        assert!(
+            attestation
+                .validate_response_uri("https://any.com/cb")
+                .is_ok()
+        );
+        assert!(
+            attestation
+                .validate_response_uri("https://other.com/cb")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_verifier_attestation_error_display() {
+        let err = VerifierAttestationError::InvalidFormat("test error".to_string());
+        assert!(err.to_string().contains("invalid JWT format"));
+
+        let err = VerifierAttestationError::InvalidTyp {
+            expected: "verifier-attestation+jwt".to_string(),
+            actual: "jwt".to_string(),
+        };
+        assert!(err.to_string().contains("invalid 'typ' header"));
+
+        let err = VerifierAttestationError::UntrustedIssuer("bad-issuer".to_string());
+        assert!(err.to_string().contains("untrusted issuer"));
+
+        let err = VerifierAttestationError::SubjectMismatch {
+            expected: "expected-sub".to_string(),
+            actual: "actual-sub".to_string(),
+        };
+        assert!(err.to_string().contains("subject mismatch"));
+
+        let err = VerifierAttestationError::Expired;
+        assert!(err.to_string().contains("expired"));
+
+        let err = VerifierAttestationError::NotYetValid;
+        assert!(err.to_string().contains("not yet valid"));
+
+        let err = VerifierAttestationError::MissingCnfJwk;
+        assert!(err.to_string().contains("cnf.jwk"));
+
+        let err = VerifierAttestationError::ResponseUriNotAllowed("https://evil.com".to_string());
+        assert!(err.to_string().contains("response_uri not allowed"));
+    }
+
+    #[test]
+    fn test_trusted_attestation_issuer_creation() {
+        let issuer = TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(),
+            jwks: vec![],
+        };
+        assert_eq!(issuer.issuer_id, TEST_ISSUER);
+    }
+
+    #[test]
+    fn test_verifier_attestation_claims_serde() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: Some("https://wallet.example.com".to_string()),
+            iat: now,
+            exp: now + 3600,
+            nbf: Some(now),
+            jti: Some("test-jti".to_string()),
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: Some(vec!["https://verifier.example.com/cb".to_string()]),
+            nonce: Some("test-nonce".to_string()),
+        };
+
+        let serialized = serde_json::to_string(&claims).expect("failed to serialize");
+        let deserialized: VerifierAttestationClaims =
+            serde_json::from_str(&serialized).expect("failed to deserialize");
+
+        assert_eq!(deserialized.iss, claims.iss);
+        assert_eq!(deserialized.sub, claims.sub);
+        assert_eq!(deserialized.aud, claims.aud);
+        assert_eq!(deserialized.iat, claims.iat);
+        assert_eq!(deserialized.exp, claims.exp);
+    }
+
+    #[test]
+    fn test_cnfg_claim_serde() {
+        let keys = TestKeys::generate();
+        let cnf = CnfClaim {
+            jwk: keys.verifier_jwk(),
+        };
+        let serialized = serde_json::to_string(&cnf).expect("failed to serialize");
+        assert!(serialized.contains("jwk"));
+
+        let deserialized: CnfClaim =
+            serde_json::from_str(&serialized).expect("failed to deserialize");
+        assert!(matches!(
+            deserialized.jwk.key,
+            cloud_wallet_crypto::jwk::Key::Ec(_)
+        ));
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -27,8 +27,10 @@ pub struct VerifierAttestationClaims {
 
     pub cnf: CnfClaim,
 
-    /// Authorized response URI for this verifier.
-    pub response_uri: Option<Vec<String>>,
+    /// Authorized redirect URIs for this verifier.
+    /// The Wallet must compare the Authorization Request `redirect_uri` or `response_uri`
+    /// against this allowlist as defined in OpenID4VP Section 12.
+    pub redirect_uris: Option<Vec<String>>,
 
     pub nonce: Option<String>,
 }
@@ -319,16 +321,17 @@ impl VerifierAttestationJwt {
         Ok(())
     }
 
-    /// Validates that a response_uri is in the allowed list.
-    pub fn validate_response_uri(
-        &self,
-        response_uri: &str,
-    ) -> Result<(), VerifierAttestationError> {
-        if let Some(ref allowed_uris) = self.claims.response_uri {
+    /// Validates that a redirect_uri or response_uri is in the allowed list.
+    ///
+    /// Per OpenID4VP Section 13.3, the `response_uri` value follows the same
+    /// permission rules as `redirect_uri`. The attestation JWT contains a
+    /// `redirect_uris` allowlist that the request URI must match against.
+    pub fn validate_redirect_uri(&self, uri: &str) -> Result<(), VerifierAttestationError> {
+        if let Some(ref allowed_uris) = self.claims.redirect_uris {
             let allowed_set: HashSet<&str> = allowed_uris.iter().map(String::as_str).collect();
-            if !allowed_set.contains(response_uri) {
+            if !allowed_set.contains(uri) {
                 return Err(VerifierAttestationError::ResponseUriNotAllowed(
-                    response_uri.to_string(),
+                    uri.to_string(),
                 ));
             }
         }
@@ -360,9 +363,9 @@ impl VerifierAttestationJwt {
         &self.raw
     }
 
-    /// Returns the list of allowed response URIs, if specified.
-    pub fn allowed_response_uri(&self) -> Option<&[String]> {
-        self.claims.response_uri.as_deref()
+    /// Returns the list of allowed redirect URIs, if specified.
+    pub fn allowed_redirect_uris(&self) -> Option<&[String]> {
+        self.claims.redirect_uris.as_deref()
     }
 }
 
@@ -469,7 +472,7 @@ mod tests {
             cnf: CnfClaim {
                 jwk: keys.verifier_jwk(),
             },
-            response_uri: Some(vec![
+            redirect_uris: Some(vec![
                 "https://verifier.example.com/cb1".to_string(),
                 "https://verifier.example.com/cb2".to_string(),
             ]),
@@ -587,7 +590,7 @@ mod tests {
             cnf: CnfClaim {
                 jwk: keys.verifier_jwk(),
             },
-            response_uri: None,
+            redirect_uris: None,
             nonce: None,
         };
         let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
@@ -650,9 +653,9 @@ mod tests {
         );
     }
 
-    /// 7. `response_uri` allowlist enforcement
+    /// 7. `redirect_uris` allowlist enforcement
     #[test]
-    fn test_response_uri_allowlist_enforcement() {
+    fn test_redirect_uris_allowlist_enforcement() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
         let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
@@ -665,12 +668,12 @@ mod tests {
         // Allowed URI should succeed
         assert!(
             attestation
-                .validate_response_uri("https://verifier.example.com/cb1")
+                .validate_redirect_uri("https://verifier.example.com/cb1")
                 .is_ok()
         );
 
         // Not allowed URI should fail
-        let result = attestation.validate_response_uri("https://evil.com/cb");
+        let result = attestation.validate_redirect_uri("https://evil.com/cb");
         assert!(result.is_err());
         assert!(matches!(
             result.unwrap_err(),
@@ -728,7 +731,7 @@ mod tests {
             nbf: None,
             jti: None,
             cnf: CnfClaim { jwk: symmetric_jwk },
-            response_uri: None,
+            redirect_uris: None,
             nonce: None,
         };
 
@@ -764,7 +767,7 @@ mod tests {
             nbf: None,
             jti: None,
             cnf: CnfClaim { jwk: wrong_use_jwk },
-            response_uri: None,
+            redirect_uris: None,
             nonce: None,
         };
 
@@ -800,7 +803,7 @@ mod tests {
             nbf: None,
             jti: None,
             cnf: CnfClaim { jwk: wrong_ops_jwk },
-            response_uri: None,
+            redirect_uris: None,
             nonce: None,
         };
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -17,7 +17,7 @@ pub struct VerifierAttestationClaims {
 
     pub aud: Option<String>,
 
-    pub iat: i64,
+    pub iat: Option<i64>,
 
     pub exp: i64,
 
@@ -223,6 +223,13 @@ impl VerifierAttestationJwt {
             return Err(VerifierAttestationError::NotYetValid);
         }
 
+        // Check issued-at if present (iat should not be in the future)
+        if let Some(iat) = claims.iat
+            && iat > now
+        {
+            return Err(VerifierAttestationError::IssuedInFuture);
+        }
+
         Ok(())
     }
 
@@ -285,7 +292,6 @@ impl VerifierAttestationJwt {
     }
 
     /// Returns the Verifier's public key from the `cnf.jwk` claim.
-
     pub fn verifier_public_key(&self) -> &Jwk {
         &self.claims.cnf.jwk
     }
@@ -396,7 +402,7 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: Some("https://wallet.example.com".to_string()),
-            iat: now,
+            iat: Some(now),
             exp: now + 3600, // Valid for 1 hour
             nbf: None,
             jti: Some("test-jti".to_string()),
@@ -447,7 +453,7 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: None, // Optional
-            iat: now,
+            iat: None, // Optional - iat is now optional per spec
             exp: now + 3600,
             nbf: None, // Optional
             jti: None, // Optional
@@ -570,8 +576,8 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: None,
-            iat: now - 7200, // Issued 2 hours ago
-            exp: now - 3600, // Expired 1 hour ago
+            iat: Some(now - 7200), // Issued 2 hours ago
+            exp: now - 3600,       // Expired 1 hour ago
             nbf: None,
             jti: None,
             cnf: CnfClaim {
@@ -601,7 +607,7 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: None,
-            iat: now,
+            iat: Some(now),
             exp: now + 7200,
             nbf: Some(now + 3600), // Not valid for another hour
             jti: None,
@@ -714,7 +720,7 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: None,
-            iat: now,
+            iat: Some(now),
             exp: now + 3600,
             nbf: None,
             jti: None,
@@ -775,6 +781,9 @@ mod tests {
 
         let err = VerifierAttestationError::ResponseUriNotAllowed("https://evil.com".to_string());
         assert!(err.to_string().contains("response_uri not allowed"));
+
+        let err = VerifierAttestationError::IssuedInFuture;
+        assert!(err.to_string().contains("iat claim in the future"));
     }
 
     #[test]
@@ -794,7 +803,7 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: Some("https://wallet.example.com".to_string()),
-            iat: now,
+            iat: Some(now),
             exp: now + 3600,
             nbf: Some(now),
             jti: Some("test-jti".to_string()),
@@ -831,5 +840,84 @@ mod tests {
             deserialized.jwk.key,
             cloud_wallet_crypto::jwk::Key::Ec(_)
         ));
+    }
+
+    #[test]
+    fn test_issued_in_future_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_CLIENT_ID.to_string(),
+            aud: None,
+            iat: Some(now + 3600), // Issued 1 hour in the future - invalid
+            exp: now + 7200,
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim {
+                jwk: keys.verifier_jwk(),
+            },
+            response_uris: None,
+            nonce: None,
+        };
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::IssuedInFuture
+        ));
+    }
+
+    #[test]
+    fn test_missing_cnf_claim_rejection() {
+        use jsonwebtoken::Algorithm;
+
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+
+        // Create claims without cnf by manually constructing the JWT payload
+        let claims_without_cnf = serde_json::json!({
+            "iss": TEST_ISSUER,
+            "sub": TEST_CLIENT_ID,
+            "exp": now + 3600,
+            "iat": now,
+        });
+
+        // Create a JWT without the cnf claim
+        let header = jsonwebtoken::Header {
+            typ: Some(VerifierAttestationJwt::EXPECTED_TYP.to_string()),
+            alg: Algorithm::ES256,
+            kid: None,
+            ..Default::default()
+        };
+
+        let encoding_key = keys.issuer_encoding_key();
+        let jwt = jsonwebtoken::encode(&header, &claims_without_cnf, &encoding_key)
+            .expect("failed to encode JWT");
+
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        // Attempt to decode and validate - should fail due to missing cnf
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        // The error should be a decoding/validation error due to missing cnf
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                VerifierAttestationError::DecodingFailed(_)
+                    | VerifierAttestationError::MissingCnf(_)
+                    | VerifierAttestationError::MissingCnfJwk
+            ),
+            "Expected error due to missing cnf, got: {:?}",
+            err
+        );
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -424,8 +424,11 @@ mod tests {
         }
     }
 
+    // ==== TICKET-REQUIRED TESTS (7 tests) ====
+
+    /// 1. Valid attestation JWT decode and validation
     #[test]
-    fn test_decode_and_validate_success() {
+    fn test_valid_attestation_decode_and_validation() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
         let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
@@ -436,44 +439,15 @@ mod tests {
 
         assert!(
             result.is_ok(),
-            "expected success but got: {:?}",
+            "Expected success but got: {:?}",
             result.err()
         );
         let attestation = result.unwrap();
         assert_eq!(attestation.issuer(), TEST_ISSUER);
         assert_eq!(attestation.subject(), TEST_CLIENT_ID);
-        assert!(attestation.allowed_response_uris().is_some());
     }
 
-    #[test]
-    fn test_valid_jwt_without_optional_claims() {
-        let keys = TestKeys::generate();
-        let now = jsonwebtoken::get_current_timestamp() as i64;
-        let claims = VerifierAttestationClaims {
-            iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
-            aud: None, // Optional
-            iat: None, // Optional - iat is now optional per spec
-            exp: now + 3600,
-            nbf: None, // Optional
-            jti: None, // Optional
-            cnf: CnfClaim {
-                jwk: keys.verifier_jwk(),
-            },
-            response_uris: None, // Optional - no restrictions
-            nonce: None,         // Optional
-        };
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
-
-        assert!(result.is_ok());
-        let attestation = result.unwrap();
-        assert!(attestation.allowed_response_uris().is_none());
-    }
-
+    /// 2. Wrong `typ` header rejection
     #[test]
     fn test_wrong_typ_header_rejection() {
         let keys = TestKeys::generate();
@@ -491,54 +465,14 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_missing_typ_header_rejection() {
-        let keys = TestKeys::generate();
-        let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, ""); // Empty typ header
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
-
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::InvalidTyp { .. }
-        ));
-    }
-
+    /// 3. Untrusted issuer rejection
     #[test]
     fn test_untrusted_issuer_rejection() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
         let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
 
-        // Use a different issuer (not matching the JWT's iss claim)
-        let other_keys = TestKeys::generate();
-        let wrong_issuer = TrustedAttestationIssuer {
-            issuer_id: TEST_ISSUER.to_string(), // Same ID but different key
-            jwks: vec![other_keys.issuer_jwk()],
-        };
-
-        let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &[wrong_issuer]);
-
-        assert!(result.is_err());
-        // Signature verification will fail because the key doesn't match
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::SignatureVerificationFailed(_)
-        ));
-    }
-
-    #[test]
-    fn test_unknown_issuer_rejection() {
-        let keys = TestKeys::generate();
-        let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-
-        // Empty trusted issuers list
+        // Unknown issuer - not in trusted list
         let result = VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &[]);
 
         assert!(result.is_err());
@@ -548,8 +482,9 @@ mod tests {
         ));
     }
 
+    /// 4. `sub` / `client_id` mismatch rejection
     #[test]
-    fn test_subject_client_id_mismatch_rejection() {
+    fn test_sub_client_id_mismatch_rejection() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
         let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
@@ -568,6 +503,7 @@ mod tests {
         ));
     }
 
+    /// 5. Expired attestation rejection
     #[test]
     fn test_expired_attestation_rejection() {
         let keys = TestKeys::generate();
@@ -576,8 +512,8 @@ mod tests {
             iss: TEST_ISSUER.to_string(),
             sub: TEST_CLIENT_ID.to_string(),
             aud: None,
-            iat: Some(now - 7200), // Issued 2 hours ago
-            exp: now - 3600,       // Expired 1 hour ago
+            iat: None,
+            exp: now - 3600, // Expired 1 hour ago
             nbf: None,
             jti: None,
             cnf: CnfClaim {
@@ -599,282 +535,9 @@ mod tests {
         ));
     }
 
+    /// 6. Missing `cnf.jwk` rejection
     #[test]
-    fn test_not_yet_valid_rejection() {
-        let keys = TestKeys::generate();
-        let now = jsonwebtoken::get_current_timestamp() as i64;
-        let claims = VerifierAttestationClaims {
-            iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
-            aud: None,
-            iat: Some(now),
-            exp: now + 7200,
-            nbf: Some(now + 3600), // Not valid for another hour
-            jti: None,
-            cnf: CnfClaim {
-                jwk: keys.verifier_jwk(),
-            },
-            response_uris: None,
-            nonce: None,
-        };
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
-
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::NotYetValid
-        ));
-    }
-
-    #[test]
-    fn test_invalid_jwt_format_rejection() {
-        let result =
-            VerifierAttestationJwt::decode_and_validate("not.a.valid.jwt", TEST_CLIENT_ID, &[]);
-
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::InvalidFormat(_)
-        ));
-    }
-
-    #[test]
-    fn test_verifier_attestation_jwt_accessors() {
-        let keys = TestKeys::generate();
-        let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let attestation =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
-                .expect("should succeed");
-
-        assert_eq!(attestation.issuer(), TEST_ISSUER);
-        assert_eq!(attestation.subject(), TEST_CLIENT_ID);
-        assert_eq!(attestation.raw(), jwt);
-
-        // Check that verifier_public_key returns the key from cnf.jwk
-        let verifier_jwk = keys.verifier_jwk();
-        assert_eq!(
-            serde_json::to_string(attestation.verifier_public_key()).unwrap(),
-            serde_json::to_string(&verifier_jwk).unwrap()
-        );
-
-        let allowed_uris = attestation.allowed_response_uris().unwrap();
-        assert_eq!(allowed_uris.len(), 2);
-        assert!(allowed_uris.contains(&"https://verifier.example.com/cb1".to_string()));
-    }
-
-    #[test]
-    fn test_validate_response_uri_allowed() {
-        let keys = TestKeys::generate();
-        let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let attestation =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
-                .expect("should succeed");
-
-        // Both URIs from the allowlist should be valid
-        assert!(
-            attestation
-                .validate_response_uri("https://verifier.example.com/cb1")
-                .is_ok()
-        );
-        assert!(
-            attestation
-                .validate_response_uri("https://verifier.example.com/cb2")
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn test_validate_response_uri_not_allowed() {
-        let keys = TestKeys::generate();
-        let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let attestation =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
-                .expect("should succeed");
-
-        let result = attestation.validate_response_uri("https://evil.com/cb");
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::ResponseUriNotAllowed(uri) if uri == "https://evil.com/cb"
-        ));
-    }
-
-    #[test]
-    fn test_validate_response_uri_no_restrictions() {
-        let keys = TestKeys::generate();
-        let now = jsonwebtoken::get_current_timestamp() as i64;
-        let claims = VerifierAttestationClaims {
-            iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
-            aud: None,
-            iat: Some(now),
-            exp: now + 3600,
-            nbf: None,
-            jti: None,
-            cnf: CnfClaim {
-                jwk: keys.verifier_jwk(),
-            },
-            response_uris: None, // No restrictions
-            nonce: None,
-        };
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let attestation =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
-                .expect("should succeed");
-
-        // Any URI should be allowed when response_uris is not set
-        assert!(
-            attestation
-                .validate_response_uri("https://any.com/cb")
-                .is_ok()
-        );
-        assert!(
-            attestation
-                .validate_response_uri("https://other.com/cb")
-                .is_ok()
-        );
-    }
-
-    #[test]
-    fn test_verifier_attestation_error_display() {
-        let err = VerifierAttestationError::InvalidFormat("test error".to_string());
-        assert!(err.to_string().contains("invalid JWT format"));
-
-        let err = VerifierAttestationError::InvalidTyp {
-            expected: "verifier-attestation+jwt".to_string(),
-            actual: "jwt".to_string(),
-        };
-        assert!(err.to_string().contains("invalid 'typ' header"));
-
-        let err = VerifierAttestationError::UntrustedIssuer("bad-issuer".to_string());
-        assert!(err.to_string().contains("untrusted issuer"));
-
-        let err = VerifierAttestationError::SubjectMismatch {
-            expected: "expected-sub".to_string(),
-            actual: "actual-sub".to_string(),
-        };
-        assert!(err.to_string().contains("subject mismatch"));
-
-        let err = VerifierAttestationError::Expired;
-        assert!(err.to_string().contains("expired"));
-
-        let err = VerifierAttestationError::NotYetValid;
-        assert!(err.to_string().contains("not yet valid"));
-
-        let err = VerifierAttestationError::MissingCnfJwk;
-        assert!(err.to_string().contains("cnf.jwk"));
-
-        let err = VerifierAttestationError::ResponseUriNotAllowed("https://evil.com".to_string());
-        assert!(err.to_string().contains("response_uri not allowed"));
-
-        let err = VerifierAttestationError::IssuedInFuture;
-        assert!(err.to_string().contains("iat claim in the future"));
-    }
-
-    #[test]
-    fn test_trusted_attestation_issuer_creation() {
-        let issuer = TrustedAttestationIssuer {
-            issuer_id: TEST_ISSUER.to_string(),
-            jwks: vec![],
-        };
-        assert_eq!(issuer.issuer_id, TEST_ISSUER);
-    }
-
-    #[test]
-    fn test_verifier_attestation_claims_serde() {
-        let keys = TestKeys::generate();
-        let now = jsonwebtoken::get_current_timestamp() as i64;
-        let claims = VerifierAttestationClaims {
-            iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
-            aud: Some("https://wallet.example.com".to_string()),
-            iat: Some(now),
-            exp: now + 3600,
-            nbf: Some(now),
-            jti: Some("test-jti".to_string()),
-            cnf: CnfClaim {
-                jwk: keys.verifier_jwk(),
-            },
-            response_uris: Some(vec!["https://verifier.example.com/cb".to_string()]),
-            nonce: Some("test-nonce".to_string()),
-        };
-
-        let serialized = serde_json::to_string(&claims).expect("failed to serialize");
-        let deserialized: VerifierAttestationClaims =
-            serde_json::from_str(&serialized).expect("failed to deserialize");
-
-        assert_eq!(deserialized.iss, claims.iss);
-        assert_eq!(deserialized.sub, claims.sub);
-        assert_eq!(deserialized.aud, claims.aud);
-        assert_eq!(deserialized.iat, claims.iat);
-        assert_eq!(deserialized.exp, claims.exp);
-    }
-
-    #[test]
-    fn test_cnfg_claim_serde() {
-        let keys = TestKeys::generate();
-        let cnf = CnfClaim {
-            jwk: keys.verifier_jwk(),
-        };
-        let serialized = serde_json::to_string(&cnf).expect("failed to serialize");
-        assert!(serialized.contains("jwk"));
-
-        let deserialized: CnfClaim =
-            serde_json::from_str(&serialized).expect("failed to deserialize");
-        assert!(matches!(
-            deserialized.jwk.key,
-            cloud_wallet_crypto::jwk::Key::Ec(_)
-        ));
-    }
-
-    #[test]
-    fn test_issued_in_future_rejection() {
-        let keys = TestKeys::generate();
-        let now = jsonwebtoken::get_current_timestamp() as i64;
-        let claims = VerifierAttestationClaims {
-            iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
-            aud: None,
-            iat: Some(now + 3600), // Issued 1 hour in the future - invalid
-            exp: now + 7200,
-            nbf: None,
-            jti: None,
-            cnf: CnfClaim {
-                jwk: keys.verifier_jwk(),
-            },
-            response_uris: None,
-            nonce: None,
-        };
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
-        let trusted_issuers = vec![trusted_issuer(&keys)];
-
-        let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
-
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            VerifierAttestationError::IssuedInFuture
-        ));
-    }
-
-    #[test]
-    fn test_missing_cnf_claim_rejection() {
+    fn test_missing_cnf_jwk_rejection() {
         use jsonwebtoken::Algorithm;
 
         let keys = TestKeys::generate();
@@ -885,7 +548,6 @@ mod tests {
             "iss": TEST_ISSUER,
             "sub": TEST_CLIENT_ID,
             "exp": now + 3600,
-            "iat": now,
         });
 
         // Create a JWT without the cnf claim
@@ -907,7 +569,6 @@ mod tests {
             VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
 
         assert!(result.is_err());
-        // The error should be a decoding/validation error due to missing cnf
         let err = result.unwrap_err();
         assert!(
             matches!(
@@ -919,5 +580,33 @@ mod tests {
             "Expected error due to missing cnf, got: {:?}",
             err
         );
+    }
+
+    /// 7. `response_uris` allowlist enforcement
+    #[test]
+    fn test_response_uris_allowlist_enforcement() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let attestation =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+                .expect("should succeed");
+
+        // Allowed URI should succeed
+        assert!(
+            attestation
+                .validate_response_uri("https://verifier.example.com/cb1")
+                .is_ok()
+        );
+
+        // Not allowed URI should fail
+        let result = attestation.validate_response_uri("https://evil.com/cb");
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::ResponseUriNotAllowed(uri) if uri == "https://evil.com/cb"
+        ));
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -424,8 +424,6 @@ mod tests {
         }
     }
 
-    // ==== TICKET-REQUIRED TESTS (7 tests) ====
-
     /// 1. Valid attestation JWT decode and validation
     #[test]
     fn test_valid_attestation_decode_and_validation() {

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use cloud_wallet_crypto::jwk::Jwk;
+use cloud_wallet_crypto::jwk::{Jwk, Key, KeyUse, Operations};
 use jsonwebtoken::{DecodingKey, Validation, decode, jwk::Jwk as JwtJwk};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -27,7 +27,8 @@ pub struct VerifierAttestationClaims {
 
     pub cnf: CnfClaim,
 
-    pub response_uris: Option<Vec<String>>,
+    /// Authorized response URI for this verifier.
+    pub response_uri: Option<Vec<String>>,
 
     pub nonce: Option<String>,
 }
@@ -45,6 +46,9 @@ impl VerifierAttestationJwt {
     pub const EXPECTED_TYP: &'static str = "verifier-attestation+jwt";
 
     /// Decodes and validates a Verifier Attestation JWT.
+    ///
+    /// The `client_id` should be the unprefixed verifier identifier (without `verifier_attestation:`).
+    /// The `sub` claim in the JWT must match this client_id exactly.
     pub fn decode_and_validate(
         jwt: &str,
         client_id: &str,
@@ -69,7 +73,7 @@ impl VerifierAttestationJwt {
         // Validate temporal claims
         Self::validate_temporal(&claims)?;
 
-        // Validate that cnf.jwk is present
+        // Validate that cnf.jwk is present and is a valid public key
         Self::validate_cnf(&claims)?;
 
         Ok(Self {
@@ -129,9 +133,52 @@ impl VerifierAttestationJwt {
         header: &jsonwebtoken::Header,
         trusted_issuer: &TrustedAttestationIssuer,
     ) -> Result<VerifierAttestationClaims, VerifierAttestationError> {
-        // Find the appropriate key based on header (kid) or try all keys
-        let key = Self::resolve_verification_key(header, &trusted_issuer.jwks)?;
+        // If there's a kid in the header, find the matching key and use it
+        if let Some(ref kid) = header.kid {
+            let key = trusted_issuer
+                .jwks
+                .iter()
+                .find(|k| k.prm.kid.as_deref() == Some(kid));
+            match key {
+                Some(key) => {
+                    let decoding_key = Self::jwk_to_decoding_key(key)?;
+                    return Self::decode_with_key(jwt, header, &decoding_key);
+                }
+                None => {
+                    return Err(VerifierAttestationError::UnknownKeyId(kid.clone()));
+                }
+            }
+        }
 
+        // No kid in header - if exactly one key, use it
+        if trusted_issuer.jwks.len() == 1 {
+            let decoding_key = Self::jwk_to_decoding_key(&trusted_issuer.jwks[0])?;
+            return Self::decode_with_key(jwt, header, &decoding_key);
+        }
+
+        // No kid and multiple keys - try all keys until one verifies
+        for jwk in &trusted_issuer.jwks {
+            let decoding_key = match Self::jwk_to_decoding_key(jwk) {
+                Ok(key) => key,
+                Err(_) => continue, // Skip keys that can't be converted
+            };
+            if let Ok(claims) = Self::decode_with_key(jwt, header, &decoding_key) {
+                return Ok(claims);
+            }
+        }
+
+        // None of the keys verified
+        Err(VerifierAttestationError::SignatureVerificationFailed(
+            "signature verification failed with all available keys".to_string(),
+        ))
+    }
+
+    /// Decodes the JWT with a specific decoding key.
+    fn decode_with_key(
+        jwt: &str,
+        header: &jsonwebtoken::Header,
+        decoding_key: &DecodingKey,
+    ) -> Result<VerifierAttestationClaims, VerifierAttestationError> {
         // Configure validation - we validate exp and iat here, others manually
         let mut validation = Validation::new(header.alg);
         validation.validate_exp = false;
@@ -139,38 +186,10 @@ impl VerifierAttestationJwt {
         validation.validate_aud = false; // Audience is optional per spec, validate manually if needed
         validation.required_spec_claims.clear();
 
-        let token_data = decode::<VerifierAttestationClaims>(jwt, &key, &validation)
+        let token_data = decode::<VerifierAttestationClaims>(jwt, decoding_key, &validation)
             .map_err(|e| VerifierAttestationError::SignatureVerificationFailed(e.to_string()))?;
 
         Ok(token_data.claims)
-    }
-
-    /// Resolves the verification key from the JWKS based on the header.
-    fn resolve_verification_key(
-        header: &jsonwebtoken::Header,
-        jwks: &[Jwk],
-    ) -> Result<DecodingKey, VerifierAttestationError> {
-        // If there's a kid in the header, find the matching key
-        if let Some(ref kid) = header.kid {
-            let key = jwks.iter().find(|k| k.prm.kid.as_deref() == Some(kid));
-            if let Some(key) = key {
-                return Self::jwk_to_decoding_key(key);
-            }
-        }
-
-        // If no kid or no matching key found, try the first key (if only one)
-        if jwks.len() == 1 {
-            return Self::jwk_to_decoding_key(&jwks[0]);
-        }
-
-        if !jwks.is_empty() {
-            // Return the first key - the decode function will fail if it doesn't match
-            return Self::jwk_to_decoding_key(&jwks[0]);
-        }
-
-        Err(VerifierAttestationError::SignatureVerificationFailed(
-            "no verification keys available".to_string(),
-        ))
     }
 
     /// Converts a JWK to a jsonwebtoken DecodingKey.
@@ -234,48 +253,78 @@ impl VerifierAttestationJwt {
     }
 
     /// Validate that the `cnf` claim contains a valid `jwk`.
+    ///
+    /// The JWK must be a public key suitable for verifying request object signatures.
+    /// Symmetric keys (Oct) are rejected as they would represent a shared secret
+    /// rather than a public verification key.
     fn validate_cnf(claims: &VerifierAttestationClaims) -> Result<(), VerifierAttestationError> {
-        // Check that the cnf claim exists (it's required by struct definition)
-        // and that the JWK contains valid key material
-        match &claims.cnf.jwk.key {
-            cloud_wallet_crypto::jwk::Key::Ec(ec) => {
+        let jwk = &claims.cnf.jwk;
+
+        // Reject symmetric keys - cnf.jwk must be a public key for signature verification
+        if matches!(jwk.key, Key::Oct(_)) {
+            return Err(VerifierAttestationError::InvalidKeyType(
+                "symmetric keys (oct) are not allowed for cnf.jwk - must be a public key"
+                    .to_string(),
+            ));
+        }
+
+        // Check key usage metadata when present
+        if let Some(key_use) = &jwk.prm.key_use
+            && *key_use != KeyUse::Signing
+        {
+            return Err(VerifierAttestationError::InvalidKeyType(format!(
+                "key 'use' must be 'sig' for signature verification, got '{:?}'",
+                key_use
+            )));
+        }
+
+        // Check key operations when present
+        if let Some(ops) = &jwk.prm.ops {
+            // For signature verification, the key should support 'verify' operation
+            if !ops.contains(&Operations::Verify) {
+                return Err(VerifierAttestationError::InvalidKeyType(
+                    "key 'key_ops' must include 'verify' for signature verification".to_string(),
+                ));
+            }
+        }
+
+        // Validate key material based on key type
+        match &jwk.key {
+            Key::Ec(ec) => {
                 // Validate that EC key has non-empty coordinates
                 if ec.x.is_empty() || ec.y.is_empty() {
                     return Err(VerifierAttestationError::MissingCnfJwk);
                 }
             }
-            cloud_wallet_crypto::jwk::Key::Rsa(rsa) => {
+            Key::Rsa(rsa) => {
                 // Validate that RSA key has non-empty modulus and exponent
                 if rsa.n.is_empty() || rsa.e.is_empty() {
                     return Err(VerifierAttestationError::MissingCnfJwk);
                 }
             }
-            cloud_wallet_crypto::jwk::Key::Oct(oct) => {
-                // Validate that octet key has non-empty value
-                if oct.k.is_empty() {
-                    return Err(VerifierAttestationError::MissingCnfJwk);
-                }
-            }
-            cloud_wallet_crypto::jwk::Key::Okp(okp) => {
+            Key::Okp(okp) => {
                 // Validate that OKP key has non-empty public key
                 if okp.x.is_empty() {
                     return Err(VerifierAttestationError::MissingCnfJwk);
                 }
             }
-            // Handle non-exhaustive enum - any future key types are considered invalid
+            // Oct keys were already rejected above, this handles any future key types
             _ => {
-                return Err(VerifierAttestationError::MissingCnfJwk);
+                return Err(VerifierAttestationError::InvalidKeyType(
+                    "unsupported key type for cnf.jwk".to_string(),
+                ));
             }
         }
+
         Ok(())
     }
 
-    /// Validates that a responseuri is in the allowed list.
+    /// Validates that a response_uri is in the allowed list.
     pub fn validate_response_uri(
         &self,
         response_uri: &str,
     ) -> Result<(), VerifierAttestationError> {
-        if let Some(ref allowed_uris) = self.claims.response_uris {
+        if let Some(ref allowed_uris) = self.claims.response_uri {
             let allowed_set: HashSet<&str> = allowed_uris.iter().map(String::as_str).collect();
             if !allowed_set.contains(response_uri) {
                 return Err(VerifierAttestationError::ResponseUriNotAllowed(
@@ -312,8 +361,8 @@ impl VerifierAttestationJwt {
     }
 
     /// Returns the list of allowed response URIs, if specified.
-    pub fn allowed_response_uris(&self) -> Option<&[String]> {
-        self.claims.response_uris.as_deref()
+    pub fn allowed_response_uri(&self) -> Option<&[String]> {
+        self.claims.response_uri.as_deref()
     }
 }
 
@@ -345,7 +394,8 @@ mod tests {
     use super::*;
 
     const TEST_ISSUER: &str = "https://attestation.example.com";
-    const TEST_CLIENT_ID: &str = "verifier_attestation:verifier123";
+    // The client_id WITHOUT the prefix - sub claim must match this exactly
+    const TEST_VERIFIER_ID: &str = "verifier123";
 
     /// Helper struct to manage test keys for creating and validating JWTs.
     struct TestKeys {
@@ -372,7 +422,12 @@ mod tests {
         }
 
         fn verifier_jwk(&self) -> Jwk {
-            Jwk::try_from(&self.verifier_key_pair).expect("failed to convert verifier key to JWK")
+            let mut jwk = Jwk::try_from(&self.verifier_key_pair)
+                .expect("failed to convert verifier key to JWK");
+            // Set appropriate key metadata for a signing key
+            jwk.prm.key_use = Some(KeyUse::Signing);
+            jwk.prm.ops = Some([Operations::Verify, Operations::Sign].into_iter().collect());
+            jwk
         }
 
         fn issuer_encoding_key(&self) -> EncodingKey {
@@ -383,11 +438,16 @@ mod tests {
     }
 
     /// Creates a signed Verifier Attestation JWT with the given claims.
-    fn create_test_jwt(keys: &TestKeys, claims: &VerifierAttestationClaims, typ: &str) -> String {
+    fn create_test_jwt(
+        keys: &TestKeys,
+        claims: &VerifierAttestationClaims,
+        typ: &str,
+        kid: Option<&str>,
+    ) -> String {
         let header = jsonwebtoken::Header {
             typ: Some(typ.to_string()),
             alg: Algorithm::ES256,
-            kid: None,
+            kid: kid.map(|s| s.to_string()),
             ..Default::default()
         };
 
@@ -400,7 +460,7 @@ mod tests {
         let now = jsonwebtoken::get_current_timestamp() as i64;
         VerifierAttestationClaims {
             iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
+            sub: TEST_VERIFIER_ID.to_string(), // sub is the unprefixed verifier ID
             aud: Some("https://wallet.example.com".to_string()),
             iat: Some(now),
             exp: now + 3600, // Valid for 1 hour
@@ -409,7 +469,7 @@ mod tests {
             cnf: CnfClaim {
                 jwk: keys.verifier_jwk(),
             },
-            response_uris: Some(vec![
+            response_uri: Some(vec![
                 "https://verifier.example.com/cb1".to_string(),
                 "https://verifier.example.com/cb2".to_string(),
             ]),
@@ -424,16 +484,26 @@ mod tests {
         }
     }
 
+    fn trusted_issuer_with_kid(keys: &TestKeys, kid: &str) -> TrustedAttestationIssuer {
+        let mut jwk = keys.issuer_jwk();
+        jwk.prm.kid = Some(kid.to_string());
+        TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(),
+            jwks: vec![jwk],
+        }
+    }
+
     /// 1. Valid attestation JWT decode and validation
     #[test]
     fn test_valid_attestation_decode_and_validation() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
         let trusted_issuers = vec![trusted_issuer(&keys)];
 
+        // Pass the unprefixed verifier ID
         let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
 
         assert!(
             result.is_ok(),
@@ -442,7 +512,7 @@ mod tests {
         );
         let attestation = result.unwrap();
         assert_eq!(attestation.issuer(), TEST_ISSUER);
-        assert_eq!(attestation.subject(), TEST_CLIENT_ID);
+        assert_eq!(attestation.subject(), TEST_VERIFIER_ID); // sub is the unprefixed ID
     }
 
     /// 2. Wrong `typ` header rejection
@@ -450,11 +520,11 @@ mod tests {
     fn test_wrong_typ_header_rejection() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, "JWT"); // Wrong typ header
+        let jwt = create_test_jwt(&keys, &claims, "JWT", None); // Wrong typ header
         let trusted_issuers = vec![trusted_issuer(&keys)];
 
         let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -468,10 +538,10 @@ mod tests {
     fn test_untrusted_issuer_rejection() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
 
         // Unknown issuer - not in trusted list
-        let result = VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &[]);
+        let result = VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &[]);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -485,12 +555,12 @@ mod tests {
     fn test_sub_client_id_mismatch_rejection() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
         let trusted_issuers = vec![trusted_issuer(&keys)];
 
         let result = VerifierAttestationJwt::decode_and_validate(
             &jwt,
-            "verifier_attestation:wrong-client", // Different client_id
+            "wrong-verifier", // Different client_id
             &trusted_issuers,
         );
 
@@ -508,7 +578,7 @@ mod tests {
         let now = jsonwebtoken::get_current_timestamp() as i64;
         let claims = VerifierAttestationClaims {
             iss: TEST_ISSUER.to_string(),
-            sub: TEST_CLIENT_ID.to_string(),
+            sub: TEST_VERIFIER_ID.to_string(),
             aud: None,
             iat: None,
             exp: now - 3600, // Expired 1 hour ago
@@ -517,14 +587,14 @@ mod tests {
             cnf: CnfClaim {
                 jwk: keys.verifier_jwk(),
             },
-            response_uris: None,
+            response_uri: None,
             nonce: None,
         };
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
         let trusted_issuers = vec![trusted_issuer(&keys)];
 
         let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
 
         assert!(result.is_err());
         assert!(matches!(
@@ -544,7 +614,7 @@ mod tests {
         // Create claims without cnf by manually constructing the JWT payload
         let claims_without_cnf = serde_json::json!({
             "iss": TEST_ISSUER,
-            "sub": TEST_CLIENT_ID,
+            "sub": TEST_VERIFIER_ID,
             "exp": now + 3600,
         });
 
@@ -564,7 +634,7 @@ mod tests {
 
         // Attempt to decode and validate - should fail due to missing cnf
         let result =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers);
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -580,16 +650,16 @@ mod tests {
         );
     }
 
-    /// 7. `response_uris` allowlist enforcement
+    /// 7. `response_uri` allowlist enforcement
     #[test]
-    fn test_response_uris_allowlist_enforcement() {
+    fn test_response_uri_allowlist_enforcement() {
         let keys = TestKeys::generate();
         let claims = valid_claims(&keys);
-        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP);
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
         let trusted_issuers = vec![trusted_issuer(&keys)];
 
         let attestation =
-            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_CLIENT_ID, &trusted_issuers)
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers)
                 .expect("should succeed");
 
         // Allowed URI should succeed
@@ -606,5 +676,171 @@ mod tests {
             result.unwrap_err(),
             VerifierAttestationError::ResponseUriNotAllowed(uri) if uri == "https://evil.com/cb"
         ));
+    }
+
+    /// 8. Unknown `kid` in header should fail (not fallback to other keys)
+    #[test]
+    fn test_unknown_kid_rejection() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+
+        // Create issuer with a specific kid
+        let trusted_issuers = vec![trusted_issuer_with_kid(&keys, "known-key-1")];
+
+        // Create JWT with a different kid
+        let jwt = create_test_jwt(
+            &keys,
+            &claims,
+            VerifierAttestationJwt::EXPECTED_TYP,
+            Some("unknown-key-id"),
+        );
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::UnknownKeyId(kid) if kid == "unknown-key-id"
+        ));
+    }
+
+    /// 9. Symmetric key (oct) in cnf.jwk should be rejected
+    #[test]
+    fn test_symmetric_key_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+
+        // Create a symmetric key (oct) for cnf.jwk
+        let symmetric_jwk = Jwk {
+            key: Key::Oct(cloud_wallet_crypto::jwk::Oct {
+                k: cloud_wallet_crypto::secret::Secret::new(vec![1, 2, 3, 4, 5, 6, 7, 8]),
+            }),
+            prm: cloud_wallet_crypto::jwk::Parameters::default(),
+        };
+
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_VERIFIER_ID.to_string(),
+            aud: None,
+            iat: None,
+            exp: now + 3600,
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim { jwk: symmetric_jwk },
+            response_uri: None,
+            nonce: None,
+        };
+
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidKeyType(_)
+        ));
+    }
+
+    /// 10. Key with wrong 'use' (encryption instead of signing) should be rejected
+    #[test]
+    fn test_key_wrong_use_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+
+        // Create a verifier key with wrong 'use' (enc instead of sig)
+        let mut wrong_use_jwk = keys.verifier_jwk();
+        wrong_use_jwk.prm.key_use = Some(KeyUse::Encryption); // Wrong use
+
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_VERIFIER_ID.to_string(),
+            aud: None,
+            iat: None,
+            exp: now + 3600,
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim { jwk: wrong_use_jwk },
+            response_uri: None,
+            nonce: None,
+        };
+
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidKeyType(_)
+        ));
+    }
+
+    /// 11. Key without 'verify' operation should be rejected
+    #[test]
+    fn test_key_missing_verify_operation_rejection() {
+        let keys = TestKeys::generate();
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+
+        // Create a verifier key with key_ops that doesn't include 'verify'
+        let mut wrong_ops_jwk = keys.verifier_jwk();
+        wrong_ops_jwk.prm.ops = Some([Operations::Sign].into_iter().collect()); // Missing 'verify'
+
+        let claims = VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: TEST_VERIFIER_ID.to_string(),
+            aud: None,
+            iat: None,
+            exp: now + 3600,
+            nbf: None,
+            jti: None,
+            cnf: CnfClaim { jwk: wrong_ops_jwk },
+            response_uri: None,
+            nonce: None,
+        };
+
+        let jwt = create_test_jwt(&keys, &claims, VerifierAttestationJwt::EXPECTED_TYP, None);
+        let trusted_issuers = vec![trusted_issuer(&keys)];
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            VerifierAttestationError::InvalidKeyType(_)
+        ));
+    }
+
+    /// 12. Valid kid in header resolves to correct key
+    #[test]
+    fn test_valid_kid_resolves_correctly() {
+        let keys = TestKeys::generate();
+        let claims = valid_claims(&keys);
+
+        // Create issuer with a specific kid
+        let trusted_issuers = vec![trusted_issuer_with_kid(&keys, "issuer-key-1")];
+
+        // Create JWT with matching kid
+        let jwt = create_test_jwt(
+            &keys,
+            &claims,
+            VerifierAttestationJwt::EXPECTED_TYP,
+            Some("issuer-key-1"),
+        );
+
+        let result =
+            VerifierAttestationJwt::decode_and_validate(&jwt, TEST_VERIFIER_ID, &trusted_issuers);
+
+        assert!(
+            result.is_ok(),
+            "Expected success but got: {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION
Implement validation of Verifier Attestation JWTs as defined in spec Section 12. When a Verifier uses the `verifier_attestation:` client ID prefix, the Authorization Request includes a JWT issued by a trusted third party that attests to the Verifier's identity and authorized presentation requests. The Wallet must validate this attestation before trusting the Verifier.

All types go in `crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs`.

## Tasks

- [x] Create `crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs`
- [x] Define `VerifierAttestationJwt` struct with claims
- [x] Define `CnfClaim` struct
- [x] Implement `VerifierAttestationJwt::decode_and_validate(jwt: &str, trusted_issuers: &[String]) -> Result<Self>`
- [x] Define `TrustedAttestationIssuer` configuration struct for configuring which attestation issuers the Wallet trusts
- [x] Write unit tests:
  - Valid attestation JWT decode and validation
  - Wrong `typ` header rejection
  - Untrusted issuer rejection
  - `sub` / `client_id` mismatch rejection
  - Expired attestation rejection
  - Missing `cnf.jwk` rejection
  - `response_uris` allowlist enforcement

## Acceptance Criteria

- Verifier Attestation JWTs are decoded, signature-verified, and validated per spec
- The Verifier's public key is extracted for Request Object verification
- Trust is configurable via a list of trusted attestation issuers