### PR TITLE
feat(oid4vp) Add key resolution module and VerifierAttestationKey implementation

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/mod.rs
@@ -1,0 +1,6 @@
+//! Key resolution implementations for VerifierKeyResolver trait.
+//!
+//! This module provides different resolver implementations for various
+//! client identifier prefix types as defined in OpenID4VP Section 5.9.
+
+pub mod verifier_attestation;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
@@ -1,0 +1,458 @@
+use jsonwebtoken::{DecodingKey, Header};
+
+use crate::errors::{Error, ErrorKind};
+use crate::oid4vp::client_id::ParsedClientId;
+use crate::oid4vp::request_object::VerifierKeyResolver;
+use crate::oid4vp::verifier_attestation::{TrustedAttestationIssuer, VerifierAttestationJwt};
+
+/// Key resolver for `verifier_attestation:` client identifier prefix.
+///
+/// Implements the `VerifierKeyResolver` trait to resolve the Verifier's public key
+/// from a Verifier Attestation JWT as defined in OpenID4VP §5.9.3 and §12.
+pub struct VerifierAttestationKey {
+    trusted_issuers: Vec<TrustedAttestationIssuer>,
+    expected_uri: String,
+}
+
+impl VerifierAttestationKey {
+    /// Creates a new `VerifierAttestationKey` resolver.
+    pub fn new(trusted_issuers: Vec<TrustedAttestationIssuer>, expected_uri: String) -> Self {
+        Self {
+            trusted_issuers,
+            expected_uri,
+        }
+    }
+
+    /// Extracts the attestation JWT from the JOSE header's `jwt` field.
+    ///
+    /// Per OpenID4VP §5.9.3, the Verifier Attestation JWT is passed in the
+    /// Request Object's JOSE header as a custom `jwt` parameter.
+    fn extract_jwt_from_header(header: &Header) -> crate::errors::Result<&str> {
+        let jwt_value = header
+            .extras
+            .get("jwt")
+            .map(|s| s.as_str())
+            .ok_or_else(|| {
+                Error::message(
+                    ErrorKind::InvalidPresentationRequest,
+                    "missing required 'jwt' header parameter for verifier_attestation client_id",
+                )
+            })?;
+
+        Ok(jwt_value)
+    }
+}
+
+#[async_trait::async_trait]
+impl VerifierKeyResolver for VerifierAttestationKey {
+    async fn resolve_key(
+        &self,
+        client_id: &ParsedClientId,
+        header: &Header,
+    ) -> crate::errors::Result<DecodingKey> {
+        // Verify this is a verifier_attestation client_id
+        if !client_id.is_verifier_attestation() {
+            return Err(Error::message(
+                ErrorKind::InvalidPresentationRequest,
+                format!(
+                    "VerifierAttestationKey can only resolve verifier_attestation client_ids, got: {}",
+                    client_id.raw()
+                ),
+            ));
+        }
+
+        // Extract the unprefixed client_id value (the sub claim expected value)
+        let verifier_id = client_id.value();
+
+        // Extract the attestation JWT from the header's `jwt` field
+        let attestation_jwt = Self::extract_jwt_from_header(header)?;
+
+        // Decode and validate the attestation JWT
+        let attestation = VerifierAttestationJwt::decode_and_validate(
+            attestation_jwt,
+            verifier_id,
+            &self.trusted_issuers,
+        )
+        .map_err(|e| {
+            Error::message(
+                ErrorKind::InvalidPresentationRequest,
+                format!("verifier attestation validation failed: {e}"),
+            )
+        })?;
+
+        // Validate redirect_uris allowlist against the expected URI
+        // Per OpenID4VP §12, the attestation contains an allowlist of redirect_uris
+        // that the verifier is authorized to use
+        attestation
+            .validate_redirect_uri(&self.expected_uri)
+            .map_err(|e| {
+                Error::message(
+                    ErrorKind::InvalidPresentationRequest,
+                    format!("verifier attestation redirect_uri validation failed: {e}"),
+                )
+            })?;
+
+        // Convert cnf.jwk to DecodingKey
+        let jwk = attestation.verifier_public_key();
+        let decoding_key = jwk_to_decoding_key(jwk).map_err(|e| {
+            Error::message(
+                ErrorKind::InvalidPresentationRequest,
+                format!("failed to convert attestation JWK to decoding key: {e}"),
+            )
+        })?;
+
+        Ok(decoding_key)
+    }
+}
+
+/// Converts a JWK to a jsonwebtoken DecodingKey.
+fn jwk_to_decoding_key(jwk: &cloud_wallet_crypto::jwk::Jwk) -> crate::errors::Result<DecodingKey> {
+    use jsonwebtoken::jwk::Jwk as JwtJwk;
+
+    // Convert our Jwk type to jsonwebtoken's Jwk type via JSON serialization
+    let jwt_jwk = serde_json::to_value(jwk)
+        .and_then(serde_json::from_value::<JwtJwk>)
+        .map_err(|e| {
+            Error::message(
+                ErrorKind::InvalidPresentationRequest,
+                format!("failed to convert JWK: {e}"),
+            )
+        })?;
+
+    DecodingKey::from_jwk(&jwt_jwk).map_err(|e| {
+        Error::message(
+            ErrorKind::InvalidPresentationRequest,
+            format!("failed to create decoding key from JWK: {e}"),
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cloud_wallet_crypto::jwk::{Jwk, KeyUse, Operations, Parameters};
+    use jsonwebtoken::{Algorithm, EncodingKey};
+
+    const TEST_ISSUER: &str = "https://attestation.example.com";
+    const TEST_VERIFIER_ID: &str = "verifier123";
+    const TEST_RESPONSE_URI: &str = "https://verifier.example.com/cb1";
+
+    /// Helper struct to manage test keys.
+    struct TestKeys {
+        issuer_key_pair: cloud_wallet_crypto::ecdsa::KeyPair,
+        verifier_key_pair: cloud_wallet_crypto::ecdsa::KeyPair,
+    }
+
+    impl TestKeys {
+        fn generate() -> Self {
+            Self {
+                issuer_key_pair: cloud_wallet_crypto::ecdsa::KeyPair::generate(
+                    cloud_wallet_crypto::ecdsa::Curve::P256,
+                )
+                .expect("failed to generate issuer key"),
+                verifier_key_pair: cloud_wallet_crypto::ecdsa::KeyPair::generate(
+                    cloud_wallet_crypto::ecdsa::Curve::P256,
+                )
+                .expect("failed to generate verifier key"),
+            }
+        }
+
+        fn issuer_jwk(&self) -> Jwk {
+            Jwk::try_from(&self.issuer_key_pair).expect("failed to convert issuer key to JWK")
+        }
+
+        fn verifier_jwk(&self) -> Jwk {
+            let mut jwk = Jwk::try_from(&self.verifier_key_pair)
+                .expect("failed to convert verifier key to JWK");
+            jwk.prm.key_use = Some(KeyUse::Signing);
+            jwk.prm.ops = Some([Operations::Verify, Operations::Sign].into_iter().collect());
+            jwk
+        }
+
+        fn issuer_encoding_key(&self) -> EncodingKey {
+            let secret = self.issuer_key_pair.to_pkcs8_der();
+            EncodingKey::from_ec_der(secret)
+        }
+    }
+
+    /// Helper to create a JWK with the required metadata for a verifier key.
+    fn create_verifier_jwk(keys: &TestKeys) -> Jwk {
+        let mut jwk = keys.verifier_jwk();
+        jwk.prm = Parameters {
+            key_use: Some(KeyUse::Signing),
+            ops: Some([Operations::Verify, Operations::Sign].into_iter().collect()),
+            ..Default::default()
+        };
+        jwk
+    }
+
+    /// Creates claims for a Verifier Attestation JWT.
+    fn create_attestation_claims(
+        keys: &TestKeys,
+        verifier_id: &str,
+        redirect_uris: Vec<String>,
+        exp_offset: i64,
+    ) -> crate::oid4vp::verifier_attestation::VerifierAttestationClaims {
+        use crate::oid4vp::verifier_attestation::{CnfClaim, VerifierAttestationClaims};
+
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: verifier_id.to_string(),
+            aud: None,
+            iat: Some(now),
+            exp: now + exp_offset,
+            nbf: None,
+            jti: Some("test-jti".to_string()),
+            cnf: CnfClaim {
+                jwk: create_verifier_jwk(keys),
+            },
+            redirect_uris: Some(redirect_uris),
+            nonce: None,
+        }
+    }
+
+    /// Creates a signed Verifier Attestation JWT.
+    fn create_attestation_jwt(
+        keys: &TestKeys,
+        claims: &crate::oid4vp::verifier_attestation::VerifierAttestationClaims,
+    ) -> String {
+        use crate::oid4vp::verifier_attestation::VerifierAttestationJwt;
+
+        let header = jsonwebtoken::Header {
+            typ: Some(VerifierAttestationJwt::EXPECTED_TYP.to_string()),
+            alg: Algorithm::ES256,
+            kid: None,
+            ..Default::default()
+        };
+
+        jsonwebtoken::encode(&header, claims, &keys.issuer_encoding_key())
+            .expect("failed to encode attestation JWT")
+    }
+
+    /// Creates a trusted issuer configuration.
+    fn create_trusted_issuer(keys: &TestKeys) -> TrustedAttestationIssuer {
+        TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(),
+            jwks: vec![keys.issuer_jwk()],
+        }
+    }
+
+    /// Creates a ParsedClientId for verifier_attestation prefix.
+    fn create_client_id(verifier_id: &str) -> ParsedClientId {
+        ParsedClientId::parse(format!("verifier_attestation:{verifier_id}"))
+            .expect("valid client_id")
+    }
+
+    /// Creates a Header with the jwt field containing the attestation.
+    fn create_header_with_jwt(attestation_jwt: &str) -> Header {
+        let mut header = Header::new(Algorithm::ES256);
+        header.typ = Some("oauth-authz-req+jwt".to_string());
+        header
+            .extras
+            .insert("jwt".to_string(), attestation_jwt.to_string());
+        header
+    }
+
+    #[tokio::test]
+    async fn valid_attestation_resolves_key() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        let claims = create_attestation_claims(
+            &keys,
+            TEST_VERIFIER_ID,
+            vec![TEST_RESPONSE_URI.to_string()],
+            3600,
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(
+            result.is_ok(),
+            "Expected successful key resolution, got: {:?}",
+            result.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn untrusted_issuer_rejected() {
+        let keys = TestKeys::generate();
+        let other_keys = TestKeys::generate();
+
+        // Use a different issuer key that is not trusted
+        let trusted_issuers = vec![TrustedAttestationIssuer {
+            issuer_id: TEST_ISSUER.to_string(),
+            jwks: vec![other_keys.issuer_jwk()], // Different key
+        }];
+
+        let claims = create_attestation_claims(
+            &keys,
+            TEST_VERIFIER_ID,
+            vec![TEST_RESPONSE_URI.to_string()],
+            3600,
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("untrusted issuer") || err.contains("signature verification failed"),
+            "Expected untrusted issuer error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn expired_attestation_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        // Create expired claims
+        let claims = create_attestation_claims(
+            &keys,
+            TEST_VERIFIER_ID,
+            vec![TEST_RESPONSE_URI.to_string()],
+            -3600, // Expired 1 hour ago
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("expired") || err.contains("attestation"),
+            "Expected expired attestation error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn sub_mismatch_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        // Create claims with wrong sub
+        let claims = create_attestation_claims(
+            &keys,
+            "different-verifier", // Wrong sub
+            vec![TEST_RESPONSE_URI.to_string()],
+            3600,
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        // Still using original verifier_id as client_id
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("sub") || err.contains("subject") || err.contains("mismatch"),
+            "Expected subject mismatch error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn redirect_uris_violation_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        // Create claims with different redirect_uris
+        let claims = create_attestation_claims(
+            &keys,
+            TEST_VERIFIER_ID,
+            vec!["https://other.example.com/cb".to_string()], // Different URI
+            3600,
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        // Expected URI doesn't match the allowlist
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("redirect_uri")
+                || err.contains("response_uri")
+                || err.contains("not allowed"),
+            "Expected redirect_uri not allowed error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_jwt_header_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+
+        // Header without jwt field
+        let header = Header::new(Algorithm::ES256);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("jwt") && err.contains("missing"),
+            "Expected missing jwt header error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_prefix_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        let claims = create_attestation_claims(
+            &keys,
+            TEST_VERIFIER_ID,
+            vec![TEST_RESPONSE_URI.to_string()],
+            3600,
+        );
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        // Use redirect_uri prefix instead of verifier_attestation
+        let client_id = ParsedClientId::parse("redirect_uri:https://verifier.example.com").unwrap();
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("verifier_attestation"),
+            "Expected verifier_attestation prefix error, got: {}",
+            err
+        );
+    }
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
@@ -11,6 +11,11 @@ use crate::oid4vp::verifier_attestation::{TrustedAttestationIssuer, VerifierAtte
 /// from a Verifier Attestation JWT as defined in OpenID4VP §5.9.3 and §12.
 pub struct VerifierAttestationKey {
     trusted_issuers: Vec<TrustedAttestationIssuer>,
+
+    /// The URI to validate against the attestation's `redirect_uris` allowlist.
+    /// Each resolver instance is bound to a single request's response_uri/redirect_uri.
+    /// If the trait ever gains a request-context parameter, this field should move
+    /// to the method signature instead.
     expected_uri: String,
 }
 
@@ -73,58 +78,29 @@ impl VerifierKeyResolver for VerifierAttestationKey {
             verifier_id,
             &self.trusted_issuers,
         )
-        .map_err(|e| {
-            Error::message(
-                ErrorKind::InvalidPresentationRequest,
-                format!("verifier attestation validation failed: {e}"),
-            )
-        })?;
+        .map_err(|e| Error::new(ErrorKind::InvalidPresentationRequest, e))?;
 
         // Validate redirect_uris allowlist against the expected URI
         // Per OpenID4VP §12, the attestation contains an allowlist of redirect_uris
-        // that the verifier is authorized to use
+        // that the verifier is authorized to use. A missing allowlist means no URIs
+        // are allowed, not that all URIs are allowed.
+        if attestation.allowed_redirect_uris().is_none() {
+            return Err(Error::message(
+                ErrorKind::InvalidPresentationRequest,
+                "verifier attestation must include redirect_uris to authorize a response_uri",
+            ));
+        }
         attestation
             .validate_redirect_uri(&self.expected_uri)
-            .map_err(|e| {
-                Error::message(
-                    ErrorKind::InvalidPresentationRequest,
-                    format!("verifier attestation redirect_uri validation failed: {e}"),
-                )
-            })?;
+            .map_err(|e| Error::new(ErrorKind::InvalidPresentationRequest, e))?;
 
         // Convert cnf.jwk to DecodingKey
         let jwk = attestation.verifier_public_key();
-        let decoding_key = jwk_to_decoding_key(jwk).map_err(|e| {
-            Error::message(
-                ErrorKind::InvalidPresentationRequest,
-                format!("failed to convert attestation JWK to decoding key: {e}"),
-            )
-        })?;
+        let decoding_key = crate::oid4vp::jwk_to_decoding_key(jwk)
+            .map_err(|e| Error::message(ErrorKind::InvalidPresentationRequest, e))?;
 
         Ok(decoding_key)
     }
-}
-
-/// Converts a JWK to a jsonwebtoken DecodingKey.
-fn jwk_to_decoding_key(jwk: &cloud_wallet_crypto::jwk::Jwk) -> crate::errors::Result<DecodingKey> {
-    use jsonwebtoken::jwk::Jwk as JwtJwk;
-
-    // Convert our Jwk type to jsonwebtoken's Jwk type via JSON serialization
-    let jwt_jwk = serde_json::to_value(jwk)
-        .and_then(serde_json::from_value::<JwtJwk>)
-        .map_err(|e| {
-            Error::message(
-                ErrorKind::InvalidPresentationRequest,
-                format!("failed to convert JWK: {e}"),
-            )
-        })?;
-
-    DecodingKey::from_jwk(&jwt_jwk).map_err(|e| {
-        Error::message(
-            ErrorKind::InvalidPresentationRequest,
-            format!("failed to create decoding key from JWK: {e}"),
-        )
-    })
 }
 
 #[cfg(test)]
@@ -208,6 +184,31 @@ mod tests {
                 jwk: create_verifier_jwk(keys),
             },
             redirect_uris: Some(redirect_uris),
+            nonce: None,
+        }
+    }
+
+    /// Creates claims for a Verifier Attestation JWT without redirect_uris.
+    fn create_attestation_claims_no_redirect_uris(
+        keys: &TestKeys,
+        verifier_id: &str,
+        exp_offset: i64,
+    ) -> crate::oid4vp::verifier_attestation::VerifierAttestationClaims {
+        use crate::oid4vp::verifier_attestation::{CnfClaim, VerifierAttestationClaims};
+
+        let now = jsonwebtoken::get_current_timestamp() as i64;
+        VerifierAttestationClaims {
+            iss: TEST_ISSUER.to_string(),
+            sub: verifier_id.to_string(),
+            aud: None,
+            iat: Some(now),
+            exp: now + exp_offset,
+            nbf: None,
+            jti: Some("test-jti".to_string()),
+            cnf: CnfClaim {
+                jwk: create_verifier_jwk(keys),
+            },
+            redirect_uris: None,
             nonce: None,
         }
     }
@@ -401,6 +402,29 @@ mod tests {
                 || err.contains("response_uri")
                 || err.contains("not allowed"),
             "Expected redirect_uri not allowed error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_redirect_uris_rejected() {
+        let keys = TestKeys::generate();
+        let trusted_issuers = vec![create_trusted_issuer(&keys)];
+
+        let claims = create_attestation_claims_no_redirect_uris(&keys, TEST_VERIFIER_ID, 3600);
+        let attestation_jwt = create_attestation_jwt(&keys, &claims);
+
+        let resolver = VerifierAttestationKey::new(trusted_issuers, TEST_RESPONSE_URI.to_string());
+        let client_id = create_client_id(TEST_VERIFIER_ID);
+        let header = create_header_with_jwt(&attestation_jwt);
+
+        let result = resolver.resolve_key(&client_id, &header).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("redirect_uris") || err.contains("response_uri"),
+            "Expected missing redirect_uris error, got: {}",
             err
         );
     }

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs
@@ -13,9 +13,9 @@ pub struct VerifierAttestationKey {
     trusted_issuers: Vec<TrustedAttestationIssuer>,
 
     /// The URI to validate against the attestation's `redirect_uris` allowlist.
-    /// Each resolver instance is bound to a single request's response_uri/redirect_uri.
-    /// If the trait ever gains a request-context parameter, this field should move
-    /// to the method signature instead.
+    /// This can be either the request's `redirect_uri` or `response_uri` parameter
+    /// (mutually exclusive per OpenID4VP). Per §5.9.3, if the attestation contains
+    /// `redirect_uris`, the Wallet MUST ensure the URI exactly matches an entry.
     expected_uri: String,
 }
 
@@ -81,15 +81,9 @@ impl VerifierKeyResolver for VerifierAttestationKey {
         .map_err(|e| Error::new(ErrorKind::InvalidPresentationRequest, e))?;
 
         // Validate redirect_uris allowlist against the expected URI
-        // Per OpenID4VP §12, the attestation contains an allowlist of redirect_uris
-        // that the verifier is authorized to use. A missing allowlist means no URIs
-        // are allowed, not that all URIs are allowed.
-        if attestation.allowed_redirect_uris().is_none() {
-            return Err(Error::message(
-                ErrorKind::InvalidPresentationRequest,
-                "verifier attestation must include redirect_uris to authorize a response_uri",
-            ));
-        }
+        // Per OpenID4VP §5.9.3, the `redirect_uris` claim is OPTIONAL. If present,
+        // the Wallet MUST ensure the request's redirect_uri/response_uri exactly
+        // matches an entry in the allowlist. If absent, no validation is required.
         attestation
             .validate_redirect_uri(&self.expected_uri)
             .map_err(|e| Error::new(ErrorKind::InvalidPresentationRequest, e))?;
@@ -407,7 +401,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn missing_redirect_uris_rejected() {
+    async fn missing_redirect_uris_accepted() {
+        // Per OpenID4VP §5.9.3, redirect_uris is OPTIONAL. If absent, no validation is required.
         let keys = TestKeys::generate();
         let trusted_issuers = vec![create_trusted_issuer(&keys)];
 
@@ -420,12 +415,10 @@ mod tests {
 
         let result = resolver.resolve_key(&client_id, &header).await;
 
-        assert!(result.is_err());
-        let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("redirect_uris") || err.contains("response_uri"),
-            "Expected missing redirect_uris error, got: {}",
-            err
+            result.is_ok(),
+            "Expected success when redirect_uris is absent (optional per spec), got: {:?}",
+            result.err()
         );
     }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -7,6 +7,7 @@ pub mod authorization;
 pub mod client_id;
 pub mod dcql;
 pub mod error;
+pub mod key_resolution;
 pub mod metadata;
 pub mod presentation;
 pub mod request_object;

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/mod.rs
@@ -17,3 +17,20 @@ pub mod transaction_data;
 pub mod verifier_attestation;
 
 pub use error::*;
+
+/// Converts a `cloud_wallet_crypto::jwk::Jwk` to a `jsonwebtoken::DecodingKey`.
+///
+/// This is shared between `verifier_attestation` and `key_resolution` to avoid
+/// duplicating the serde conversion logic.
+pub(crate) fn jwk_to_decoding_key(
+    jwk: &cloud_wallet_crypto::jwk::Jwk,
+) -> Result<jsonwebtoken::DecodingKey, String> {
+    use jsonwebtoken::jwk::Jwk as JwtJwk;
+
+    let jwt_jwk = serde_json::to_value(jwk)
+        .and_then(serde_json::from_value::<JwtJwk>)
+        .map_err(|e| format!("failed to convert JWK: {e}"))?;
+
+    jsonwebtoken::DecodingKey::from_jwk(&jwt_jwk)
+        .map_err(|e| format!("failed to create decoding key from JWK: {e}"))
+}

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/verifier_attestation.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use cloud_wallet_crypto::jwk::{Jwk, Key, KeyUse, Operations};
-use jsonwebtoken::{DecodingKey, Validation, decode, jwk::Jwk as JwtJwk};
+use jsonwebtoken::{DecodingKey, Validation, decode};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 
@@ -196,20 +196,8 @@ impl VerifierAttestationJwt {
 
     /// Converts a JWK to a jsonwebtoken DecodingKey.
     fn jwk_to_decoding_key(jwk: &Jwk) -> Result<DecodingKey, VerifierAttestationError> {
-        // Convert our Jwk type to jsonwebtoken's Jwk type
-        let jwt_jwk = serde_json::to_value(jwk)
-            .and_then(serde_json::from_value::<JwtJwk>)
-            .map_err(|e| {
-                VerifierAttestationError::SignatureVerificationFailed(format!(
-                    "failed to convert JWK: {e}"
-                ))
-            })?;
-
-        DecodingKey::from_jwk(&jwt_jwk).map_err(|e| {
-            VerifierAttestationError::SignatureVerificationFailed(format!(
-                "failed to create decoding key from JWK: {e}"
-            ))
-        })
+        super::jwk_to_decoding_key(jwk)
+            .map_err(VerifierAttestationError::SignatureVerificationFailed)
     }
 
     /// Validates that the `sub` claim matches the expected client_id.


### PR DESCRIPTION
Implement the `VerifierKeyResolver` trait for the `verifier_attestation:` client identifier prefix.

The existing `VerifierAttestationJwt` handles decoding and validation but is not wired into the key resolution pipeline.

The resolver must:

1. Extract the `jwt` from the JOSE header's `jwt` field (the Verifier Attestation JWT is passed in the Request Object header as per OpenID4VP §5.9.3).
2. Decode and validate it using `VerifierAttestationJwt::decode_and_validate` against configured `TrustedAttestationIssuer`s.
3. Validate `redirect_uris` allowlist from the attestation against the request's `response_uri`/`redirect_uri`.
4. Return the `cnf.jwk` public key from the attestation as the `DecodingKey` for Request Object signature verification.

### File Placement

`crates/cloud-wallet-openid4vc/src/oid4vp/key_resolution/verifier_attestation.rs`

### Acceptance Criteria

- [x] `VerifierAttestationKey` implementing `VerifierKeyResolver`.
- [x] Constructor accepts `Vec<TrustedAttestationIssuer>`.
- [x] Extracts the attestation JWT from the `jwt` JOSE header parameter.
- [x] Delegates to existing `VerifierAttestationJwt::decode_and_validate`.
- [x] Converts `cnf.jwk` to `DecodingKey`.
- [x] Unit tests for: valid attestation, untrusted issuer, expired attestation, `sub` mismatch, `redirect_uris` violation, missing `jwt` header.

### Spec References

- [OpenID4VP §5.9.3 — verifier_attestation](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.9.3)
- [OpenID4VP §12 — Verifier Attestation](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-12)