### PR TITLE
fix(oid4vci): use DPoP Authorization scheme for DPoP-bound tokens

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -732,7 +732,10 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(endpoint.as_str())
-            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
+            .header(
+                AUTHORIZATION_HEADER_NAME,
+                auth_header(token_type, access_token),
+            )
             .json(&request);
 
         if let Some(opts) = dpop {
@@ -765,7 +768,10 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(endpoint.as_str())
-                    .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
+                    .header(
+                        AUTHORIZATION_HEADER_NAME,
+                        auth_header(token_type, access_token),
+                    )
                     .json(&request)
                     .header(DPOP_HEADER_NAME, retry_proof)
                     .send()
@@ -847,7 +853,10 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(notification_endpoint.as_str())
-            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
+            .header(
+                AUTHORIZATION_HEADER_NAME,
+                auth_header(token_type, access_token),
+            )
             .json(&req);
 
         if let Some(opts) = dpop {
@@ -1122,7 +1131,10 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(credential_endpoint.as_str())
-            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
+            .header(
+                AUTHORIZATION_HEADER_NAME,
+                auth_header(token_type, access_token),
+            )
             .json(request);
 
         if let Some(opts) = dpop {
@@ -1155,7 +1167,10 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(credential_endpoint.as_str())
-                    .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
+                    .header(
+                        AUTHORIZATION_HEADER_NAME,
+                        auth_header(token_type, access_token),
+                    )
                     .json(request)
                     .header(DPOP_HEADER_NAME, retry_proof)
                     .send()

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -52,6 +52,10 @@ type Result<T> = std::result::Result<T, ClientError>;
 const OAUTH_RESPONSE_TYPE: &str = "code";
 const FORM_ENCODED_HEADER: &str = "application/x-www-form-urlencoded";
 const JSON_HEADER: &str = "application/json";
+const AUTHORIZATION_HEADER_NAME: &str = "Authorization";
+const DPOP_HEADER_NAME: &str = "DPoP";
+const AUTH_SCHEME_BEARER: &str = "Bearer";
+const AUTH_SCHEME_DPOP: &str = "DPoP";
 
 /// Fully resolved context from a single credential offer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -728,12 +732,12 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(endpoint.as_str())
-            .header("Authorization", auth_header(token_type, access_token))
+            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
             .json(&request);
 
         if let Some(opts) = dpop {
             let proof = build_dpop_proof(opts.key, "POST", &htu, nonce.as_deref(), ath.as_deref())?;
-            http_request = http_request.header("DPoP", proof);
+            http_request = http_request.header(DPOP_HEADER_NAME, proof);
         }
 
         let response = http_request
@@ -761,9 +765,9 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(endpoint.as_str())
-                    .header("Authorization", auth_header(token_type, access_token))
+                    .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
                     .json(&request)
-                    .header("DPoP", retry_proof)
+                    .header(DPOP_HEADER_NAME, retry_proof)
                     .send()
                     .await
                     .map_err(|e| ClientError::http("Deferred credential DPoP retry failed", e))?;
@@ -843,12 +847,12 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(notification_endpoint.as_str())
-            .header("Authorization", auth_header(token_type, access_token))
+            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
             .json(&req);
 
         if let Some(opts) = dpop {
             let proof = build_dpop_proof(opts.key, "POST", &htu, nonce.as_deref(), ath.as_deref())?;
-            http_request = http_request.header("DPoP", proof);
+            http_request = http_request.header(DPOP_HEADER_NAME, proof);
         }
 
         let response = http_request
@@ -1053,7 +1057,7 @@ impl Oid4vciClient {
             .body(body);
 
         if let Some(proof) = dpop_proof {
-            http_request = http_request.header("DPoP", proof);
+            http_request = http_request.header(DPOP_HEADER_NAME, proof);
         }
 
         http_request
@@ -1118,12 +1122,12 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(credential_endpoint.as_str())
-            .header("Authorization", auth_header(token_type, access_token))
+            .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
             .json(request);
 
         if let Some(opts) = dpop {
             let proof = build_dpop_proof(opts.key, "POST", &htu, nonce.as_deref(), ath.as_deref())?;
-            http_request = http_request.header("DPoP", proof);
+            http_request = http_request.header(DPOP_HEADER_NAME, proof);
         }
 
         let response = http_request
@@ -1151,9 +1155,9 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(credential_endpoint.as_str())
-                    .header("Authorization", auth_header(token_type, access_token))
+                    .header(AUTHORIZATION_HEADER_NAME, auth_header(token_type, access_token))
                     .json(request)
-                    .header("DPoP", retry_proof)
+                    .header(DPOP_HEADER_NAME, retry_proof)
                     .send()
                     .await
                     .map_err(|e| ClientError::http("credential request retry failed", e))?;
@@ -1222,10 +1226,10 @@ impl Oid4vciClient {
 ///
 /// Per RFC 9449 §7.1, DPoP-bound tokens use the `DPoP` scheme instead of `Bearer`.
 fn auth_header(token_type: &str, access_token: &str) -> String {
-    if token_type.eq_ignore_ascii_case("DPoP") {
-        format!("DPoP {access_token}")
+    if token_type.eq_ignore_ascii_case(AUTH_SCHEME_DPOP) {
+        format!("{AUTH_SCHEME_DPOP} {access_token}")
     } else {
-        format!("Bearer {access_token}")
+        format!("{AUTH_SCHEME_BEARER} {access_token}")
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -629,7 +629,7 @@ impl Oid4vciClient {
     pub async fn request_credential<S: ProofSigner>(
         &self,
         context: &ResolvedOfferContext,
-        access_token: &str,
+        token: &TokenResponse,
         credential_identifier: impl Into<String>,
         credential_config_id: &str,
         signer: &S,
@@ -655,7 +655,7 @@ impl Oid4vciClient {
             request = request.with_proofs(p);
         }
 
-        self.post_credential_request(context, access_token, &request, dpop)
+        self.post_credential_request(context, token, &request, dpop)
             .await
     }
 
@@ -676,7 +676,6 @@ impl Oid4vciClient {
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<Vec<CredentialResponse>> {
         let resolved = resolve_credential_ids(token)?;
-        let token = &token.access_token;
         let total: usize = resolved.iter().map(|(_, ids)| ids.len()).sum();
         let mut results = Vec::with_capacity(total);
         let mut futures = FuturesUnordered::new();
@@ -704,6 +703,7 @@ impl Oid4vciClient {
         &self,
         context: &ResolvedOfferContext,
         access_token: &str,
+        token_type: &str,
         transaction_id: impl Into<String>,
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<DeferredCredentialResult> {
@@ -728,7 +728,7 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(endpoint.as_str())
-            .bearer_auth(access_token)
+            .header("Authorization", auth_header(token_type, access_token))
             .json(&request);
 
         if let Some(opts) = dpop {
@@ -761,7 +761,7 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(endpoint.as_str())
-                    .bearer_auth(access_token)
+                    .header("Authorization", auth_header(token_type, access_token))
                     .json(&request)
                     .header("DPoP", retry_proof)
                     .send()
@@ -831,6 +831,7 @@ impl Oid4vciClient {
         &self,
         notification_endpoint: &Url,
         access_token: &str,
+        token_type: &str,
         req: &NotificationRequest,
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<()> {
@@ -842,7 +843,7 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(notification_endpoint.as_str())
-            .bearer_auth(access_token)
+            .header("Authorization", auth_header(token_type, access_token))
             .json(&req);
 
         if let Some(opts) = dpop {
@@ -1102,10 +1103,12 @@ impl Oid4vciClient {
     async fn post_credential_request(
         &self,
         context: &ResolvedOfferContext,
-        access_token: &str,
+        token: &TokenResponse,
         request: &CredentialRequest,
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<CredentialResponse> {
+        let access_token = &token.access_token;
+        let token_type = &token.token_type;
         let credential_endpoint = &context.issuer_metadata.credential_endpoint;
         let htu = htu_from_url(credential_endpoint)?;
         let ath = dpop.map(|_| compute_ath(access_token));
@@ -1115,7 +1118,7 @@ impl Oid4vciClient {
             .inner_client
             .http_client()
             .post(credential_endpoint.as_str())
-            .bearer_auth(access_token)
+            .header("Authorization", auth_header(token_type, access_token))
             .json(request);
 
         if let Some(opts) = dpop {
@@ -1148,7 +1151,7 @@ impl Oid4vciClient {
                     .inner_client
                     .http_client()
                     .post(credential_endpoint.as_str())
-                    .bearer_auth(access_token)
+                    .header("Authorization", auth_header(token_type, access_token))
                     .json(request)
                     .header("DPoP", retry_proof)
                     .send()
@@ -1212,6 +1215,17 @@ impl Oid4vciClient {
             return Ok(Some(self.fetch_nonce(endpoint).await?));
         }
         Ok(None)
+    }
+}
+
+/// Build the Authorization header value based on the token type.
+///
+/// Per RFC 9449 §7.1, DPoP-bound tokens use the `DPoP` scheme instead of `Bearer`.
+fn auth_header(token_type: &str, access_token: &str) -> String {
+    if token_type.eq_ignore_ascii_case("DPoP") {
+        format!("DPoP {access_token}")
+    } else {
+        format!("Bearer {access_token}")
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
@@ -1132,6 +1132,7 @@ async fn test_dpop_deferred_credential_request() {
         .poll_deferred_credential(
             &context,
             "deferred_access_token",
+            "DPoP",
             "txn_ready",
             Some(&DpopOptions {
                 key: &dpop_key,

--- a/src/domain/models/issuance/mod.rs
+++ b/src/domain/models/issuance/mod.rs
@@ -468,6 +468,7 @@ impl IssuanceEngine {
         self.send_notifications(
             context,
             &token_response.access_token,
+            &token_response.token_type,
             notification_ids,
             Some(&dpop_opts),
         )
@@ -538,7 +539,6 @@ impl IssuanceEngine {
                     self.emit_processing(session_id, ProcessingStep::AwaitingDeferredCredential)
                         .await;
 
-                    let token = &token.access_token;
                     let tx_id = pending.transaction_id.clone();
                     let interval = pending.interval_seconds();
                     let immediate = self
@@ -604,16 +604,18 @@ impl IssuanceEngine {
     }
 
     /// Poll the deferred credential endpoint.
-    #[instrument(skip(self, context, access_token))]
+    #[instrument(skip(self, context, token))]
     async fn poll_deferred(
         &self,
         context: &ResolvedOfferContext,
-        access_token: &str,
+        token: &TokenResponse,
         initial_tx_id: String,
         initial_interval: u64,
         session_id: &str,
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<ImmediateCredentialResponse> {
+        let access_token = &token.access_token;
+        let token_type = &token.token_type;
         let mut tx_id = initial_tx_id;
         let mut interval_secs = initial_interval;
 
@@ -630,7 +632,7 @@ impl IssuanceEngine {
 
             let result = self
                 .client
-                .poll_deferred_credential(context, access_token, &tx_id, dpop)
+                .poll_deferred_credential(context, access_token, token_type, &tx_id, dpop)
                 .await?;
 
             match result {
@@ -813,6 +815,7 @@ impl IssuanceEngine {
         &self,
         context: &ResolvedOfferContext,
         access_token: &str,
+        token_type: &str,
         notification_ids: Vec<String>,
         dpop: Option<&DpopOptions<'_>>,
     ) {
@@ -823,7 +826,7 @@ impl IssuanceEngine {
             let req = NotificationRequest::new(id, NotificationEvent::CredentialAccepted);
             if let Err(e) = self
                 .client
-                .send_notification(endpoint, access_token, &req, dpop)
+                .send_notification(endpoint, access_token, token_type, &req, dpop)
                 .await
             {
                 warn!(error = %e, "notification to issuer failed");


### PR DESCRIPTION
When DPoP is used during the OID4VCI issuance flow, the wallet was unconditionally sending `Authorization: Bearer <token>` for all subsequent requests (credential endpoint, deferred credential endpoint, and notification endpoint). Per [RFC 9449 §7.1](https://www.rfc-editor.org/rfc/rfc9449.html#section-7.1), DPoP-bound access tokens **must** use the `DPoP` scheme: `Authorization: DPoP <token>`. Strict authorization servers (e.g., Keycloak with DPoP enabled) reject requests that present a DPoP token with the `Bearer` scheme, returning `invalid_token` / `Invalid or missing token`.

## Root cause

`reqwest`'s `bearer_auth()` always produces `Authorization: Bearer …`. The `token_type` field from the token response (`"DPoP"` or `"Bearer"`) was never inspected when constructing the `Authorization` header for credential or deferred-credential requests.

## What changed

1. **Added `auth_header` helper** (`crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs`)
   Returns `DPoP <token>` when `token_type.eq_ignore_ascii_case("DPoP")`, otherwise `Bearer <token>`.

2. **Updated OID4VCI client methods** to use the helper instead of `bearer_auth()`:
   - `post_credential_request`
   - `poll_deferred_credential`
   - `send_notification`

3. **Updated issuance engine callers** (`src/domain/models/issuance/mod.rs`) to thread `token_type` through to the methods above.

4. **Refactored to avoid clippy warnings**: bundled `access_token` and `token_type` into `TokenResponse` parameters where appropriate instead of passing them as separate arguments.

5. **Updated test** (`crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs`) to supply the `"DPoP"` token type for the deferred-credential DPoP test.

## Verification

- `cargo test -p cloud-wallet-openid4vc` — all 663 tests pass.
- `cargo clippy --all-targets --all-features -- -D warnings` — compiles cleanly.

## Steps to reproduce (before the fix)

1. Configure a Keycloak instance with DPoP support enabled.
2. Start an issuance flow (authorization-code or pre-authorized code).
3. Token exchange succeeds.
4. The credential request POSTs to the credential endpoint with `Authorization: Bearer <dpop_token>`.
5. Keycloak responds with `400` and body `{"error":"invalid_token","error_description":"Invalid or missing token"}`.
6. The issuance worker emits `IssuanceError { step: Internal, error: InternalError, ... }` and terminates the session.

## After the fix

The credential (and deferred / notification) requests now correctly send `Authorization: DPoP <token>`, allowing Keycloak to validate the DPoP-bound access token and proceed with credential issuance.
