### PR TITLE
implementing presentation session model and persistance

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/selection/matching.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::core::claim_path_pointer::{ClaimPathPointer, ClaimValue};
@@ -9,7 +10,7 @@ use crate::oid4vp::dcql::{
 };
 
 /// The result of matching a full [`DcqlQuery`] against the Wallet's credentials.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SelectionResult {
     /// All matching candidates, grouped by credential query ID.
     ///
@@ -80,7 +81,7 @@ impl SelectionResult {
 }
 
 /// A credential that matched a single [`CredentialQuery`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialCandidate {
     /// Identifier of the [`CredentialQuery`] that this credential satisfies.
     pub credential_query_id: String,
@@ -99,7 +100,7 @@ pub struct CredentialCandidate {
 }
 
 /// A claim that was matched by a [`ClaimsQuery`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MatchedClaim {
     /// The claim query that produced this match.
     pub claim_query_id: Option<String>,
@@ -115,7 +116,7 @@ pub struct MatchedClaim {
 ///
 /// Callers construct this from their domain `Credential` model before passing
 /// it into the matching engine.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialView {
     /// Opaque identifier for this credential (e.g., UUID string).
     pub id: String,
@@ -151,7 +152,7 @@ pub struct CredentialView {
 }
 
 /// A trusted authority reference associated with a stored credential.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CredentialAuthority {
     pub authority_type: TrustedAuthorityType,
     pub value: String,

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -12,7 +12,7 @@ use crate::domain::models::issuance::{
     ConsentError, IssuanceError, IssuanceErrorCode, TxCodeError,
 };
 use crate::domain::models::tenants::TenantError;
-use crate::session::SessionError;
+use crate::session::{PresentationSessionStoreError, SessionError};
 
 /// The unified error type used by all HTTP handlers.
 ///
@@ -211,6 +211,24 @@ impl IntoApiError for TxCodeError {
                 error_description: Some(description),
             },
             TxCodeError::SessionStore(source) => ApiError::internal(source),
+        }
+    }
+}
+
+impl IntoApiError for PresentationSessionStoreError {
+    fn into_api_error(self) -> ApiError {
+        match self {
+            PresentationSessionStoreError::SessionNotFound => ApiError {
+                status: StatusCode::NOT_FOUND,
+                error: Cow::Borrowed("session_not_found"),
+                error_description: Some("Session does not exist or has expired.".into()),
+            },
+            PresentationSessionStoreError::InvalidSessionState => ApiError {
+                status: StatusCode::CONFLICT,
+                error: Cow::Borrowed("invalid_session_state"),
+                error_description: Some("Session is not in awaiting_consent state.".into()),
+            },
+            PresentationSessionStoreError::Store(source) => ApiError::internal(source),
         }
     }
 }

--- a/src/session/data.rs
+++ b/src/session/data.rs
@@ -1,4 +1,6 @@
 use cloud_wallet_openid4vc::oid4vci::client::ResolvedOfferContext;
