### PR TITLE
Feat/sd jwt vc verifiable presentation format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
  "aws-types",
  "bytes",
  "fastrand",
- "http 1.4.1",
+ "http 1.4.2",
  "time",
  "tokio",
  "tracing",
@@ -304,7 +304,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "fastrand",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "percent-encoding",
  "pin-project-lite",
@@ -332,7 +332,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -358,7 +358,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -378,7 +378,7 @@ dependencies = [
  "hex",
  "hmac",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "percent-encoding",
  "sha2 0.11.0",
  "time",
@@ -408,7 +408,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -427,7 +427,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2",
- "http 1.4.1",
+ "http 1.4.2",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -487,7 +487,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -508,7 +508,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -534,7 +534,7 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -547,7 +547,7 @@ dependencies = [
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -595,7 +595,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -626,7 +626,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -766,7 +766,7 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-named-pipe",
@@ -1315,9 +1315,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1501,7 +1501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "crypto-common 0.1.7",
+ "crypto-common 0.1.6",
 ]
 
 [[package]]
@@ -1854,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1926,7 +1926,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -1985,9 +1985,9 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2056,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2082,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2093,7 +2093,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2130,7 +2130,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2162,7 +2162,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2195,7 +2195,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper",
  "ipnet",
@@ -2484,13 +2484,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "f2025f20d7a4fa7785846e7b63d10a76d3f1cee98ee5cb79ea59703f95e42162"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3207,9 +3206,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3217,9 +3216,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -3230,9 +3229,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -3473,9 +3472,9 @@ checksum = "f4ed1d73fb92eba9b841ba2aef69533a060ccc0d3ec71c90aeda5996d4afb7a9"
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3502,9 +3501,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -3517,7 +3516,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "h2",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -3555,7 +3554,7 @@ checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.1",
+ "http 1.4.2",
  "reqwest",
  "serde",
  "thiserror 2.0.18",
@@ -3572,7 +3571,7 @@ dependencies = [
  "async-trait",
  "futures",
  "getrandom 0.2.17",
- "http 1.4.1",
+ "http 1.4.2",
  "hyper",
  "reqwest",
  "reqwest-middleware",
@@ -3961,9 +3960,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -3981,9 +3980,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -4464,7 +4463,7 @@ dependencies = [
  "etcetera",
  "ferroid",
  "futures",
- "http 1.4.1",
+ "http 1.4.2",
  "itertools 0.14.0",
  "log",
  "memchr",
@@ -4726,7 +4725,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper",
@@ -4783,7 +4782,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -4994,7 +4993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -5032,9 +5031,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5158,9 +5157,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "a254a4b10c19a76f09a27640e7ffbf9bc30bf67e16a3bf28aaefa4920fe81563"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5171,9 +5170,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "54568702fabf5d4849ce2b90fadfa64168a097eaf4b351ce9df8b687a0086aaf"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5181,9 +5180,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "24a40fc75b0ec6f3746ceb10d36f53a93dcd68a93b11b6445983945d79eba0dc"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5191,9 +5190,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "908f34bd9b9ce3d4caf07b72dfab63d61504d156856c6bd3cd87fa350cf3985b"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5204,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7acbf7616c27b194bbb550bf77ed0c2c3e5b7fd1260a93082b95fb7f47959b92"
 dependencies = [
  "unicode-ident",
 ]
@@ -5261,9 +5260,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "6e0871acf327f283dc6da28a1696cdc64fb355ba9f935d052021fa77f35cce69"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5579,7 +5578,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -5779,18 +5778,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/decode.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/decode.rs
@@ -12,6 +12,21 @@ const SD_ALG_CLAIM: &str = "_sd_alg";
 const ARRAY_DIGEST_CLAIM: &str = "...";
 const MAX_JSON_NESTING_DEPTH: usize = 64;
 
+/// Determines the hash algorithm to use for disclosure hashing.
+///
+/// Defaults to SHA-256 when `_sd_alg` is absent, per RFC 9901.
+pub fn disclosure_hash_algorithm(sd_alg: Option<&str>) -> Result<HashAlg, Error> {
+    sd_alg
+        .map(IanaHashAlgorithm::from_str)
+        .unwrap_or(Ok(IanaHashAlgorithm::Sha256))
+        .map(Into::into)
+}
+
+/// Computes the base64url-encoded digest of a raw string using the specified hash algorithm.
+pub fn disclosure_digest(raw_disclosure: &str, algorithm: HashAlg) -> String {
+    URL_SAFE_NO_PAD.encode(algorithm.hash(raw_disclosure.as_bytes()).as_ref())
+}
+
 /// Processes the disclosures in the SD-JWT and returns the processed payload.
 ///
 /// The processing is done according to [RFC 9901 Section 7].
@@ -231,19 +246,6 @@ fn encounter_digest(digest: &str, state: &mut ProcessingState) -> Result<(), Err
             digest.to_owned(),
         )))
     }
-}
-
-/// Determines the hash algorithm to use for disclosure hashing.
-fn disclosure_hash_algorithm(sd_alg: Option<&str>) -> Result<HashAlg, Error> {
-    sd_alg
-        .map(IanaHashAlgorithm::from_str)
-        .unwrap_or(Ok(IanaHashAlgorithm::Sha256))
-        .map(Into::into)
-}
-
-/// Computes the digest of a raw disclosure string using the specified hash algorithm.
-fn disclosure_digest(raw_disclosure: &str, algorithm: HashAlg) -> String {
-    URL_SAFE_NO_PAD.encode(algorithm.hash(raw_disclosure.as_bytes()).as_ref())
 }
 
 fn decode_error(reason: ProcessingError) -> Error {

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/kb_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/kb_jwt.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Error, Jwt, KEY_BINDING_JWT_COMPONENT};
 
-const KEY_BINDING_JWT_TYP: &str = "kb+jwt";
+pub const KEY_BINDING_JWT_TYP: &str = "kb+jwt";
 
 /// Key Binding JWT carried by an SD-JWT presentation.
 #[derive(Debug, Clone, PartialEq)]
@@ -35,6 +35,11 @@ impl<'a> KeyBindingJwt<'a> {
 }
 
 /// Claims required in an RFC 9901 Key Binding JWT payload.
