### PR TITLE
Feat/iaca trust store loader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,7 +978,6 @@ dependencies = [
  "rcgen",
  "redis",
  "reqwest",
- "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
@@ -3705,15 +3704,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "rcgen",
  "redis",
  "reqwest",
+ "rustls-pemfile",
  "rustls-pki-types",
  "rustls-webpki",
  "secrecy",
@@ -986,6 +987,7 @@ dependencies = [
  "serde_qs",
  "serde_with",
  "sqlx",
+ "tempfile",
  "testcontainers-modules",
  "thiserror 2.0.18",
  "tikv-jemallocator",
@@ -3400,6 +3402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "aws-lc-rs",
+ "pem",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -3702,6 +3705,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4451,6 +4463,19 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "testcontainers"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,7 @@ futures.workspace = true
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 parking_lot = "0.12"
 rand.workspace = true
-rustls-pemfile = "2"
-rustls-pki-types.workspace = true
+rustls-pki-types = { workspace = true, features = ["alloc"] }
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ futures.workspace = true
 jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 parking_lot = "0.12"
 rand.workspace = true
+rustls-pemfile = "2"
 rustls-pki-types.workspace = true
 secrecy = { version = "0.10", features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
@@ -123,9 +124,10 @@ features = [
 [dev-dependencies]
 base64ct = { workspace = true, features = ["alloc"] }
 ciborium.workspace = true
-rcgen.workspace = true
+rcgen = { workspace = true, features = ["pem"] }
 reqwest = { version = "0.13", features = ["json"] }
 serde_json = { workspace = true }
+tempfile = "3"
 testcontainers-modules = { version = "0.15", features = ["mysql", "postgres", "redis"] }
 tower = { version = "0.5", features = ["util"] }
 webpki.workspace = true

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The application is configured via environment variables prefixed with `APP_`, us
 | `APP_OID4VCI__CLIENT_ID`                 | `cloud-identity-wallet`                          | OAuth2 client identifier                                                                                             |
 | `APP_OID4VCI__REDIRECT_URI`              | `http://localhost:3000/api/v1/issuance/callback` | OAuth2 redirect URI                                                                                                  |
 | `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES` | `en`                                             | Comma-separated locale prefixes tried in priority order when selecting credential display metadata (e.g. `en,fr,de`) |
+| `APP_MDOC__IACA_ROOT_PATHS`              | *(empty)*                                        | Comma-separated paths to DER- or PEM-encoded IACA root certificate files (e.g. `/certs/iaca-root.pem`). An empty list is fail-closed: all ISO 18013-5 mDoc credential issuances will be rejected. A startup `WARN` is logged when no roots are loaded. Paths containing commas must be set via a config file instead of this variable. |
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The application is configured via environment variables prefixed with `APP_`, us
 | `APP_OID4VCI__CLIENT_ID`                 | `cloud-identity-wallet`                          | OAuth2 client identifier                                                                                             |
 | `APP_OID4VCI__REDIRECT_URI`              | `http://localhost:3000/api/v1/issuance/callback` | OAuth2 redirect URI                                                                                                  |
 | `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES` | `en`                                             | Comma-separated locale prefixes tried in priority order when selecting credential display metadata (e.g. `en,fr,de`) |
-| `APP_MDOC__IACA_ROOT_PATHS`              | *(empty)*                                        | Comma-separated paths to DER- or PEM-encoded IACA root certificate files (e.g. `/certs/iaca-root.pem`). An empty list is fail-closed: all ISO 18013-5 mDoc credential issuances will be rejected. A startup `WARN` is logged when no roots are loaded. Paths containing commas must be set via a config file instead of this variable. |
+| `APP_OID4VCI__IACA_ROOT_PATHS`              | *(empty)*                                        | Comma-separated paths to DER- or PEM-encoded IACA root certificate files (e.g. `/certs/iaca-root.pem`). An empty list is fail-closed: all ISO 18013-5 mDoc credential issuances will be rejected. A startup `WARN` is logged when no roots are loaded. Paths containing commas must be set via a config file instead of this variable. |
 
 ### Testing
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,6 +17,7 @@ pub struct Config {
     pub redis: RedisConfig,
     pub database: DatabaseConfig,
     pub oid4vci: Oid4vciConfig,
+    pub mdoc: MdocConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,6 +46,21 @@ pub struct Oid4vciConfig {
     /// Configurable via `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES=en,fr,de`.
     #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, Vec<_>)>")]
     pub preferred_display_locales: Vec<String>,
+}
+
+/// Configuration for ISO 18013-5 mDoc credential verification.
+#[serde_as]
+#[derive(Debug, Clone, Deserialize)]
+pub struct MdocConfig {
+    /// Paths to DER- or PEM-encoded IACA root certificate files loaded at startup.
+    ///
+    /// An empty list means the trust store has no roots and all mso_mdoc issuances
+    /// will be rejected.  Configure via `APP_MDOC__IACA_ROOT_PATHS=/a.pem,/b.der`.
+    ///
+    /// Paths are comma-separated when supplied via environment variable; filesystem
+    /// paths containing commas cannot be expressed that way — use a config file instead.
+    #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, Vec<_>)>")]
+    pub iaca_root_paths: Vec<String>,
 }
 
 impl RedisConfig {
@@ -114,7 +130,8 @@ impl Config {
                 "http://localhost:3000/api/v1/issuance/callback",
             )?
             .set_default("oid4vci.use_system_proxy", true)?
-            .set_default("oid4vci.preferred_display_locales", vec!["en"])
+            .set_default("oid4vci.preferred_display_locales", vec!["en"])?
+            .set_default("mdoc.iaca_root_paths", Vec::<String>::new())
     }
 }
 
@@ -165,6 +182,28 @@ mod tests {
         assert_eq!(
             config.redis.uri.expose_secret(),
             "redis://127.0.0.1:6379?protocol=resp3"
+        );
+    }
+
+    #[test]
+    fn test_mdoc_iaca_root_paths_defaults_to_empty() {
+        let config = Config::load().expect("Failed to load config");
+        assert!(config.mdoc.iaca_root_paths.is_empty());
+    }
+
+    #[test]
+    fn test_mdoc_iaca_root_paths_csv_string_override() {
+        let mut env_vars = HashMap::new();
+        env_vars.insert(
+            "mdoc.iaca_root_paths".to_string(),
+            "/certs/root1.pem,/certs/root2.der".to_string(),
+        );
+
+        let config = Config::load_with_sources(Some(env_vars)).expect("Failed to load config");
+
+        assert_eq!(
+            config.mdoc.iaca_root_paths,
+            vec!["/certs/root1.pem", "/certs/root2.der"]
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,6 @@ pub struct Config {
     pub redis: RedisConfig,
     pub database: DatabaseConfig,
     pub oid4vci: Oid4vciConfig,
-    pub mdoc: MdocConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -46,19 +45,7 @@ pub struct Oid4vciConfig {
     /// Configurable via `APP_OID4VCI__PREFERRED_DISPLAY_LOCALES=en,fr,de`.
     #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, Vec<_>)>")]
     pub preferred_display_locales: Vec<String>,
-}
-
-/// Configuration for ISO 18013-5 mDoc credential verification.
-#[serde_as]
-#[derive(Debug, Clone, Deserialize)]
-pub struct MdocConfig {
     /// Paths to DER- or PEM-encoded IACA root certificate files loaded at startup.
-    ///
-    /// An empty list means the trust store has no roots and all mso_mdoc issuances
-    /// will be rejected.  Configure via `APP_MDOC__IACA_ROOT_PATHS=/a.pem,/b.der`.
-    ///
-    /// Paths are comma-separated when supplied via environment variable; filesystem
-    /// paths containing commas cannot be expressed that way — use a config file instead.
     #[serde_as(as = "PickFirst<(StringWithSeparator::<CommaSeparator, String>, Vec<_>)>")]
     pub iaca_root_paths: Vec<String>,
 }
@@ -131,7 +118,7 @@ impl Config {
             )?
             .set_default("oid4vci.use_system_proxy", true)?
             .set_default("oid4vci.preferred_display_locales", vec!["en"])?
-            .set_default("mdoc.iaca_root_paths", Vec::<String>::new())
+            .set_default("oid4vci.iaca_root_paths", Vec::<String>::new())
     }
 }
 
@@ -186,23 +173,23 @@ mod tests {
     }
 
     #[test]
-    fn test_mdoc_iaca_root_paths_defaults_to_empty() {
+    fn test_iaca_root_paths_defaults_to_empty() {
         let config = Config::load().expect("Failed to load config");
-        assert!(config.mdoc.iaca_root_paths.is_empty());
+        assert!(config.oid4vci.iaca_root_paths.is_empty());
     }
 
     #[test]
-    fn test_mdoc_iaca_root_paths_csv_string_override() {
+    fn test_iaca_root_paths_csv_string_override() {
         let mut env_vars = HashMap::new();
         env_vars.insert(
-            "mdoc.iaca_root_paths".to_string(),
+            "oid4vci.iaca_root_paths".to_string(),
             "/certs/root1.pem,/certs/root2.der".to_string(),
         );
 
         let config = Config::load_with_sources(Some(env_vars)).expect("Failed to load config");
 
         assert_eq!(
-            config.mdoc.iaca_root_paths,
+            config.oid4vci.iaca_root_paths,
             vec!["/certs/root1.pem", "/certs/root2.der"]
         );
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -14,7 +14,7 @@ use crate::utils::load_iaca_roots;
 
 /// Constructs an [`IssuanceEngine`] from configuration.
 ///
-/// Loads IACA roots from [`crate::config::MdocConfig`].  Returns an error if any
+/// Loads IACA roots from [`crate::config::Oid4vciConfig`].  Returns an error if any
 /// configured root path is unreadable or is a PEM file with no certificates.
 /// Logs a `WARN` at startup if no roots are loaded — the resulting store is
 /// fail-closed and all mso_mdoc issuances will be rejected.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -40,7 +40,7 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
     let credential_repo = MemoryCredentialRepo::new();
     let preferred_display_locales = config.oid4vci.preferred_display_locales.clone();
 
-    let iaca_roots = load_iaca_roots(&config.mdoc.iaca_root_paths)?;
+    let iaca_roots = load_iaca_roots(&config.oid4vci.iaca_root_paths)?;
     if iaca_roots.is_empty() {
         tracing::warn!(
             "mdoc IACA trust store is empty: all mso_mdoc credential issuances will be rejected"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -28,7 +28,8 @@ use crate::session::SessionStore;
 /// PEM file contains no `CERTIFICATE` blocks.
 fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8>>> {
     use color_eyre::eyre::eyre;
-    use std::io::BufReader;
+    use rustls_pki_types::CertificateDer;
+    use rustls_pki_types::pem::PemObject as _;
 
     let mut roots = Vec::new();
     for path in paths {
@@ -36,12 +37,11 @@ fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8>>> {
             .map_err(|e| eyre!("failed to read IACA root file '{path}': {e}"))?;
 
         if bytes.starts_with(b"-----BEGIN") {
-            let mut reader = BufReader::new(bytes.as_slice());
             let mut count = 0usize;
-            for cert in rustls_pemfile::certs(&mut reader) {
+            for cert in CertificateDer::pem_slice_iter(&bytes) {
                 let cert =
                     cert.map_err(|e| eyre!("malformed PEM in IACA root file '{path}': {e}"))?;
-                roots.push(cert.to_vec());
+                roots.push(cert.as_ref().to_vec());
                 count += 1;
             }
             if count == 0 {
@@ -105,6 +105,16 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
     Ok(engine)
 }
 
+/// Build a fully wired [`Service`] ready for use in the server.
+pub fn build_service<S: SessionStore + Clone>(
+    session_store: S,
+    tenant_repo: impl TenantRepo + Clone,
+    config: &Config,
+) -> color_eyre::Result<Service<S>> {
+    let engine = build_issuance_engine(config, tenant_repo.clone(), &session_store)?;
+    Ok(Service::new(session_store, tenant_repo, engine))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -135,7 +145,7 @@ mod tests {
             let store = StaticTrustStore::new(roots);
             assert_eq!(
                 store.trusted_roots(),
-                &[der.clone()],
+                std::slice::from_ref(&der),
                 "{label} roots must reach the store"
             );
         }
@@ -168,14 +178,4 @@ mod tests {
             .unwrap();
         assert!(load_iaca_roots(&[f2.path().to_string_lossy().into_owned()]).is_err());
     }
-}
-
-/// Build a fully wired [`Service`] ready for use in the server.
-pub fn build_service<S: SessionStore + Clone>(
-    session_store: S,
-    tenant_repo: impl TenantRepo + Clone,
-    config: &Config,
-) -> color_eyre::Result<Service<S>> {
-    let engine = build_issuance_engine(config, tenant_repo.clone(), &session_store)?;
-    Ok(Service::new(session_store, tenant_repo, engine))
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -163,7 +163,10 @@ mod tests {
     }
 
     #[test]
-    fn errors_on_malformed_pem() {
+    fn errors_on_bad_input() {
+        // unreadable path — hard startup error, not silently skipped
+        assert!(load_iaca_roots(&["/nonexistent/path/root.pem".into()]).is_err());
+
         // invalid base64 inside a CERTIFICATE block
         let mut f1 = tempfile::NamedTempFile::new().unwrap();
         f1.write_all(

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -10,51 +10,7 @@ use crate::outbound::{
     MemoryCredentialRepo, MemoryEventPublisher, MemoryEventSubscriber, MemoryTaskQueue,
 };
 use crate::session::SessionStore;
-
-/// Loads IACA root certificates from the given file paths.
-///
-/// Each path may point to either a DER-encoded certificate or a PEM file containing
-/// one or more certificates.  Format is detected by checking whether the file starts
-/// with the ASCII bytes `-----BEGIN`.
-///
-/// DER files are accepted without structural validation; a malformed DER file
-/// produces an `InvalidCertificateChain` error at the first credential
-/// verification, not at startup.  PEM files are validated only insofar as they
-/// must contain at least one parseable `CERTIFICATE` block.
-///
-/// # Errors
-///
-/// Returns an error if any path cannot be read, if a PEM file is malformed, or if a
-/// PEM file contains no `CERTIFICATE` blocks.
-fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8>>> {
-    use color_eyre::eyre::eyre;
-    use rustls_pki_types::CertificateDer;
-    use rustls_pki_types::pem::PemObject as _;
-
-    let mut roots = Vec::new();
-    for path in paths {
-        let bytes = std::fs::read(path)
-            .map_err(|e| eyre!("failed to read IACA root file '{path}': {e}"))?;
-
-        if bytes.starts_with(b"-----BEGIN") {
-            let mut count = 0usize;
-            for cert in CertificateDer::pem_slice_iter(&bytes) {
-                let cert =
-                    cert.map_err(|e| eyre!("malformed PEM in IACA root file '{path}': {e}"))?;
-                roots.push(cert.as_ref().to_vec());
-                count += 1;
-            }
-            if count == 0 {
-                return Err(eyre!(
-                    "IACA root file '{path}' is PEM-formatted but contains no certificates"
-                ));
-            }
-        } else {
-            roots.push(bytes);
-        }
-    }
-    Ok(roots)
-}
+use crate::utils::load_iaca_roots;
 
 /// Constructs an [`IssuanceEngine`] from configuration.
 ///
@@ -113,72 +69,4 @@ pub fn build_service<S: SessionStore + Clone>(
 ) -> color_eyre::Result<Service<S>> {
     let engine = build_issuance_engine(config, tenant_repo.clone(), &session_store)?;
     Ok(Service::new(session_store, tenant_repo, engine))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use cloud_wallet_openid4vc::formats::mdoc::IacaTrustStore;
-    use std::io::Write;
-
-    fn self_signed_cert() -> (Vec<u8>, String) {
-        let params =
-            rcgen::CertificateParams::new(vec!["test.local".to_string()]).expect("cert params");
-        let key = rcgen::KeyPair::generate().expect("key generation");
-        let cert = params.self_signed(&key).expect("self-signed cert");
-        (cert.der().to_vec(), cert.pem())
-    }
-
-    #[test]
-    fn loads_der_and_pem_to_same_bytes() {
-        let (der, pem) = self_signed_cert();
-        for (label, content) in [("DER", der.clone()), ("PEM", pem.into_bytes())] {
-            let mut f = tempfile::NamedTempFile::new().unwrap();
-            f.write_all(&content).unwrap();
-            let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
-            assert_eq!(
-                roots,
-                vec![der.clone()],
-                "{label} file should decode to the same DER"
-            );
-            // loader→store link: the loaded bytes populate the trust store correctly
-            let store = StaticTrustStore::new(roots);
-            assert_eq!(
-                store.trusted_roots(),
-                std::slice::from_ref(&der),
-                "{label} roots must reach the store"
-            );
-        }
-    }
-
-    #[test]
-    fn pem_bundle_loads_all_certs() {
-        let (der1, pem1) = self_signed_cert();
-        let (der2, pem2) = self_signed_cert();
-        let mut f = tempfile::NamedTempFile::new().unwrap();
-        f.write_all(format!("{pem1}{pem2}").as_bytes()).unwrap();
-        let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
-        assert_eq!(roots.len(), 2);
-        assert!(roots.contains(&der1) && roots.contains(&der2));
-    }
-
-    #[test]
-    fn errors_on_bad_input() {
-        // unreadable path — hard startup error, not silently skipped
-        assert!(load_iaca_roots(&["/nonexistent/path/root.pem".into()]).is_err());
-
-        // invalid base64 inside a CERTIFICATE block
-        let mut f1 = tempfile::NamedTempFile::new().unwrap();
-        f1.write_all(
-            b"-----BEGIN CERTIFICATE-----\nnot-valid-base64!!!\n-----END CERTIFICATE-----\n",
-        )
-        .unwrap();
-        assert!(load_iaca_roots(&[f1.path().to_string_lossy().into_owned()]).is_err());
-
-        // valid PEM syntax but no CERTIFICATE blocks (e.g. a private-key file)
-        let mut f2 = tempfile::NamedTempFile::new().unwrap();
-        f2.write_all(b"-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n")
-            .unwrap();
-        assert!(load_iaca_roots(&[f2.path().to_string_lossy().into_owned()]).is_err());
-    }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -11,6 +11,57 @@ use crate::outbound::{
 };
 use crate::session::SessionStore;
 
+/// Loads IACA root certificates from the given file paths.
+///
+/// Each path may point to either a DER-encoded certificate or a PEM file containing
+/// one or more certificates.  Format is detected by checking whether the file starts
+/// with the ASCII bytes `-----BEGIN`.
+///
+/// DER files are accepted without structural validation; a malformed DER file
+/// produces an `InvalidCertificateChain` error at the first credential
+/// verification, not at startup.  PEM files are validated only insofar as they
+/// must contain at least one parseable `CERTIFICATE` block.
+///
+/// # Errors
+///
+/// Returns an error if any path cannot be read, if a PEM file is malformed, or if a
+/// PEM file contains no `CERTIFICATE` blocks.
+fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8>>> {
+    use color_eyre::eyre::eyre;
+    use std::io::BufReader;
+
+    let mut roots = Vec::new();
+    for path in paths {
+        let bytes = std::fs::read(path)
+            .map_err(|e| eyre!("failed to read IACA root file '{path}': {e}"))?;
+
+        if bytes.starts_with(b"-----BEGIN") {
+            let mut reader = BufReader::new(bytes.as_slice());
+            let mut count = 0usize;
+            for cert in rustls_pemfile::certs(&mut reader) {
+                let cert =
+                    cert.map_err(|e| eyre!("malformed PEM in IACA root file '{path}': {e}"))?;
+                roots.push(cert.to_vec());
+                count += 1;
+            }
+            if count == 0 {
+                return Err(eyre!(
+                    "IACA root file '{path}' is PEM-formatted but contains no certificates"
+                ));
+            }
+        } else {
+            roots.push(bytes);
+        }
+    }
+    Ok(roots)
+}
+
+/// Constructs an [`IssuanceEngine`] from configuration.
+///
+/// Loads IACA roots from [`crate::config::MdocConfig`].  Returns an error if any
+/// configured root path is unreadable or is a PEM file with no certificates.
+/// Logs a `WARN` at startup if no roots are loaded — the resulting store is
+/// fail-closed and all mso_mdoc issuances will be rejected.
 pub fn build_issuance_engine<S: SessionStore + Clone>(
     config: &Config,
     tenant_repo: impl TenantRepo,
@@ -33,6 +84,13 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
     let credential_repo = MemoryCredentialRepo::new();
     let preferred_display_locales = config.oid4vci.preferred_display_locales.clone();
 
+    let iaca_roots = load_iaca_roots(&config.mdoc.iaca_root_paths)?;
+    if iaca_roots.is_empty() {
+        tracing::warn!(
+            "mdoc IACA trust store is empty: all mso_mdoc credential issuances will be rejected"
+        );
+    }
+
     let engine = IssuanceEngine::new(
         client,
         task_queue,
@@ -43,11 +101,73 @@ pub fn build_issuance_engine<S: SessionStore + Clone>(
         session_store,
         preferred_display_locales,
     )
-    // TODO: load IACA root certificates from configuration for mdoc verification.
-    // The empty store is the fail-closed default: all mdoc credentials are rejected
-    // until IACA roots are supplied.
-    .with_iaca_trust_store(StaticTrustStore::new(vec![]));
+    .with_iaca_trust_store(StaticTrustStore::new(iaca_roots));
     Ok(engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloud_wallet_openid4vc::formats::mdoc::IacaTrustStore;
+    use std::io::Write;
+
+    fn self_signed_cert() -> (Vec<u8>, String) {
+        let params =
+            rcgen::CertificateParams::new(vec!["test.local".to_string()]).expect("cert params");
+        let key = rcgen::KeyPair::generate().expect("key generation");
+        let cert = params.self_signed(&key).expect("self-signed cert");
+        (cert.der().to_vec(), cert.pem())
+    }
+
+    #[test]
+    fn loads_der_and_pem_to_same_bytes() {
+        let (der, pem) = self_signed_cert();
+        for (label, content) in [("DER", der.clone()), ("PEM", pem.into_bytes())] {
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            f.write_all(&content).unwrap();
+            let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
+            assert_eq!(
+                roots,
+                vec![der.clone()],
+                "{label} file should decode to the same DER"
+            );
+            // loader→store link: the loaded bytes populate the trust store correctly
+            let store = StaticTrustStore::new(roots);
+            assert_eq!(
+                store.trusted_roots(),
+                &[der.clone()],
+                "{label} roots must reach the store"
+            );
+        }
+    }
+
+    #[test]
+    fn pem_bundle_loads_all_certs() {
+        let (der1, pem1) = self_signed_cert();
+        let (der2, pem2) = self_signed_cert();
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(format!("{pem1}{pem2}").as_bytes()).unwrap();
+        let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.contains(&der1) && roots.contains(&der2));
+    }
+
+    #[test]
+    fn errors_on_malformed_pem() {
+        // invalid base64 inside a CERTIFICATE block
+        let mut f1 = tempfile::NamedTempFile::new().unwrap();
+        f1.write_all(
+            b"-----BEGIN CERTIFICATE-----\nnot-valid-base64!!!\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        assert!(load_iaca_roots(&[f1.path().to_string_lossy().into_owned()]).is_err());
+
+        // valid PEM syntax but no CERTIFICATE blocks (e.g. a private-key file)
+        let mut f2 = tempfile::NamedTempFile::new().unwrap();
+        f2.write_all(b"-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n")
+            .unwrap();
+        assert!(load_iaca_roots(&[f2.path().to_string_lossy().into_owned()]).is_err());
+    }
 }
 
 /// Build a fully wired [`Service`] ready for use in the server.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -151,6 +151,7 @@ pub(crate) fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write as _;
 
     #[test]
     fn rewrites_postgres_bindings_to_question_marks() {
@@ -197,8 +198,6 @@ mod tests {
 
     #[test]
     fn pem_bundle_loads_all_certs() {
-        use std::io::Write as _;
-
         let (der1, pem1) = self_signed_cert();
         let (der2, pem2) = self_signed_cert();
         let mut f = tempfile::NamedTempFile::new().unwrap();
@@ -210,8 +209,6 @@ mod tests {
 
     #[test]
     fn errors_on_bad_input() {
-        use std::io::Write as _;
-
         assert!(load_iaca_roots(&["/nonexistent/path/root.pem".into()]).is_err());
 
         let mut f1 = tempfile::NamedTempFile::new().unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,6 @@
+use color_eyre::eyre::{WrapErr as _, eyre};
+use rustls_pki_types::CertificateDer;
+use rustls_pki_types::pem::PemObject as _;
 use std::borrow::Cow;
 use std::fmt::Write;
 use std::sync::OnceLock;
@@ -104,6 +107,47 @@ fn rewrite_to_positional(sql: &str) -> Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Loads IACA root certificates from the given file paths.
+///
+/// Each path may point to either a DER-encoded certificate or a PEM file containing
+/// one or more certificates.  Format is detected by checking whether the file starts
+/// with the ASCII bytes `-----BEGIN`.
+///
+/// DER files are accepted without structural validation; a malformed DER file
+/// produces an `InvalidCertificateChain` error at the first credential
+/// verification, not at startup.  PEM files are validated only insofar as they
+/// must contain at least one parseable `CERTIFICATE` block.
+///
+/// # Errors
+///
+/// Returns an error if any path cannot be read, if a PEM file is malformed, or if a
+/// PEM file contains no `CERTIFICATE` blocks.
+pub(crate) fn load_iaca_roots(paths: &[String]) -> color_eyre::Result<Vec<Vec<u8>>> {
+    let mut roots = Vec::new();
+    for path in paths {
+        let bytes = std::fs::read(path)
+            .wrap_err_with(|| format!("failed to read IACA root file '{path}'"))?;
+
+        if bytes.starts_with(b"-----BEGIN") {
+            let mut count = 0usize;
+            for cert in CertificateDer::pem_slice_iter(&bytes) {
+                let cert =
+                    cert.wrap_err_with(|| format!("malformed PEM in IACA root file '{path}'"))?;
+                roots.push(cert.as_ref().to_vec());
+                count += 1;
+            }
+            if count == 0 {
+                return Err(eyre!(
+                    "IACA root file '{path}' is PEM-formatted but contains no certificates"
+                ));
+            }
+        } else {
+            roots.push(bytes);
+        }
+    }
+    Ok(roots)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +159,71 @@ mod tests {
             rewrite_to_positional(sql).as_ref(),
             "SELECT * FROM credentials WHERE id = ? AND tenant_id = ?"
         );
+    }
+
+    // --- load_iaca_roots tests ---
+
+    fn self_signed_cert() -> (Vec<u8>, String) {
+        let params =
+            rcgen::CertificateParams::new(vec!["test.local".to_string()]).expect("cert params");
+        let key = rcgen::KeyPair::generate().expect("key generation");
+        let cert = params.self_signed(&key).expect("self-signed cert");
+        (cert.der().to_vec(), cert.pem())
+    }
+
+    #[test]
+    fn loads_der_and_pem_to_same_bytes() {
+        use cloud_wallet_openid4vc::formats::mdoc::{IacaTrustStore, StaticTrustStore};
+        use std::io::Write as _;
+
+        let (der, pem) = self_signed_cert();
+        for (label, content) in [("DER", der.clone()), ("PEM", pem.into_bytes())] {
+            let mut f = tempfile::NamedTempFile::new().unwrap();
+            f.write_all(&content).unwrap();
+            let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
+            assert_eq!(
+                roots,
+                vec![der.clone()],
+                "{label} file should decode to the same DER"
+            );
+            let store = StaticTrustStore::new(roots);
+            assert_eq!(
+                store.trusted_roots(),
+                std::slice::from_ref(&der),
+                "{label} roots must reach the store"
+            );
+        }
+    }
+
+    #[test]
+    fn pem_bundle_loads_all_certs() {
+        use std::io::Write as _;
+
+        let (der1, pem1) = self_signed_cert();
+        let (der2, pem2) = self_signed_cert();
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(format!("{pem1}{pem2}").as_bytes()).unwrap();
+        let roots = load_iaca_roots(&[f.path().to_string_lossy().into_owned()]).unwrap();
+        assert_eq!(roots.len(), 2);
+        assert!(roots.contains(&der1) && roots.contains(&der2));
+    }
+
+    #[test]
+    fn errors_on_bad_input() {
+        use std::io::Write as _;
+
+        assert!(load_iaca_roots(&["/nonexistent/path/root.pem".into()]).is_err());
+
+        let mut f1 = tempfile::NamedTempFile::new().unwrap();
+        f1.write_all(
+            b"-----BEGIN CERTIFICATE-----\nnot-valid-base64!!!\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        assert!(load_iaca_roots(&[f1.path().to_string_lossy().into_owned()]).is_err());
+
+        let mut f2 = tempfile::NamedTempFile::new().unwrap();
+        f2.write_all(b"-----BEGIN PRIVATE KEY-----\nMIIE\n-----END PRIVATE KEY-----\n")
+            .unwrap();
+        assert!(load_iaca_roots(&[f2.path().to_string_lossy().into_owned()]).is_err());
     }
 }


### PR DESCRIPTION
`verify_issuer_signature` validates the mdoc `issuerAuth` certificate chain against the roots exposed by an injected `IacaTrustStore`. `build_issuance_engine` injects this store via `with_iaca_trust_store`, but it currently defaults to a **fail-closed empty** `StaticTrustStore::new(vec![])` with a TODO. The plumbing is in place; nothing populates it.
with an empty store, every mdoc chain fails to anchor and is rejected. This is safe (fail-closed — no roots means nothing verifies, never the reverse) but it means mdoc issuance is non-functional for real credentials until roots are loaded. This issue adds the loader and config that populate the store at startup.

This is the baseline trust-root source. A richer source (VICAL, Annex C) is tracked separately and is a low-priority enhancement, not a substitute for this.

**Acceptance Criteria**

- [ ] `MdocConfig { iaca_root_paths }` added with empty-list default; overridable via `APP_MDOC__IACA_ROOT_PATHS`
- [ ] Loader parses both DER and PEM root files into `Vec<Vec<u8>>`
- [ ] `build_issuance_engine` populates `iaca_trust_store` from the loader
- [ ] Empty/unset config yields an empty (fail-closed) store, not an open one
- [ ] Startup `WARN` logged when mdoc is enabled but no roots loaded
- [ ] Malformed/unreadable root file is a hard startup error, not silently skipped
- [ ] Paths and DER are plain (not `SecretString`)   public certs