+use cloud_wallet_openid4vc::oid4vp::authorization::{AuthorizationRequest, ResponseMode};
+use cloud_wallet_openid4vc::oid4vp::selection::SelectionResult;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -50,6 +52,78 @@ impl IssuanceSession {
             code_verifier: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresentationSession {
+    pub id: String,
+    pub tenant_id: Uuid,
+    pub state: PresentationState,
+    pub resolved_request: AuthorizationRequest,
+    pub dcql_result: SelectionResult,
+    pub flow: PresentationFlow,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresentationState {
+    AwaitingConsent,
+    Completed,
+    Failed,
+}
+
+impl PresentationState {
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PresentationFlow {
+    CrossDevice,
+    SameDevice,
+}
+
+impl PresentationSession {
+    pub fn new(
+        tenant_id: Uuid,
+        resolved_request: AuthorizationRequest,
+        dcql_result: SelectionResult,
+    ) -> Self {
+        let flow = match resolved_request.response_mode {
+            ResponseMode::DcApi | ResponseMode::DcApiJwt => PresentationFlow::SameDevice,
+            _ => PresentationFlow::CrossDevice,
+        };
+        Self {
+            id: utils::generate_presentation_session_id(),
+            tenant_id,
+            state: PresentationState::AwaitingConsent,
+            resolved_request,
+            dcql_result,
+            flow,
+        }
+    }
+}
+
+pub fn transition_presentation(
+    session: &mut PresentationSession,
+    new_state: PresentationState,
+) -> Result<()> {
+    if session.state != PresentationState::AwaitingConsent {
+        return Err(SessionError::InvalidStateTransition(
+            format!("{:?}", session.state).into(),
+            format!("{:?}", new_state).into(),
+        ));
+    }
+    if new_state == PresentationState::AwaitingConsent {
+        return Err(SessionError::InvalidStateTransition(
+            format!("{:?}", session.state).into(),
+            format!("{:?}", new_state).into(),
+        ));
+    }
+    session.state = new_state;
+    Ok(())
 }
 
 pub fn transition(session: &mut IssuanceSession, new_state: IssuanceState) -> Result<()> {
@@ -191,5 +265,84 @@ mod tests {
         let mut session = mock_session(FlowType::AuthorizationCode);
         session.state = IssuanceState::AwaitingTxCode;
         assert!(transition(&mut session, IssuanceState::Processing).is_err());
+    }
+
+    fn mock_presentation_session(response_mode: ResponseMode) -> PresentationSession {
+        use cloud_wallet_openid4vc::oid4vp::dcql::DcqlQuery;
+        let request = AuthorizationRequest {
+            response_type: cloud_wallet_openid4vc::oid4vp::authorization::ResponseType::VpToken,
+            client_id: "client".to_string(),
+            redirect_uri: None,
+            scope: None,
+            state: None,
+            nonce: "nonce".to_string(),
+            response_mode,
+            response_uri: Some(url::Url::parse("https://example.com/response").unwrap()),
+            request_uri: None,
+            request_uri_method: None,
+            dcql_query: Some(DcqlQuery {
+                credentials: vec![],
+                credential_sets: None,
+            }),
+            client_metadata: None,
+            client_metadata_uri: None,
+            request: None,
+            transaction_data: None,
+            verifier_info: None,
+            expected_origins: None,
+        };
+        let dcql_result = SelectionResult {
+            candidates: std::collections::HashMap::new(),
+            unsatisfied_queries: vec![],
+            satisfies_query: true,
+            selected_credential_query_ids: vec![],
+            multiple_allowed_by_query_id: std::collections::HashMap::new(),
+        };
+        PresentationSession::new(Uuid::new_v4(), request, dcql_result)
+    }
+
+    #[test]
+    fn test_presentation_flow_from_response_mode() {
+        let session = mock_presentation_session(ResponseMode::DirectPost);
+        assert_eq!(session.flow, PresentationFlow::CrossDevice);
+
+        let session = mock_presentation_session(ResponseMode::DirectPostJwt);
+        assert_eq!(session.flow, PresentationFlow::CrossDevice);
+
+        let session = mock_presentation_session(ResponseMode::DcApi);
+        assert_eq!(session.flow, PresentationFlow::SameDevice);
+
+        let session = mock_presentation_session(ResponseMode::DcApiJwt);
+        assert_eq!(session.flow, PresentationFlow::SameDevice);
+    }
+
+    #[test]
+    fn test_presentation_valid_transitions() {
+        let mut session = mock_presentation_session(ResponseMode::DirectPost);
+        assert_eq!(session.state, PresentationState::AwaitingConsent);
+
+        transition_presentation(&mut session, PresentationState::Completed).unwrap();
+        assert_eq!(session.state, PresentationState::Completed);
+
+        let mut session = mock_presentation_session(ResponseMode::DirectPost);
+        transition_presentation(&mut session, PresentationState::Failed).unwrap();
+        assert_eq!(session.state, PresentationState::Failed);
+    }
+
+    #[test]
+    fn test_presentation_invalid_transitions_from_terminal() {
+        let mut session = mock_presentation_session(ResponseMode::DirectPost);
+        transition_presentation(&mut session, PresentationState::Completed).unwrap();
+        assert!(transition_presentation(&mut session, PresentationState::Failed).is_err());
+
+        let mut session = mock_presentation_session(ResponseMode::DirectPost);
+        transition_presentation(&mut session, PresentationState::Failed).unwrap();
+        assert!(transition_presentation(&mut session, PresentationState::Completed).is_err());
+    }
+
+    #[test]
+    fn test_presentation_invalid_transition_to_awaiting_consent() {
+        let mut session = mock_presentation_session(ResponseMode::DirectPost);
+        assert!(transition_presentation(&mut session, PresentationState::AwaitingConsent).is_err());
     }
 }

--- a/src/session/error.rs
+++ b/src/session/error.rs
@@ -15,3 +15,16 @@ pub enum Error {
     #[error("{0}")]
     Other(color_eyre::eyre::Report),
 }
+
+/// Presentation session store errors.
+#[derive(thiserror::Error, Debug)]
+pub enum PresentationSessionStoreError {
+    #[error("Session not found")]
+    SessionNotFound,
+
+    #[error("Invalid session state")]
+    InvalidSessionState,
+
+    #[error("Store error: {0}")]
+    Store(#[from] Error),
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -5,8 +5,9 @@ mod utils;
 
 pub use data::*;
 pub use error::Error as SessionError;
-pub use store::{MemorySession, RedisSession};
-pub use utils::generate_session_id;
+pub use error::PresentationSessionStoreError;
+pub use store::{MemorySession, RedisPresentationSessionStore, RedisSession};
+pub use utils::{generate_presentation_session_id, generate_session_id};
 
 pub type Result<T> = std::result::Result<T, SessionError>;
 

--- a/src/session/store/mod.rs
+++ b/src/session/store/mod.rs
@@ -1,5 +1,7 @@
 mod memory;
 mod redis;
+mod redis_presentation;
 
 pub use memory::MemorySession;
 pub use redis::RedisSession;
+pub use redis_presentation::RedisPresentationSessionStore;

--- a/src/session/store/redis_presentation.rs
+++ b/src/session/store/redis_presentation.rs
@@ -1,0 +1,307 @@
+use std::time::Duration;
+
+use redis::aio::ConnectionManager;
+
+use crate::session::{
+    Id, PresentationSession, PresentationSessionStoreError, PresentationState, RedisSession,
+    Result, SessionStore,
+};
+
+const PRESENTATION_PREFIX: &str = "presentation_sessions";
+const DEFAULT_TTL: Duration = Duration::from_mins(15);
+
+/// A Redis-backed store for presentation sessions.
+///
+/// Uses a dedicated key prefix (`presentation_sessions`) and the same TTL
+/// semantics as issuance sessions.  Provides `transition` which enforces
+/// the state guard needed by the presentation flow.
+#[derive(Debug, Clone)]
+pub struct RedisPresentationSessionStore {
+    inner: RedisSession,
+}
+
+impl RedisPresentationSessionStore {
+    /// Create a new presentation session store backed by the given connection.
+    pub fn new(conn: ConnectionManager) -> Self {
+        let inner = RedisSession::new(conn)
+            .with_prefix(PRESENTATION_PREFIX)
+            .with_ttl(DEFAULT_TTL);
+        Self { inner }
+    }
+
+    /// Set a custom TTL. Must be greater than zero.
+    #[allow(dead_code)]
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.inner = self.inner.with_ttl(ttl);
+        self
+    }
+
+    /// Atomically transitions a session to a new terminal state.
+    ///
+    /// Returns:
+    /// - `Ok(())` on success.
+    /// - `PresentationSessionStoreError::SessionNotFound` if the session
+    ///   does not exist or has expired (maps to 404).
+    /// - `PresentationSessionStoreError::InvalidSessionState` if the session
+    ///   is already terminal (maps to 409).
+    pub async fn transition(
+        &self,
+        session_id: &str,
+        new_state: PresentationState,
+    ) -> std::result::Result<(), PresentationSessionStoreError> {
+        let mut session: PresentationSession = self
+            .inner
+            .get(session_id)
+            .await?
+            .ok_or_else(|| PresentationSessionStoreError::SessionNotFound)?;
+
+        if session.state != PresentationState::AwaitingConsent {
+            return Err(PresentationSessionStoreError::InvalidSessionState);
+        }
+        if new_state == PresentationState::AwaitingConsent {
+            return Err(PresentationSessionStoreError::InvalidSessionState);
+        }
+
+        session.state = new_state;
+        self.inner.upsert(session_id, &session).await?;
+        Ok(())
+    }
+}
+
+// Delegate generic operations to the inner RedisSession.
+#[async_trait::async_trait]
+impl SessionStore for RedisPresentationSessionStore {
+    async fn upsert<K, V>(&self, key: K, value: &V) -> Result<()>
+    where
+        K: Into<Id> + Send + Sync,
+        V: serde::Serialize + Send + Sync,
+    {
+        self.inner.upsert(key, value).await
+    }
+
+    async fn get<K, V>(&self, key: K) -> Result<Option<V>>
+    where
+        K: Into<Id> + Send + Sync,
+        V: serde::de::DeserializeOwned + Send + Sync,
+    {
+        self.inner.get(key).await
+    }
+
+    async fn exists<K: Into<Id> + Send + Sync>(&self, key: K) -> Result<bool> {
+        self.inner.exists(key).await
+    }
+
+    async fn consume<K, V>(&self, key: K) -> Result<Option<V>>
+    where
+        K: Into<Id> + Send + Sync,
+        V: serde::de::DeserializeOwned + Send + Sync,
+    {
+        self.inner.consume(key).await
+    }
+
+    async fn remove<K: Into<Id> + Send + Sync>(&self, key: K) -> Result<()> {
+        self.inner.remove(key).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    use cloud_wallet_openid4vc::oid4vp::authorization::{
+        AuthorizationRequest, ResponseMode, ResponseType,
+    };
+    use cloud_wallet_openid4vc::oid4vp::dcql::{
+        CredentialFormat, CredentialMeta, CredentialQuery, DcqlQuery,
+    };
+    use cloud_wallet_openid4vc::oid4vp::selection::SelectionResult;
+    use redis::Client;
+    use testcontainers_modules::{
+        redis::{REDIS_PORT, Redis},
+        testcontainers::{ImageExt, runners::AsyncRunner},
+    };
+    use uuid::Uuid;
+
+    async fn init_store(
+        ttl: Duration,
+    ) -> (
+        RedisPresentationSessionStore,
+        testcontainers_modules::testcontainers::ContainerAsync<Redis>,
+    ) {
+        let container = Redis::default()
+            .with_tag("8-alpine")
+            .start()
+            .await
+            .expect("redis container failed to start");
+
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(REDIS_PORT).await.unwrap();
+        let connection_string = format!("redis://{host}:{port}");
+
+        let client = Client::open(connection_string).expect("failed to create redis client");
+        let conn = client
+            .get_connection_manager()
+            .await
+            .expect("failed to get redis connection manager");
+
+        let store = RedisPresentationSessionStore::new(conn).with_ttl(ttl);
+        (store, container)
+    }
+
+    fn mock_session() -> PresentationSession {
+        let request = AuthorizationRequest {
+            response_type: ResponseType::VpToken,
+            client_id: "client".to_string(),
+            redirect_uri: None,
+            scope: None,
+            state: None,
+            nonce: "nonce".to_string(),
+            response_mode: ResponseMode::DirectPost,
+            response_uri: Some(url::Url::parse("https://example.com/response").unwrap()),
+            request_uri: None,
+            request_uri_method: None,
+            dcql_query: Some(DcqlQuery {
+                credentials: vec![CredentialQuery {
+                    id: "pid".to_string(),
+                    format: CredentialFormat::DcSdJwt,
+                    multiple: None,
+                    meta: CredentialMeta::SdJwt {
+                        vct_values: vec!["https://example.com/identity".to_string()],
+                    },
+                    claims: None,
+                    claim_sets: None,
+                    trusted_authorities: None,
+                    require_cryptographic_holder_binding: None,
+                }],
+                credential_sets: None,
+            }),
+            client_metadata: None,
+            client_metadata_uri: None,
+            request: None,
+            transaction_data: None,
+            verifier_info: None,
+            expected_origins: None,
+        };
+        let dcql_result = SelectionResult {
+            candidates: HashMap::new(),
+            unsatisfied_queries: vec![],
+            satisfies_query: true,
+            selected_credential_query_ids: vec![],
+            multiple_allowed_by_query_id: HashMap::new(),
+        };
+        PresentationSession::new(Uuid::new_v4(), request, dcql_result)
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_roundtrip_and_remove() {
+        let (store, _container) = init_store(Duration::from_secs(2)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        assert!(store.exists(session_id.as_str()).await.unwrap());
+
+        let retrieved: PresentationSession = store.get(session_id.as_str()).await.unwrap().unwrap();
+        assert_eq!(retrieved.id, session_id);
+        assert_eq!(retrieved.state, PresentationState::AwaitingConsent);
+
+        store.remove(session_id.as_str()).await.unwrap();
+        assert!(!store.exists(session_id.as_str()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_consume_is_one_time() {
+        let (store, _container) = init_store(Duration::from_secs(2)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        let retrieved: Option<PresentationSession> =
+            store.consume(session_id.as_str()).await.unwrap();
+        assert!(retrieved.is_some());
+
+        let second: Option<PresentationSession> = store.consume(session_id.as_str()).await.unwrap();
+        assert!(second.is_none());
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_expired_returns_not_found() {
+        let (store, _container) = init_store(Duration::from_millis(50)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(150)).await;
+
+        let exists = store.exists(session_id.as_str()).await.unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_transition_valid() {
+        let (store, _container) = init_store(Duration::from_secs(2)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        store
+            .transition(session_id.as_str(), PresentationState::Completed)
+            .await
+            .unwrap();
+
+        let retrieved: PresentationSession = store.get(session_id.as_str()).await.unwrap().unwrap();
+        assert_eq!(retrieved.state, PresentationState::Completed);
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_transition_from_terminal_returns_invalid_state() {
+        let (store, _container) = init_store(Duration::from_secs(2)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        store
+            .transition(session_id.as_str(), PresentationState::Completed)
+            .await
+            .unwrap();
+
+        let result = store
+            .transition(session_id.as_str(), PresentationState::Failed)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_transition_missing_returns_not_found() {
+        let (store, _container) = init_store(Duration::from_secs(2)).await;
+        let result = store
+            .transition("nonexistent", PresentationState::Completed)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn redis_presentation_upsert_does_not_extend_ttl() {
+        let (store, _container) = init_store(Duration::from_millis(220)).await;
+        let session = mock_session();
+        let session_id = session.id.clone();
+
+        store.upsert(session_id.as_str(), &session).await.unwrap();
+        tokio::time::sleep(Duration::from_millis(130)).await;
+
+        // Update state without refreshing TTL
+        store
+            .transition(session_id.as_str(), PresentationState::Completed)
+            .await
+            .unwrap();
+
+        let val: Option<PresentationSession> = store.get(session_id.as_str()).await.unwrap();
+        assert!(val.is_some());
+
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        let val: Option<PresentationSession> = store.get(session_id.as_str()).await.unwrap();
+        assert!(val.is_none());
+    }
+}

--- a/src/session/utils.rs
+++ b/src/session/utils.rs
@@ -7,6 +7,12 @@ pub fn generate_session_id() -> String {
     format!("ses_{}", URL_SAFE_NO_PAD.encode(bytes))
 }
 
+pub fn generate_presentation_session_id() -> String {
+    let mut bytes = [0u8; 16];
+    rand::fill(&mut bytes);
+    format!("prs_{}", URL_SAFE_NO_PAD.encode(bytes))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -23,6 +29,20 @@ mod tests {
     fn test_generate_session_id_uniqueness() {
         let id1 = generate_session_id();
         let id2 = generate_session_id();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_generate_presentation_session_id() {
+        let id = generate_presentation_session_id();
+        assert!(id.starts_with("prs_"));
+        assert_eq!(id.len(), 26);
+    }
+
+    #[test]
+    fn test_generate_presentation_session_id_uniqueness() {
+        let id1 = generate_presentation_session_id();
+        let id2 = generate_presentation_session_id();
         assert_ne!(id1, id2);
     }
 }


### PR DESCRIPTION
Here is a PR description you can use:

---

## Summary

Implements the presentation session model and Redis-backed persistence, as specified in the ticket.

## Changes

### 1. Session Model
- **`PresentationSession`** (`src/session/data.rs`): bridges `POST /start` and `POST /consent` by storing:
  - `resolved_request`: fully parsed and validated `AuthorizationRequest`
  - `dcql_result`: `SelectionResult` with credential-to-query mappings
  - `flow`: `CrossDevice` or `SameDevice`, derived from `response_mode`
- **`PresentationState`**: `AwaitingConsent` → `Completed` | `Failed`
- **`PresentationFlow`**: `cross_device` / `same_device`

### 2. Session ID Generation
- Added `generate_presentation_session_id()` (`src/session/utils.rs`)
- Uses `prs_` prefix (issuance keeps `ses_`)

### 3. Redis Presentation Store
- **`RedisPresentationSessionStore`** (`src/session/store/redis_presentation.rs`)
- Dedicated key prefix `presentation_sessions`, TTL 15 min (never renewed on update)
- Delegates generic ops to `RedisSession` (upsert, get, consume, remove)

### 4. State Transition Guard
- `transition(session_id, new_state)` enforces:
  - Missing/expired session → `SessionNotFound` (maps to **404**)
  - Already-terminal state → `InvalidSessionState` (maps to **409**)

### 5. Error Mapping
- Added `IntoApiError` for `PresentationSessionStoreError` in `src/server/error.rs`
- Returns `session_not_found` and `invalid_session_state` as required

### 6. Serialization Support
- Added `Serialize`/`Deserialize` derives to `SelectionResult` and nested types in `cloud-wallet-openid4vc` crate so presentation sessions can round-trip through Redis

### 7. Tests
- Model tests: flow derivation from `response_mode`, valid/invalid transitions
- Store tests (Redis testcontainer): roundtrip, consume-once, TTL expiry, transition guards, missing session, TTL preservation on state change

---

**Estimated:** 1 day | **Status:** Ready for review