+///
+/// The optional `transaction_data_hashes` and `transaction_data_hashes_alg`
+/// fields are defined in [OpenID4VP §8.4] for transaction data support.
+///
+/// [OpenID4VP §8.4]: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-8.4
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct KeyBindingClaims {
     /// Issued-at time as a NumericDate.
@@ -45,6 +50,58 @@ pub struct KeyBindingClaims {
     pub nonce: String,
     /// Base64url-encoded hash over the issuer-signed JWT and selected disclosures.
     pub sd_hash: String,
+    /// Base64url-encoded hashes of transaction data entries that apply to this
+    /// credential, per OpenID4VP §8.4.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_data_hashes: Option<Vec<String>>,
+    /// Hash algorithm used for `transaction_data_hashes`. Defaults to `sha-256`
+    /// when absent, per OpenID4VP §8.4.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_data_hashes_alg: Option<String>,
+}
+
+impl KeyBindingClaims {
+    /// Creates a new set of Key Binding JWT claims using the current timestamp.
+    pub fn new(
+        aud: impl Into<String>,
+        nonce: impl Into<String>,
+        sd_hash: impl Into<String>,
+    ) -> Self {
+        Self::new_with_iat(
+            time::UtcDateTime::now().unix_timestamp(),
+            aud,
+            nonce,
+            sd_hash,
+        )
+    }
+
+    /// Creates a new set of Key Binding JWT claims with an explicit issued-at timestamp.
+    pub fn new_with_iat(
+        iat: i64,
+        aud: impl Into<String>,
+        nonce: impl Into<String>,
+        sd_hash: impl Into<String>,
+    ) -> Self {
+        Self {
+            iat,
+            aud: aud.into(),
+            nonce: nonce.into(),
+            sd_hash: sd_hash.into(),
+            transaction_data_hashes: None,
+            transaction_data_hashes_alg: None,
+        }
+    }
+
+    /// Sets optional transaction data hashes.
+    pub fn with_transaction_data(
+        mut self,
+        hashes: impl IntoIterator<Item = impl Into<String>>,
+        alg: Option<impl Into<String>>,
+    ) -> Self {
+        self.transaction_data_hashes = Some(hashes.into_iter().map(|h| h.into()).collect());
+        self.transaction_data_hashes_alg = alg.map(|a| a.into());
+        self
+    }
 }
 
 fn validate_key_binding_profile(jwt: &Jwt<'_, KeyBindingClaims>) -> Result<(), Error> {

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/kb_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/kb_jwt.rs
@@ -98,8 +98,8 @@ impl KeyBindingClaims {
         hashes: impl IntoIterator<Item = impl Into<String>>,
         alg: Option<impl Into<String>>,
     ) -> Self {
-        self.transaction_data_hashes = Some(hashes.into_iter().map(|h| h.into()).collect());
-        self.transaction_data_hashes_alg = alg.map(|a| a.into());
+        self.transaction_data_hashes = Some(hashes.into_iter().map(Into::into).collect());
+        self.transaction_data_hashes_alg = alg.map(Into::into);
         self
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/sd_jwt/mod.rs
@@ -9,11 +9,12 @@ mod metadata;
 mod tests;
 mod verification;
 
+pub use decode::{disclosure_digest, disclosure_hash_algorithm};
 pub use disclosure::Disclosure;
 pub use error::{DisclosureError, Error, ProcessingError};
 pub use hash::IanaHashAlgorithm;
 pub use jwt::Jwt;
-pub use kb_jwt::{KeyBindingClaims, KeyBindingJwt};
+pub use kb_jwt::{KEY_BINDING_JWT_TYP, KeyBindingClaims, KeyBindingJwt};
 pub use metadata::IssuerMetadataError;
 pub use verification::{VerificationError, X5cTrustAnchors};
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
@@ -39,10 +39,19 @@ pub enum ProofError {
     /// Invalid proof input.
     #[error("invalid proof input: {0}")]
     InvalidInput(Cow<'static, str>),
-    /// SD-JWT parsing or disclosure processing failed.
-    #[error("SD-JWT processing failed: {0}")]
-    SdJwt(#[from] crate::formats::sd_jwt::Error),
-    /// JSON serialization error during proof construction.
-    #[error("serialization error: {0}")]
-    Serialization(String),
+    /// Format-specific processing error (e.g. SD-JWT, mdoc).
+    #[error(transparent)]
+    Format(Box<dyn std::error::Error + Send + Sync>),
+}
+
+impl From<crate::formats::sd_jwt::Error> for ProofError {
+    fn from(value: crate::formats::sd_jwt::Error) -> Self {
+        Self::Format(Box::new(value))
+    }
+}
+
+impl From<serde_json::Error> for ProofError {
+    fn from(value: serde_json::Error) -> Self {
+        Self::Format(Box::new(value))
+    }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use thiserror::Error;
 
 use crate::oid4vp::authorization::VpTokenError;
@@ -17,8 +19,11 @@ pub enum PresentationBuilderError {
 }
 
 /// Errors that can occur during holder binding proof creation.
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub enum HolderBindingProofError {
+///
+/// Used by all credential formats (SD-JWT VC, mdoc, etc.) that implement
+/// the [`PresentationCreator`](super::PresentationCreator) trait.
+#[derive(Debug, Error)]
+pub enum ProofError {
     /// Proof signing failed (e.g., cryptographic signing error).
     #[error("holder binding proof signing failed: {0}")]
     SigningFailed(String),
@@ -30,5 +35,14 @@ pub enum HolderBindingProofError {
     UnsupportedAlgorithm(String),
     /// Missing required field for proof creation.
     #[error("missing required field: {0}")]
-    MissingRequiredField(String),
+    MissingRequiredField(Cow<'static, str>),
+    /// Invalid proof input.
+    #[error("invalid proof input: {0}")]
+    InvalidInput(Cow<'static, str>),
+    /// SD-JWT parsing or disclosure processing failed.
+    #[error("SD-JWT processing failed: {0}")]
+    SdJwt(#[from] crate::formats::sd_jwt::Error),
+    /// JSON serialization error during proof construction.
+    #[error("serialization error: {0}")]
+    Serialization(String),
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/error.rs
@@ -21,7 +21,7 @@ pub enum PresentationBuilderError {
 /// Errors that can occur during holder binding proof creation.
 ///
 /// Used by all credential formats (SD-JWT VC, mdoc, etc.) that implement
-/// the [`PresentationCreator`](super::PresentationCreator) trait.
+/// the [`PresentationFactory`](super::PresentationFactory) trait.
 #[derive(Debug, Error)]
 pub enum ProofError {
     /// Proof signing failed (e.g., cryptographic signing error).

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/mod.rs
@@ -1,0 +1,3 @@
+//! Credential-format-specific OpenID4VP presentation helpers.
+
+pub mod sd_jwt;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
@@ -27,6 +27,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use cloud_wallet_crypto::digest::HashAlg;
 use serde_json::Value;
 
@@ -40,10 +41,11 @@ use crate::oid4vp::presentation::error::ProofError;
 
 /// Function type for signing a Key Binding JWT.
 ///
-/// Receives the serialized [`KeyBindingClaims`] and must return a compact JWS
-/// string (header.payload.signature). The caller is responsible for choosing
-/// the signing algorithm, constructing the JOSE header (with `typ: "kb+jwt"`),
-/// and performing the cryptographic signature.
+/// Receives the [`KeyBindingClaims`] and must return a compact JWS string
+/// (header.payload.signature). The signer must use the holder private key
+/// corresponding to the key material identified by the SD-JWT VC `cnf` claim.
+/// Its JOSE header must contain `typ: "kb+jwt"` and an `alg` compatible with
+/// that confirmation key.
 pub type JwtSigner = Box<dyn Fn(&KeyBindingClaims) -> Result<String, ProofError> + Send + Sync>;
 
 const SD_CLAIM: &str = "_sd";
@@ -110,6 +112,12 @@ impl PresentationFactory for SdJwtPresentation {
             transaction_data_hashes_alg,
             signer,
         } = self;
+
+        if !raw_credential.ends_with('~') {
+            return Err(ProofError::InvalidInput(
+                "SD-JWT VC credential must be in issued form and end with '~'".into(),
+            ));
+        }
 
         // Parse the raw credential.
         let sd_jwt = SdJwt::parse(&raw_credential)?;
@@ -397,7 +405,7 @@ fn try_collect_array_element<'a>(
 /// Returns the base64url-encoded hash, using the hash algorithm from the
 /// credential's `_sd_alg` claim (defaulting to SHA-256).
 pub fn compute_sd_hash(presentation_without_kb: &str, hash_alg: HashAlg) -> String {
-    disclosure_digest(presentation_without_kb, hash_alg)
+    URL_SAFE_NO_PAD.encode(hash_alg.hash(presentation_without_kb.as_bytes()).as_ref())
 }
 
 /// Builds the SD-JWT presentation string without the Key Binding JWT.
@@ -628,12 +636,15 @@ mod tests {
     fn computes_sd_hash_correctly() {
         let presentation = "header.payload.sig~disc1~disc2~";
         let hash = compute_sd_hash(presentation, HashAlg::Sha256);
+        let expected =
+            URL_SAFE_NO_PAD.encode(HashAlg::Sha256.hash(presentation.as_bytes()).as_ref());
 
         // Verify it's non-empty base64url (no padding).
         assert!(!hash.is_empty());
         assert!(!hash.contains('='));
         assert!(!hash.contains('+'));
         assert!(!hash.contains('/'));
+        assert_eq!(hash, expected);
 
         // Verify determinism.
         let hash2 = compute_sd_hash(presentation, HashAlg::Sha256);
@@ -841,6 +852,35 @@ mod tests {
     }
 
     #[test]
+    fn rejects_sd_jwt_presentation_input_for_presentation_builder() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let mut raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+        raw.push_str("header.payload.signature");
+
+        let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .signer(test_signer)
+            .build()
+            .create_presentation()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ProofError::InvalidInput(ref input) if input.contains("issued form")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn rejects_transaction_data_without_signer() {
         let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
         let digest = test_disclosure_digest(&disc);
@@ -929,8 +969,18 @@ mod tests {
 
         // The presentation should contain: <issuer-jwt>~<kb-jwt>
         assert!(s.starts_with(&issuer_jwt));
-        let after_jwt = &s[issuer_jwt.len()..];
-        assert!(after_jwt.starts_with('~'));
+        let parts: Vec<&str> = s.split('~').collect();
+        assert_eq!(
+            parts.len(),
+            2,
+            "expected jwt~kb-jwt format with no disclosures, got {parts:?}"
+        );
+        assert_eq!(parts[0], issuer_jwt);
+        assert_eq!(
+            parts[1].split('.').count(),
+            3,
+            "KB-JWT must be a compact JWS"
+        );
     }
 
     #[test]

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
@@ -1,0 +1,976 @@
+//! SD-JWT VC presentation format as defined in [OpenID4VP Appendix B.3].
+//!
+//! Implements the Wallet-side logic for building SD-JWT VC presentations:
+//!
+//! 1. **Selective Disclosure** — selects only the disclosures needed to reveal
+//!    claims requested by the Verifier via [`ClaimPathPointer`]s.
+//! 2. **Key Binding JWT** — constructs and signs a KB-JWT (RFC 9901) that binds
+//!    the presentation to the verifier audience and request nonce.
+//! 3. **Presentation assembly** — produces the final compact SD-JWT presentation
+//!    string: `<issuer-jwt>~<disc>*~<kb-jwt>`.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use cloud_wallet_openid4vc::oid4vp::presentation::sd_jwt::SdJwtPresentation;
+//!
+//! let sd_jwt_presentation = SdJwtPresentation::builder(raw_credential, client_id, nonce)
+//!     .requested_claims(claim_paths)
+//!     .signer(|claims| { /* sign KB-JWT */ })
+//!     .build();
+//!
+//! let presentation = sd_jwt_presentation.create_presentation()?;
+//!
+//! ```
+//!
+//! [OpenID4VP Appendix B.3]: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.3
+
+use std::collections::{HashMap, HashSet};
+
+use cloud_wallet_crypto::digest::HashAlg;
+use serde_json::Value;
+
+use crate::core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer};
+use crate::formats::sd_jwt::{
+    Disclosure, KeyBindingClaims, SdJwt, disclosure_digest, disclosure_hash_algorithm,
+};
+use crate::oid4vp::authorization::Presentation;
+use crate::oid4vp::presentation::PresentationFactory;
+use crate::oid4vp::presentation::error::ProofError;
+
+/// Function type for signing a Key Binding JWT.
+///
+/// Receives the serialized [`KeyBindingClaims`] and must return a compact JWS
+/// string (header.payload.signature). The caller is responsible for choosing
+/// the signing algorithm, constructing the JOSE header (with `typ: "kb+jwt"`),
+/// and performing the cryptographic signature.
+pub type JwtSigner = Box<dyn Fn(&KeyBindingClaims) -> Result<String, ProofError> + Send + Sync>;
+
+const SD_CLAIM: &str = "_sd";
+const ARRAY_DIGEST_CLAIM: &str = "...";
+
+/// SD-JWT VC presentation for building verifiable presentations.
+///
+/// Orchestrates selective disclosure, `sd_hash` computation, Key Binding JWT
+/// construction, and final presentation assembly as specified in
+/// [OpenID4VP Appendix B.3.6].
+///
+/// Use [`SdJwtPresentationBuilder`] (via [`SdJwtPresentation::builder`]) for
+/// ergonomic construction.
+///
+/// [OpenID4VP Appendix B.3.6]: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.3.6
+pub struct SdJwtPresentation {
+    /// The raw SD-JWT VC credential string in issued form (`<jwt>~<disc>*~`).
+    raw_credential: String,
+    /// Claim paths requested by the Verifier (from the matched DCQL query).
+    requested_claims: Vec<ClaimPathPointer>,
+    /// Verifier's `client_id`, used as the `aud` claim in the KB-JWT.
+    client_id: String,
+    /// Transaction nonce from the Authorization Request.
+    nonce: String,
+    /// Issued-at timestamp for the KB-JWT.
+    iat: i64,
+    /// Optional transaction data hashes (OpenID4VP §8.4).
+    transaction_data_hashes: Option<Vec<String>>,
+    /// Optional hash algorithm identifier for transaction data hashes.
+    transaction_data_hashes_alg: Option<String>,
+    /// Signing function that produces the compact KB-JWT JWS.
+    signer: Option<JwtSigner>,
+}
+
+impl SdJwtPresentation {
+    /// Returns a builder for constructing an `SdJwtPresentation`.
+    pub fn builder(
+        raw_credential: impl Into<String>,
+        client_id: impl Into<String>,
+        nonce: impl Into<String>,
+    ) -> SdJwtPresentationBuilder {
+        SdJwtPresentationBuilder {
+            raw_credential: raw_credential.into(),
+            client_id: client_id.into(),
+            nonce: nonce.into(),
+            iat: time::UtcDateTime::now().unix_timestamp(),
+            requested_claims: vec![],
+            transaction_data_hashes: None,
+            transaction_data_hashes_alg: None,
+            signer: None,
+        }
+    }
+}
+
+impl PresentationFactory for SdJwtPresentation {
+    fn create_presentation(self) -> Result<Presentation, ProofError> {
+        let Self {
+            raw_credential,
+            requested_claims,
+            client_id,
+            nonce,
+            iat,
+            transaction_data_hashes,
+            transaction_data_hashes_alg,
+            signer,
+        } = self;
+
+        // Parse the raw credential.
+        let sd_jwt = SdJwt::parse(&raw_credential)?;
+
+        if transaction_data_hashes.as_ref().is_some_and(Vec::is_empty) {
+            return Err(ProofError::InvalidInput(
+                "transaction_data_hashes must be non-empty when present".into(),
+            ));
+        }
+
+        if transaction_data_hashes.is_some() && signer.is_none() {
+            return Err(ProofError::MissingRequiredField(
+                "signer is required when transaction data is present".into(),
+            ));
+        }
+
+        if signer.is_some() && sd_jwt.jwt().claims().cnf.is_none() {
+            return Err(ProofError::MissingRequiredField(
+                "cnf claim is required for SD-JWT holder binding".into(),
+            ));
+        }
+
+        // Determine the hash algorithm from `_sd_alg`.
+        let hash_alg = disclosure_hash_algorithm(sd_jwt.jwt().claims().sd_alg.as_deref())?;
+
+        // Select disclosures for the requested claims.
+        let selected = select_disclosures(&sd_jwt, &requested_claims)?;
+
+        // Extract the issuer JWT raw string (the first part before '~').
+        let issuer_jwt = sd_jwt.jwt().raw();
+
+        // Build the presentation string without the KB-JWT.
+        let presentation_without_kb = build_presentation_without_kb(issuer_jwt, &selected);
+
+        // If no signer is provided, return without holder binding.
+        let Some(signer) = signer else {
+            return Ok(Presentation::String(presentation_without_kb));
+        };
+
+        // Compute sd_hash over the presentation-without-KB string.
+        let sd_hash = compute_sd_hash(&presentation_without_kb, hash_alg);
+
+        // Build Key Binding JWT claims.
+        let mut kb_claims = KeyBindingClaims::new_with_iat(iat, client_id, nonce, sd_hash);
+
+        if let Some(hashes) = transaction_data_hashes {
+            kb_claims = kb_claims.with_transaction_data(hashes, transaction_data_hashes_alg);
+        }
+
+        // Sign the KB-JWT.
+        let kb_jwt = signer(&kb_claims)?;
+
+        // Assemble the final presentation: <issuer-jwt>~<disc>*~<kb-jwt>
+        let final_presentation = format!("{presentation_without_kb}{kb_jwt}");
+        Ok(Presentation::String(final_presentation))
+    }
+}
+
+impl std::fmt::Debug for SdJwtPresentation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SdJwtPresentation")
+            .field("raw_credential", &"<redacted>")
+            .field("requested_claims", &self.requested_claims)
+            .field("client_id", &self.client_id)
+            .field("nonce", &"<redacted>")
+            .field("iat", &self.iat)
+            .finish()
+    }
+}
+
+/// Builder for [`SdJwtPresentation`].
+pub struct SdJwtPresentationBuilder {
+    raw_credential: String,
+    client_id: String,
+    nonce: String,
+    iat: i64,
+    requested_claims: Vec<ClaimPathPointer>,
+    transaction_data_hashes: Option<Vec<String>>,
+    transaction_data_hashes_alg: Option<String>,
+    signer: Option<JwtSigner>,
+}
+
+impl SdJwtPresentationBuilder {
+    /// Sets the claim paths requested by the Verifier.
+    pub fn requested_claims(mut self, claims: impl IntoIterator<Item = ClaimPathPointer>) -> Self {
+        self.requested_claims = claims.into_iter().collect();
+        self
+    }
+
+    /// Sets the JWT signing function for the Key Binding JWT.
+    ///
+    /// The function receives serialized [`KeyBindingClaims`] and must return
+    /// a compact JWS string with JOSE header `typ: "kb+jwt"`.
+    ///
+    /// When no signer is provided, the presentation is created without holder
+    /// binding (per [OpenID4VP §5.3]).
+    ///
+    /// [OpenID4VP §5.3]: https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.3
+    pub fn signer<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&KeyBindingClaims) -> Result<String, ProofError> + Send + Sync + 'static,
+    {
+        self.signer = Some(Box::new(f));
+        self
+    }
+
+    /// Sets optional transaction data hashes per OpenID4VP §8.4.
+    pub fn transaction_data(
+        mut self,
+        hashes: impl IntoIterator<Item = impl Into<String>>,
+        alg: Option<impl Into<String>>,
+    ) -> Self {
+        self.transaction_data_hashes = Some(hashes.into_iter().map(Into::into).collect());
+        self.transaction_data_hashes_alg = alg.map(Into::into);
+        self
+    }
+
+    /// Overrides the Key Binding JWT issued-at timestamp.
+    ///
+    /// By default the builder uses the current timestamp. This is mainly useful
+    /// for deterministic tests or externally controlled clocks.
+    pub fn iat(mut self, iat: i64) -> Self {
+        self.iat = iat;
+        self
+    }
+
+    /// Builds the [`SdJwtPresentation`].
+    pub fn build(self) -> SdJwtPresentation {
+        SdJwtPresentation {
+            raw_credential: self.raw_credential,
+            requested_claims: self.requested_claims,
+            client_id: self.client_id,
+            nonce: self.nonce,
+            iat: self.iat,
+            transaction_data_hashes: self.transaction_data_hashes,
+            transaction_data_hashes_alg: self.transaction_data_hashes_alg,
+            signer: self.signer,
+        }
+    }
+}
+
+/// Resolves which disclosures are required to reveal a set of requested claims.
+///
+/// Given a parsed [`SdJwt`] and the requested [`ClaimPathPointer`]s from a DCQL
+/// query, this function walks the SD-JWT payload tree and collects exactly the
+/// disclosures whose digests must be included in the presentation.
+///
+/// # Returns
+///
+/// A deduplicated set of raw disclosure strings (base64url-encoded) that the
+/// presentation must include.
+fn select_disclosures<'a>(
+    sd_jwt: &SdJwt<'a>,
+    requested_claims: &[ClaimPathPointer],
+) -> Result<Vec<&'a str>, ProofError> {
+    let sd_alg = disclosure_hash_algorithm(sd_jwt.jwt().claims().sd_alg.as_deref())?;
+
+    let mut digest_index = HashMap::with_capacity(sd_jwt.disclosures().len());
+    for (index, disclosure) in sd_jwt.disclosures().iter().enumerate() {
+        let digest = disclosure_digest(disclosure.raw(), sd_alg);
+        if digest_index.insert(digest, (index, disclosure)).is_some() {
+            return Err(ProofError::InvalidInput(
+                "duplicate disclosure digest".into(),
+            ));
+        }
+    }
+
+    let issuer_payload = serde_json::to_value(sd_jwt.jwt().claims()).map_err(|e| {
+        ProofError::Serialization(format!("failed to serialize issuer claims: {e}"))
+    })?;
+
+    let mut selected_indexes: HashSet<usize> = HashSet::new();
+
+    for path in requested_claims {
+        collect_disclosures_for_path(
+            &issuer_payload,
+            path.elements(),
+            &digest_index,
+            &mut selected_indexes,
+        );
+    }
+
+    // Return in issued-credential order for reproducible presentations
+    Ok(sd_jwt
+        .disclosures()
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| selected_indexes.contains(index))
+        .map(|(_, disclosure)| disclosure.raw())
+        .collect())
+}
+
+/// Recursively walks the payload tree along `remaining_path`, collecting any
+/// disclosures whose digests appear in `_sd` arrays or `{"...": digest}` array
+/// placeholders along the way.
+fn collect_disclosures_for_path<'a>(
+    current: &Value,
+    remaining_path: &[ClaimPathElement],
+    digest_index: &HashMap<String, (usize, &Disclosure<'a>)>,
+    selected: &mut HashSet<usize>,
+) {
+    if remaining_path.is_empty() {
+        return;
+    }
+
+    let element = &remaining_path[0];
+    let rest = &remaining_path[1..];
+
+    match (current, element) {
+        // Navigate into an object property, checking for selective disclosure.
+        (Value::Object(obj), ClaimPathElement::String(key)) => {
+            // Check if this claim is selectively disclosed via _sd.
+            if let Some(sd_digests) = obj.get(SD_CLAIM).and_then(|v| v.as_array()) {
+                for digest_value in sd_digests {
+                    let Some(digest_str) = digest_value.as_str() else {
+                        continue;
+                    };
+                    let Some((index, disc)) = digest_index.get(digest_str) else {
+                        continue;
+                    };
+                    if disc.claim_name.as_deref() == Some(key) {
+                        selected.insert(*index);
+                        // Continue into the disclosed value for deeper paths.
+                        if !rest.is_empty() {
+                            collect_disclosures_for_path(
+                                &disc.claim_value,
+                                rest,
+                                digest_index,
+                                selected,
+                            );
+                        }
+                        return;
+                    }
+                }
+            }
+            // Not selectively disclosed — check regular claims.
+            if let Some(value) = obj.get(key) {
+                collect_disclosures_for_path(value, rest, digest_index, selected);
+            }
+        }
+
+        // Navigate into an array by index.
+        (Value::Array(arr), ClaimPathElement::Index(idx)) => {
+            if let Some(element_value) = arr.get(*idx as usize) {
+                try_collect_array_element(element_value, rest, digest_index, selected);
+            }
+        }
+
+        // Select all array elements (null = wildcard).
+        (Value::Array(arr), ClaimPathElement::Null) => {
+            for element_value in arr {
+                try_collect_array_element(element_value, rest, digest_index, selected);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Handles a single array element, checking for `{"...": digest}` SD-JWT array
+/// element disclosures.
+fn try_collect_array_element<'a>(
+    element_value: &Value,
+    rest: &[ClaimPathElement],
+    digest_index: &HashMap<String, (usize, &Disclosure<'a>)>,
+    selected: &mut HashSet<usize>,
+) {
+    // Check for SD-JWT array element disclosure placeholder: {"...": digest}
+    if let Some(obj) = element_value.as_object()
+        && obj.len() == 1
+        && let Some(Value::String(digest_str)) = obj.get(ARRAY_DIGEST_CLAIM)
+        && let Some((index, disc)) = digest_index.get(digest_str)
+    {
+        selected.insert(*index);
+        if !rest.is_empty() {
+            collect_disclosures_for_path(&disc.claim_value, rest, digest_index, selected);
+        }
+        return;
+    }
+    // Regular array element.
+    collect_disclosures_for_path(element_value, rest, digest_index, selected);
+}
+
+/// Computes the `sd_hash` over an SD-JWT presentation string.
+///
+/// The input is the issuer-signed JWT concatenated with selected disclosures
+/// and a trailing `~` (i.e., `<issuer-jwt>~<disc1>~...~<discN>~`).
+///
+/// Returns the base64url-encoded hash, using the hash algorithm from the
+/// credential's `_sd_alg` claim (defaulting to SHA-256).
+pub fn compute_sd_hash(presentation_without_kb: &str, hash_alg: HashAlg) -> String {
+    disclosure_digest(presentation_without_kb, hash_alg)
+}
+
+/// Builds the SD-JWT presentation string without the Key Binding JWT.
+///
+/// Format: `<issuer-jwt>~<disc1>~...~<discN>~`
+fn build_presentation_without_kb(issuer_jwt: &str, selected_disclosures: &[&str]) -> String {
+    let mut presentation = String::with_capacity(
+        issuer_jwt.len()
+            + selected_disclosures
+                .iter()
+                .map(|d| d.len() + 1)
+                .sum::<usize>()
+            + 1,
+    );
+    presentation.push_str(issuer_jwt);
+    for disc in selected_disclosures {
+        presentation.push('~');
+        presentation.push_str(disc);
+    }
+    presentation.push('~');
+    presentation
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::Engine;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use cloud_wallet_crypto::digest::HashAlg;
+    use serde_json::json;
+
+    /// Encode a JSON value to unpadded base64url.
+    fn b64(value: Value) -> String {
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&value).unwrap())
+    }
+
+    /// Create a compact JWT from header and claims (with a dummy signature).
+    fn compact_jwt(header: Value, claims: Value) -> String {
+        format!("{}.{}.sig", b64(header), b64(claims))
+    }
+
+    /// Create a disclosure from a JSON array value.
+    fn make_disclosure(value: Value) -> String {
+        b64(value)
+    }
+
+    /// Calculate the disclosure digest using SHA-256.
+    fn test_disclosure_digest(disc: &str) -> String {
+        URL_SAFE_NO_PAD.encode(HashAlg::Sha256.hash(disc.as_bytes()).as_ref())
+    }
+
+    /// Build a minimal issued SD-JWT with the given claims and disclosures.
+    fn build_test_sd_jwt(claims: Value, disclosures: &[String]) -> String {
+        let jwt = compact_jwt(json!({ "alg": "ES256", "typ": "dc+sd-jwt" }), claims);
+        let mut raw = jwt;
+        for disc in disclosures {
+            raw.push('~');
+            raw.push_str(disc);
+        }
+        raw.push('~');
+        raw
+    }
+
+    fn holder_binding_cnf() -> Value {
+        json!({ "kid": "holder-key-1" })
+    }
+
+    /// A test signer that wraps the claims JSON in a fake compact JWS.
+    fn test_signer(claims: &KeyBindingClaims) -> Result<String, ProofError> {
+        let header = b64(json!({"alg": "ES256", "typ": "kb+jwt"}));
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).unwrap());
+        Ok(format!("{header}.{payload}.test-sig"))
+    }
+
+    #[test]
+    fn selects_no_disclosures_when_no_claims_requested() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let selected = select_disclosures(&sd_jwt, &[]).unwrap();
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn selects_matching_disclosure_for_requested_claim() {
+        let disc_name = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let disc_email = make_disclosure(json!(["salt-2", "email", "ada@example.com"]));
+        let digest_name = test_disclosure_digest(&disc_name);
+        let digest_email = test_disclosure_digest(&disc_email);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest_name, digest_email],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc_name.clone(), disc_email],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::from_strings(["given_name"])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0], disc_name);
+    }
+
+    #[test]
+    fn selects_multiple_disclosures_for_multiple_claims() {
+        let disc_name = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let disc_email = make_disclosure(json!(["salt-2", "email", "ada@example.com"]));
+        let digest_name = test_disclosure_digest(&disc_name);
+        let digest_email = test_disclosure_digest(&disc_email);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest_name, digest_email],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc_name.clone(), disc_email.clone()],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![
+            ClaimPathPointer::from_strings(["given_name"]),
+            ClaimPathPointer::from_strings(["email"]),
+        ];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(selected.len(), 2);
+        assert!(selected.contains(&disc_name.as_str()));
+        assert!(selected.contains(&disc_email.as_str()));
+    }
+
+    #[test]
+    fn does_not_select_disclosure_for_non_sd_claim() {
+        // "given_name" is a regular (non-selectively-disclosed) claim.
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "given_name": "Ada"
+            }),
+            &[],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::from_strings(["given_name"])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn selects_nested_disclosures_for_deep_path() {
+        // address is selectively disclosed, and within it, street is also SD.
+        let disc_street = make_disclosure(json!(["salt-2", "street", "Main St"]));
+        let digest_street = test_disclosure_digest(&disc_street);
+
+        let disc_address = make_disclosure(json!([
+            "salt-1",
+            "address",
+            { "_sd": [digest_street], "_sd_alg": "sha-256" }
+        ]));
+        let digest_address = test_disclosure_digest(&disc_address);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest_address],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc_address.clone(), disc_street.clone()],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::from_strings(["address", "street"])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        // Both the parent "address" and child "street" disclosures must be included.
+        assert_eq!(selected.len(), 2);
+        assert!(selected.contains(&disc_address.as_str()));
+        assert!(selected.contains(&disc_street.as_str()));
+    }
+
+    #[test]
+    fn deduplicates_disclosures_requested_multiple_times() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            std::slice::from_ref(&disc),
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        // Request the same claim twice.
+        let requested = vec![
+            ClaimPathPointer::from_strings(["given_name"]),
+            ClaimPathPointer::from_strings(["given_name"]),
+        ];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[test]
+    fn computes_sd_hash_correctly() {
+        let presentation = "header.payload.sig~disc1~disc2~";
+        let hash = compute_sd_hash(presentation, HashAlg::Sha256);
+
+        // Verify it's non-empty base64url (no padding).
+        assert!(!hash.is_empty());
+        assert!(!hash.contains('='));
+        assert!(!hash.contains('+'));
+        assert!(!hash.contains('/'));
+
+        // Verify determinism.
+        let hash2 = compute_sd_hash(presentation, HashAlg::Sha256);
+        assert_eq!(hash, hash2);
+    }
+
+    #[test]
+    fn sd_hash_differs_for_different_presentations() {
+        let hash1 = compute_sd_hash("a.b.c~d1~", HashAlg::Sha256);
+        let hash2 = compute_sd_hash("a.b.c~d1~d2~", HashAlg::Sha256);
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn builds_presentation_without_kb() {
+        let result = build_presentation_without_kb("header.payload.sig", &["disc1", "disc2"]);
+        assert_eq!(result, "header.payload.sig~disc1~disc2~");
+    }
+
+    #[test]
+    fn builds_presentation_without_disclosures() {
+        let result = build_presentation_without_kb("header.payload.sig", &[]);
+        assert_eq!(result, "header.payload.sig~");
+    }
+
+    #[test]
+    fn creates_presentation_without_holder_binding() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let presentation =
+            SdJwtPresentation::builder(raw, "https://verifier.example.com", "test-nonce")
+                .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+                .build()
+                .create_presentation()
+                .unwrap();
+
+        let Presentation::String(ref s) = presentation else {
+            panic!("expected string presentation");
+        };
+
+        // No KB-JWT -> ends with '~'.
+        assert!(s.ends_with('~'));
+        // Contains the issuer JWT.
+        assert!(s.starts_with("eyJ"));
+        // Contains exactly one disclosure.
+        let parts: Vec<&str> = s.split('~').collect();
+        // Format: <jwt> ~ <disc> ~ <empty trailing>
+        assert_eq!(parts.len(), 3, "expected jwt~disc~ format, got {parts:?}");
+    }
+
+    #[test]
+    fn creates_presentation_with_key_binding() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let presentation =
+            SdJwtPresentation::builder(raw, "https://verifier.example.com", "test-nonce")
+                .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+                .build()
+                .create_presentation()
+                .unwrap();
+        let Presentation::String(ref s) = presentation else {
+            panic!("expected string presentation");
+        };
+
+        // With KB-JWT -> does NOT end with '~'.
+        assert!(!s.ends_with('~'));
+        // Format: <jwt>~<disc>~<kb-jwt>
+        let parts: Vec<&str> = s.split('~').collect();
+        assert_eq!(parts.len(), 3, "expected jwt~disc~kb-jwt format");
+
+        // Verify the KB-JWT is a valid compact JWS (3 dot-separated parts).
+        let kb_jwt = parts[2];
+        assert_eq!(kb_jwt.split('.').count(), 3, "KB-JWT must be a compact JWS");
+    }
+
+    #[test]
+    fn kb_jwt_contains_correct_claims() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let client_id = "https://verifier.example.com";
+        let nonce = "test-nonce-123";
+        let iat = 1683000000i64;
+
+        // Capture the claims passed to the signer.
+        let captured_claims = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let captured = captured_claims.clone();
+
+        SdJwtPresentation::builder(raw, client_id, nonce)
+            .iat(iat)
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .signer(move |claims: &KeyBindingClaims| {
+                *captured.lock().unwrap() = Some(claims.clone());
+                test_signer(claims)
+            })
+            .build()
+            .create_presentation()
+            .unwrap();
+
+        let claims = captured_claims.lock().unwrap().clone().unwrap();
+        assert_eq!(claims.iat, iat);
+        assert_eq!(claims.aud, client_id);
+        assert_eq!(claims.nonce, nonce);
+        assert!(!claims.sd_hash.is_empty(), "sd_hash must be set");
+        assert!(claims.transaction_data_hashes.is_none());
+        assert!(claims.transaction_data_hashes_alg.is_none());
+    }
+
+    #[test]
+    fn kb_jwt_includes_transaction_data_hashes() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let captured_claims = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let captured = captured_claims.clone();
+
+        SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .transaction_data(vec!["hash1", "hash2"], Some("sha-256"))
+            .signer(move |claims: &KeyBindingClaims| {
+                *captured.lock().unwrap() = Some(claims.clone());
+                test_signer(claims)
+            })
+            .build()
+            .create_presentation()
+            .unwrap();
+
+        let claims = captured_claims.lock().unwrap().clone().unwrap();
+        assert_eq!(
+            claims.transaction_data_hashes,
+            Some(vec!["hash1".to_string(), "hash2".to_string()])
+        );
+        assert_eq!(
+            claims.transaction_data_hashes_alg,
+            Some("sha-256".to_string())
+        );
+    }
+
+    #[test]
+    fn rejects_key_binding_when_credential_has_no_cnf() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .signer(test_signer)
+            .build()
+            .create_presentation()
+            .unwrap_err();
+        assert!(
+            matches!(err, ProofError::MissingRequiredField(ref field) if field.contains("cnf")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_transaction_data_without_signer() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .transaction_data(vec!["hash1"], Some("sha-256"))
+            .signer(test_signer)
+            .build()
+            .create_presentation()
+            .unwrap_err();
+        assert!(
+            matches!(err, ProofError::MissingRequiredField(ref field) if field.contains("signer")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_empty_transaction_data_hashes() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .transaction_data(Vec::<&str>::new(), Some("sha-256"))
+            .signer(test_signer)
+            .build()
+            .create_presentation()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ProofError::InvalidInput(ref input) if input.contains("non-empty")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn presentation_without_requested_claims_includes_no_disclosures() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let issuer_jwt = raw
+            .split('~')
+            .next()
+            .expect("test SD-JWT should contain issuer JWT")
+            .to_string();
+
+        let pres = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            // No requested_claims -> no disclosures should be included.
+            .signer(test_signer)
+            .build();
+
+        let presentation = pres.create_presentation().unwrap();
+        let Presentation::String(ref s) = presentation else {
+            panic!("expected string presentation");
+        };
+
+        // The presentation should contain: <issuer-jwt>~<kb-jwt>
+        assert!(s.starts_with(&issuer_jwt));
+        let after_jwt = &s[issuer_jwt.len()..];
+        assert!(after_jwt.starts_with('~'));
+    }
+
+    #[test]
+    fn kb_claims_serializes_without_optional_fields() {
+        let claims = KeyBindingClaims::new_with_iat(
+            1683000000,
+            "https://verifier.example.com",
+            "nonce",
+            "sd_hash_value",
+        );
+
+        let json = serde_json::to_value(&claims).unwrap();
+        assert_eq!(json["iat"], 1683000000);
+        assert_eq!(json["aud"], "https://verifier.example.com");
+        assert_eq!(json["nonce"], "nonce");
+        assert_eq!(json["sd_hash"], "sd_hash_value");
+        assert!(json.get("transaction_data_hashes").is_none());
+        assert!(json.get("transaction_data_hashes_alg").is_none());
+    }
+
+    #[test]
+    fn kb_claims_serializes_with_transaction_data() {
+        let claims = KeyBindingClaims::new_with_iat(1683000000, "aud", "nonce", "hash")
+            .with_transaction_data(vec!["h1", "h2"], Some("sha-256"));
+
+        let json = serde_json::to_value(&claims).unwrap();
+        assert_eq!(json["transaction_data_hashes"], json!(["h1", "h2"]));
+        assert_eq!(json["transaction_data_hashes_alg"], "sha-256");
+    }
+
+    #[test]
+    fn kb_claims_round_trips_through_serde() {
+        let original = KeyBindingClaims::new_with_iat(1683000000, "aud", "nonce", "hash")
+            .with_transaction_data(vec!["h1"], None::<String>);
+
+        let json_str = serde_json::to_string(&original).unwrap();
+        let decoded: KeyBindingClaims = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(decoded, original);
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
@@ -277,10 +277,7 @@ fn select_disclosures<'a>(
         }
     }
 
-    let issuer_payload = serde_json::to_value(sd_jwt.jwt().claims()).map_err(|e| {
-        ProofError::Serialization(format!("failed to serialize issuer claims: {e}"))
-    })?;
-
+    let issuer_payload = serde_json::to_value(sd_jwt.jwt().claims())?;
     let mut selected_indexes: HashSet<usize> = HashSet::new();
 
     for path in requested_claims {

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
@@ -33,7 +33,8 @@ use serde_json::Value;
 
 use crate::core::claim_path_pointer::{ClaimPathElement, ClaimPathPointer};
 use crate::formats::sd_jwt::{
-    Disclosure, KeyBindingClaims, SdJwt, disclosure_digest, disclosure_hash_algorithm,
+    Disclosure, KeyBindingClaims, KeyBindingJwt, SdJwt, disclosure_digest,
+    disclosure_hash_algorithm,
 };
 use crate::oid4vp::authorization::Presentation;
 use crate::oid4vp::presentation::PresentationFactory;
@@ -169,6 +170,11 @@ impl PresentationFactory for SdJwtPresentation {
 
         // Sign the KB-JWT.
         let kb_jwt = signer(&kb_claims)?;
+        KeyBindingJwt::decode_unverified(&kb_jwt).map_err(|err| {
+            ProofError::InvalidInput(
+                format!("signer returned invalid Key Binding JWT: {err}").into(),
+            )
+        })?;
 
         // Assemble the final presentation: <issuer-jwt>~<disc>*~<kb-jwt>
         let final_presentation = format!("{presentation_without_kb}{kb_jwt}");
@@ -607,6 +613,121 @@ mod tests {
     }
 
     #[test]
+    fn selects_array_element_disclosure_by_index_path() {
+        let disc_de = make_disclosure(json!(["salt-1", "DE"]));
+        let disc_fr = make_disclosure(json!(["salt-2", "FR"]));
+        let digest_de = test_disclosure_digest(&disc_de);
+        let digest_fr = test_disclosure_digest(&disc_fr);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "nationalities": [
+                    { "...": digest_de },
+                    { "...": digest_fr }
+                ],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc_de, disc_fr.clone()],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::new(vec![
+            ClaimPathElement::from("nationalities"),
+            ClaimPathElement::from(1u64),
+        ])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(selected, vec![disc_fr.as_str()]);
+    }
+
+    #[test]
+    fn selects_array_element_disclosures_by_null_wildcard_path() {
+        let disc_de = make_disclosure(json!(["salt-1", "DE"]));
+        let disc_fr = make_disclosure(json!(["salt-2", "FR"]));
+        let digest_de = test_disclosure_digest(&disc_de);
+        let digest_fr = test_disclosure_digest(&disc_fr);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "nationalities": [
+                    { "...": digest_de },
+                    { "...": digest_fr }
+                ],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc_de.clone(), disc_fr.clone()],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::new(vec![
+            ClaimPathElement::from("nationalities"),
+            ClaimPathElement::Null,
+        ])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(selected, vec![disc_de.as_str(), disc_fr.as_str()]);
+    }
+
+    #[test]
+    fn selects_nested_claims_through_array_object_wildcard_path() {
+        let disc_degree_1_type = make_disclosure(json!(["salt-1-type", "type", "Bachelor"]));
+        let disc_degree_2_type = make_disclosure(json!(["salt-2-type", "type", "Master"]));
+        let digest_degree_1_type = test_disclosure_digest(&disc_degree_1_type);
+        let digest_degree_2_type = test_disclosure_digest(&disc_degree_2_type);
+
+        let disc_degree_1 = make_disclosure(json!([
+            "salt-1-degree",
+            { "_sd": [digest_degree_1_type], "_sd_alg": "sha-256" }
+        ]));
+        let disc_degree_2 = make_disclosure(json!([
+            "salt-2-degree",
+            { "_sd": [digest_degree_2_type], "_sd_alg": "sha-256" }
+        ]));
+        let digest_degree_1 = test_disclosure_digest(&disc_degree_1);
+        let digest_degree_2 = test_disclosure_digest(&disc_degree_2);
+
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "degrees": [
+                    { "...": digest_degree_1 },
+                    { "...": digest_degree_2 }
+                ],
+                "_sd_alg": "sha-256"
+            }),
+            &[
+                disc_degree_1.clone(),
+                disc_degree_1_type.clone(),
+                disc_degree_2.clone(),
+                disc_degree_2_type.clone(),
+            ],
+        );
+
+        let sd_jwt = SdJwt::parse(&raw).unwrap();
+        let requested = vec![ClaimPathPointer::new(vec![
+            ClaimPathElement::from("degrees"),
+            ClaimPathElement::Null,
+            ClaimPathElement::from("type"),
+        ])];
+        let selected = select_disclosures(&sd_jwt, &requested).unwrap();
+
+        assert_eq!(
+            selected,
+            vec![
+                disc_degree_1.as_str(),
+                disc_degree_1_type.as_str(),
+                disc_degree_2.as_str(),
+                disc_degree_2_type.as_str(),
+            ]
+        );
+    }
+
+    #[test]
     fn deduplicates_disclosures_requested_multiple_times() {
         let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
         let digest = test_disclosure_digest(&disc);
@@ -847,6 +968,34 @@ mod tests {
             .unwrap_err();
         assert!(
             matches!(err, ProofError::MissingRequiredField(ref field) if field.contains("cnf")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_key_binding_jwt_from_signer() {
+        let disc = make_disclosure(json!(["salt-1", "given_name", "Ada"]));
+        let digest = test_disclosure_digest(&disc);
+        let raw = build_test_sd_jwt(
+            json!({
+                "iss": "https://issuer.example.com",
+                "vct": "https://credentials.example.com/identity",
+                "cnf": holder_binding_cnf(),
+                "_sd": [digest],
+                "_sd_alg": "sha-256"
+            }),
+            &[disc],
+        );
+
+        let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
+            .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+            .signer(|_| Ok("not~a~compact~jws".to_string()))
+            .build()
+            .create_presentation()
+            .unwrap_err();
+
+        assert!(
+            matches!(err, ProofError::InvalidInput(ref input) if input.contains("Key Binding JWT")),
             "unexpected error: {err}"
         );
     }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/formats/sd_jwt.rs
@@ -715,6 +715,7 @@ mod tests {
         let presentation =
             SdJwtPresentation::builder(raw, "https://verifier.example.com", "test-nonce")
                 .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
+                .signer(test_signer)
                 .build()
                 .create_presentation()
                 .unwrap();
@@ -860,7 +861,6 @@ mod tests {
         let err = SdJwtPresentation::builder(raw, "https://verifier.example.com", "nonce")
             .requested_claims(vec![ClaimPathPointer::from_strings(["given_name"])])
             .transaction_data(vec!["hash1"], Some("sha-256"))
-            .signer(test_signer)
             .build()
             .create_presentation()
             .unwrap_err();

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/mod.rs
@@ -1,9 +1,21 @@
 mod builder;
 mod error;
-mod proof;
+pub mod formats;
 
 pub use builder::{PresentationBuilder, SelectedCredential};
-pub use error::{HolderBindingProofError, PresentationBuilderError};
-pub use proof::HolderBindingProof;
+pub use error::{PresentationBuilderError, ProofError};
 
-pub use crate::oid4vp::authorization::VpTokenError;
+use crate::oid4vp::authorization::Presentation;
+
+/// Creates a verifiable presentation for a selected credential.
+///
+/// Each credential format (SD-JWT VC, mdoc, etc.) provides its own
+/// implementation that assembles the format-specific presentation and includes
+/// holder-binding proof material when required by the presentation request.
+pub trait PresentationFactory: Send + Sync + 'static {
+    /// Creates the presentation.
+    ///
+    /// Implementations consume `self` because presentation construction is normally
+    /// a one-shot operation over nonce-bound request data.
+    fn create_presentation(self) -> Result<Presentation, ProofError>;
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/proof.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/presentation/proof.rs
@@ -1,7 +1,0 @@
-use crate::oid4vp::{authorization::Presentation, presentation::error::HolderBindingProofError};
-
-/// Creates a holder-binding proof for verifiable presentation.
-pub trait HolderBindingProof: Send + Sync + 'static {
-    /// Creates a holder-binding proof presentation.
-    fn create_proof(&self) -> Result<Presentation, HolderBindingProofError>;
-}


### PR DESCRIPTION
This MR provides implementation for SD-JWT VC specific presentation logic as defined in spec Appendix B.3. SD-JWT VC is the primary credential format for this wallet (`dc+sd-jwt`). This ticket covers selective disclosure (choosing which disclosures to include), Key Binding JWT creation (holder binding proof), and the presentation string assembly.

## Acceptance Criteria

- SD-JWT VC presentations include only the requested disclosures
- Key Binding JWT is correctly constructed with `nonce`, `aud`, and `sd_hash`
- Presentation string follows the `<issuer-jwt>~<disclosures>~<kb-jwt>` format

## Spec References

- [Appendix B.3 — IETF SD-JWT VC](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.3)
- [Appendix B.3.1 — Format Identifier](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.3.1)
- [Appendix B.3.6 — Presentation Response](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#appendix-B.3.6)