### PR TITLE
Iso restricts dsc public keys

### DIFF
--- a/crates/cloud-wallet-crypto/src/ecdsa.rs
+++ b/crates/cloud-wallet-crypto/src/ecdsa.rs
@@ -112,11 +112,18 @@ use crate::utils::{key_gen_error, parse_error, serialize_error};
 // Algorithm OIDs
 const OID_EC_PUBLIC_KEY: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.2.1");
 
-// EC curve OIDs
-const OID_SECP256R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.2.840.10045.3.1.7");
-const OID_SECP384R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.132.0.34");
-const OID_SECP521R1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.132.0.35");
-const OID_SECP256K1: ObjectIdentifier = ObjectIdentifier::new_unwrap("1.3.132.0.10");
+// EC curve OIDs (dotted-decimal strings, RFC 5480 §2.1.1 named curves). Defined as
+// `&str` first and reused for both the typed `ObjectIdentifier` consts below and
+// `Curve::oid`/`Curve::from_oid`, so this crate has exactly one literal per curve OID.
+const OID_STR_SECP256R1: &str = "1.2.840.10045.3.1.7";
+const OID_STR_SECP384R1: &str = "1.3.132.0.34";
+const OID_STR_SECP521R1: &str = "1.3.132.0.35";
+const OID_STR_SECP256K1: &str = "1.3.132.0.10";
+
+const OID_SECP256R1: ObjectIdentifier = ObjectIdentifier::new_unwrap(OID_STR_SECP256R1);
+const OID_SECP384R1: ObjectIdentifier = ObjectIdentifier::new_unwrap(OID_STR_SECP384R1);
+const OID_SECP521R1: ObjectIdentifier = ObjectIdentifier::new_unwrap(OID_STR_SECP521R1);
+const OID_SECP256K1: ObjectIdentifier = ObjectIdentifier::new_unwrap(OID_STR_SECP256K1);
 
 #[derive(Debug, Clone)]
 struct KeyMaterial {
@@ -206,6 +213,36 @@ impl Curve {
     /// Get the signature size of the signature produced by this curve
     pub fn signature_size(self) -> usize {
         2 * self.key_size()
+    }
+
+    /// Returns the dotted-decimal OID string naming this curve, as found in a
+    /// `SubjectPublicKeyInfo` algorithm-parameters field (RFC 5480 §2.1.1).
+    ///
+    /// This is the single source of truth for curve OIDs in this crate. Other code
+    /// that needs to recognize or allow-list a specific curve by OID (e.g. enforcing
+    /// ISO 18013-5 Table 22's permitted-curve set) should use this or [`Curve::from_oid`]
+    /// rather than hardcoding the OID string itself.
+    pub fn oid(self) -> &'static str {
+        match self {
+            Curve::P256 => OID_STR_SECP256R1,
+            Curve::P384 => OID_STR_SECP384R1,
+            Curve::P521 => OID_STR_SECP521R1,
+            Curve::P256K1 => OID_STR_SECP256K1,
+        }
+    }
+
+    /// Looks up the [`Curve`] matching a dotted-decimal OID string, as found in a
+    /// `SubjectPublicKeyInfo` algorithm-parameters field.
+    ///
+    /// Returns `None` for any OID this crate does not recognize as an EC curve.
+    pub fn from_oid(oid: &str) -> Option<Self> {
+        match oid {
+            OID_STR_SECP256R1 => Some(Curve::P256),
+            OID_STR_SECP384R1 => Some(Curve::P384),
+            OID_STR_SECP521R1 => Some(Curve::P521),
+            OID_STR_SECP256K1 => Some(Curve::P256K1),
+            _ => None,
+        }
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
@@ -185,11 +185,16 @@ pub(super) fn check_dsc_key_usage(dsc: &X509Certificate<'_>) -> Result<()> {
 ///
 /// Only applies to EC keys (SPKI algorithm OID `id-ecPublicKey`); any other SPKI
 /// algorithm OID passes through unchecked, since "curve" only has meaning for EC keys.
-/// This notably includes Ed25519 and Ed448 — neither carries a `parameters` field to
-/// check here, and neither needs one: Ed25519 is itself a Table 22 permitted algorithm,
-/// and Ed448 rejection is handled separately by the OID guard in `verify_issuer_signature`.
-/// A non-EC, non-EdDSA SPKI (e.g. RSA) is left for `dispatch_verify` to reject when it
-/// fails to construct a verifying key from it.
+/// ISO 18013-5 Table 22 itself only enumerates permitted *curves* (the NIST triad here,
+/// plus Brainpool — see note below), not algorithms in general, so there is nothing in
+/// Table 22 for a non-EC key to be checked against in the first place.
+///
+/// This notably includes Ed25519 and Ed448, both OKP keys: their SPKI algorithm OID is
+/// never `id-ecPublicKey`, so neither carries a `parameters` field to check here, and
+/// the curve restriction simply does not apply to them. Ed25519 is supported by this
+/// implementation; Ed448 rejection is handled separately by the OID guard in
+/// `verify_issuer_signature`. A non-EC, non-OKP SPKI (e.g. RSA) is left for
+/// `dispatch_verify` to reject when it fails to construct a verifying key from it.
 ///
 /// Closes the gap where a non-permitted EC curve (e.g. secp256k1) that the underlying
 /// ECDSA verification table happens to define for an unrelated hash combination would
@@ -206,10 +211,23 @@ pub(super) fn check_dsc_key_usage(dsc: &X509Certificate<'_>) -> Result<()> {
 /// here, since the ISO 18013-5 policy decision ("which curves may a DSC use") belongs
 /// to this module, not to the crypto crate.
 ///
+/// **Note on Brainpool:** `Curve::from_oid` does not recognize Brainpool curve OIDs
+/// (the crypto crate has no `Curve` variant for them yet), so a DSC carrying a
+/// Brainpool key is rejected *here*, with [`MdocError::UnsupportedDscCurve`] — not
+/// later in `dispatch_verify`, which would otherwise reject it with
+/// `MdocError::UnsupportedAlgorithm` once it inspected the alg header. This is a
+/// behavioral side effect of this function's existence: Brainpool rejection now
+/// happens earlier and under a different error variant than before, regardless of
+/// what algorithm the credential's protected header claims. Any caller matching on
+/// `UnsupportedAlgorithm` specifically for Brainpool DSCs needs to also handle
+/// `UnsupportedDscCurve`. Add a `Curve` variant (and update this allow-list) once
+/// Brainpool *verification* lands in `dispatch_verify` — see that function's TODO.
+///
 /// # Errors
 ///
 /// - [`MdocError::UnsupportedDscCurve`] — the SPKI is an EC key whose curve is not
-///   P-256, P-384, or P-521, or the curve OID is missing/malformed.
+///   P-256, P-384, or P-521, or the curve OID is missing/malformed. This includes
+///   Brainpool-keyed DSCs (see note above).
 pub(super) fn check_dsc_curve(dsc: &X509Certificate<'_>) -> Result<()> {
     use cloud_wallet_crypto::ecdsa::Curve;
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
@@ -5,6 +5,10 @@
 //!   (RFC 5280, ISO 18013-5 §9.1.2).
 //! - Check that a Document Signer Certificate (DSC) carries the mandatory Extended Key
 //!   Usage OID `1.0.18013.5.1.2` (ISO 18013-5 §9.1.2).
+//! - Check that a DSC carries the mandatory `digitalSignature` Key Usage bit, marked
+//!   critical (ISO 18013-5 Annex B Table B.3).
+//! - Check that a DSC's EC public key uses a curve on the ISO 18013-5 Table 22
+//!   permitted list (NIST P-256, P-384, P-521).
 //! - Extract the raw SubjectPublicKeyInfo (SPKI) bytes from a parsed certificate
 //!   so they can be passed to `cloud_wallet_crypto` verifying-key constructors.
 //!
@@ -16,12 +20,23 @@
 //! ASN.1 parsing for every validation step.
 
 use time::OffsetDateTime;
+use x509_parser::der_parser::Oid;
 use x509_parser::prelude::{FromDer as _, ParsedExtension, X509Certificate};
 
 use super::error::{MdocError, Result};
 
 /// The OID required in the DSC Extended Key Usage extension (ISO 18013-5 §9.1.2).
 const DSC_EKU_OID: &str = "1.0.18013.5.1.2";
+
+/// Top-level SPKI algorithm OID for all EC public keys (`id-ecPublicKey`, RFC 5480).
+/// The specific curve is carried in the SPKI algorithm *parameters*, not here.
+const OID_EC_PUBLIC_KEY: &str = "1.2.840.10045.2.1";
+/// NIST P-256 (secp256r1) curve OID — ISO 18013-5 Table 22 permitted curve.
+const OID_CURVE_P256: &str = "1.2.840.10045.3.1.7";
+/// NIST P-384 (secp384r1) curve OID — ISO 18013-5 Table 22 permitted curve.
+const OID_CURVE_P384: &str = "1.3.132.0.34";
+/// NIST P-521 (secp521r1) curve OID — ISO 18013-5 Table 22 permitted curve.
+const OID_CURVE_P521: &str = "1.3.132.0.35";
 
 /// Validates that `chain[0]` (the Document Signer Certificate) chains up to at least
 /// one certificate in `trusted_roots` via standard X.509 path validation.
@@ -168,6 +183,59 @@ pub(super) fn check_dsc_key_usage(dsc: &X509Certificate<'_>) -> Result<()> {
         Some((true, false)) => Err(MdocError::NonCriticalKeyUsage),
         // Bit set and extension is critical — compliant.
         Some((true, true)) => Ok(()),
+    }
+}
+
+/// Rejects a Document Signer Certificate whose EC public key is not on an ISO 18013-5
+/// Table 22 permitted curve (NIST P-256, P-384, or P-521).
+///
+/// Only applies to EC keys (SPKI algorithm OID `id-ecPublicKey`); any other SPKI
+/// algorithm OID passes through unchecked, since "curve" only has meaning for EC keys.
+/// This notably includes Ed25519 and Ed448 — neither carries a `parameters` field to
+/// check here, and neither needs one: Ed25519 is itself a Table 22 permitted algorithm,
+/// and Ed448 rejection is handled separately by the OID guard in `verify_issuer_signature`.
+/// A non-EC, non-EdDSA SPKI (e.g. RSA) is left for `dispatch_verify` to reject when it
+/// fails to construct a verifying key from it.
+///
+/// Closes the gap where a non-permitted EC curve (e.g. secp256k1) that the underlying
+/// ECDSA verification table happens to define for an unrelated hash combination would
+/// otherwise verify successfully under an algorithm identifier that claims a different
+/// curve (e.g. ESP256/-9, which RFC 9864 defines as P-256-specifically). Rejecting the
+/// curve once here, at chain-validation time, closes it for every algorithm at once
+/// rather than requiring a per-algorithm curve check in `dispatch_verify`.
+///
+/// # Errors
+///
+/// - [`MdocError::UnsupportedDscCurve`] — the SPKI is an EC key whose curve is not
+///   P-256, P-384, or P-521, or the curve OID is missing/malformed.
+pub(super) fn check_dsc_curve(dsc: &X509Certificate<'_>) -> Result<()> {
+    let algorithm = &dsc.public_key().algorithm;
+
+    if algorithm.algorithm.to_id_string() != OID_EC_PUBLIC_KEY {
+        // Not an EC key (e.g. Ed25519/Ed448 OKP keys) — no curve to restrict here.
+        return Ok(());
+    }
+
+    let curve_oid = algorithm
+        .parameters
+        .as_ref()
+        .and_then(|params| Oid::try_from(params).ok());
+
+    match curve_oid {
+        Some(oid)
+            if matches!(
+                oid.to_id_string().as_str(),
+                OID_CURVE_P256 | OID_CURVE_P384 | OID_CURVE_P521
+            ) =>
+        {
+            Ok(())
+        }
+        Some(oid) => Err(MdocError::UnsupportedDscCurve {
+            curve: oid.to_id_string(),
+        }),
+        None => Err(MdocError::UnsupportedDscCurve {
+            curve: "missing or malformed EC curve parameters".to_owned(),
+        }),
     }
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
@@ -20,17 +20,23 @@
 //! ASN.1 parsing for every validation step.
 
 use time::OffsetDateTime;
-use x509_parser::der_parser::Oid;
+use x509_parser::der_parser::{Oid, oid};
 use x509_parser::prelude::{FromDer as _, ParsedExtension, X509Certificate};
 
 use super::error::{MdocError, Result};
 
 /// The OID required in the DSC Extended Key Usage extension (ISO 18013-5 §9.1.2).
-const DSC_EKU_OID: &str = "1.0.18013.5.1.2";
+///
+/// Compile-time `Oid` (not a `&str`) so the EKU check compares OIDs directly rather
+/// than allocating a `String` per extension entry via `to_id_string()`.
+const DSC_EKU_OID: Oid<'static> = oid!(1.0.18013.5.1.2);
 
 /// Top-level SPKI algorithm OID for all EC public keys (`id-ecPublicKey`, RFC 5480).
 /// The specific curve is carried in the SPKI algorithm *parameters*, not here.
-const OID_EC_PUBLIC_KEY: &str = "1.2.840.10045.2.1";
+///
+/// Compile-time `Oid` so this is comparable directly against a parsed certificate's
+/// algorithm OID without allocating a `String` via `to_id_string()`.
+const OID_EC_PUBLIC_KEY: Oid<'static> = oid!(1.2.840.10045.2.1);
 
 /// Validates that `chain[0]` (the Document Signer Certificate) chains up to at least
 /// one certificate in `trusted_roots` via standard X.509 path validation.
@@ -137,11 +143,7 @@ pub(super) fn check_dsc_eku(dsc: &X509Certificate<'_>) -> Result<()> {
                 None
             }
         })
-        .any(|eku| {
-            eku.other
-                .iter()
-                .any(|oid| oid.to_id_string() == DSC_EKU_OID)
-        });
+        .any(|eku| eku.other.iter().any(|oid| oid == &DSC_EKU_OID));
 
     if !has_required_eku {
         return Err(MdocError::MissingDocSignerEku);
@@ -233,7 +235,7 @@ pub(super) fn check_dsc_curve(dsc: &X509Certificate<'_>) -> Result<()> {
 
     let algorithm = &dsc.public_key().algorithm;
 
-    if algorithm.algorithm.to_id_string() != OID_EC_PUBLIC_KEY {
+    if algorithm.algorithm != OID_EC_PUBLIC_KEY {
         // Not an EC key (e.g. Ed25519/Ed448 OKP keys) — no curve to restrict here.
         return Ok(());
     }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/cert_chain.rs
@@ -31,12 +31,6 @@ const DSC_EKU_OID: &str = "1.0.18013.5.1.2";
 /// Top-level SPKI algorithm OID for all EC public keys (`id-ecPublicKey`, RFC 5480).
 /// The specific curve is carried in the SPKI algorithm *parameters*, not here.
 const OID_EC_PUBLIC_KEY: &str = "1.2.840.10045.2.1";
-/// NIST P-256 (secp256r1) curve OID — ISO 18013-5 Table 22 permitted curve.
-const OID_CURVE_P256: &str = "1.2.840.10045.3.1.7";
-/// NIST P-384 (secp384r1) curve OID — ISO 18013-5 Table 22 permitted curve.
-const OID_CURVE_P384: &str = "1.3.132.0.34";
-/// NIST P-521 (secp521r1) curve OID — ISO 18013-5 Table 22 permitted curve.
-const OID_CURVE_P521: &str = "1.3.132.0.35";
 
 /// Validates that `chain[0]` (the Document Signer Certificate) chains up to at least
 /// one certificate in `trusted_roots` via standard X.509 path validation.
@@ -204,11 +198,21 @@ pub(super) fn check_dsc_key_usage(dsc: &X509Certificate<'_>) -> Result<()> {
 /// curve once here, at chain-validation time, closes it for every algorithm at once
 /// rather than requiring a per-algorithm curve check in `dispatch_verify`.
 ///
+/// Curve OIDs are resolved via [`cloud_wallet_crypto::ecdsa::Curve::from_oid`] rather
+/// than a locally-hardcoded OID list, so this check and the crypto layer's notion of
+/// "which curve does this OID mean" can never silently diverge. secp256k1
+/// (`Curve::P256K1`) is recognized by that lookup — it's a curve the crypto crate
+/// supports for other purposes — but is deliberately excluded from the permitted set
+/// here, since the ISO 18013-5 policy decision ("which curves may a DSC use") belongs
+/// to this module, not to the crypto crate.
+///
 /// # Errors
 ///
 /// - [`MdocError::UnsupportedDscCurve`] — the SPKI is an EC key whose curve is not
 ///   P-256, P-384, or P-521, or the curve OID is missing/malformed.
 pub(super) fn check_dsc_curve(dsc: &X509Certificate<'_>) -> Result<()> {
+    use cloud_wallet_crypto::ecdsa::Curve;
+
     let algorithm = &dsc.public_key().algorithm;
 
     if algorithm.algorithm.to_id_string() != OID_EC_PUBLIC_KEY {
@@ -224,8 +228,8 @@ pub(super) fn check_dsc_curve(dsc: &X509Certificate<'_>) -> Result<()> {
     match curve_oid {
         Some(oid)
             if matches!(
-                oid.to_id_string().as_str(),
-                OID_CURVE_P256 | OID_CURVE_P384 | OID_CURVE_P521
+                Curve::from_oid(&oid.to_id_string()),
+                Some(Curve::P256 | Curve::P384 | Curve::P521)
             ) =>
         {
             Ok(())

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/error.rs
@@ -137,6 +137,15 @@ pub enum MdocError {
     )]
     NonCriticalKeyUsage,
 
+    /// The Document Signer Certificate's EC public key uses a curve not permitted by
+    /// ISO 18013-5 Table 22 (only NIST P-256, P-384, and P-521 are allowed).
+    #[error("document signer certificate uses an unsupported EC curve: {curve}")]
+    UnsupportedDscCurve {
+        /// The rejected curve's OID (dotted string), or a description if it could not
+        /// be parsed.
+        curve: String,
+    },
+
     /// The certificate chain could not be validated against a trusted IACA root.
     #[error("certificate chain validation failed: {reason}")]
     InvalidCertificateChain { reason: String },

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests/verifier.rs
@@ -636,20 +636,24 @@ fn der_utc_time(s: &'static str) -> Vec<u8> {
     der_tlv(0x17, s.as_bytes().to_vec())
 }
 
-/// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
-/// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
+/// Assembles a minimal, hand-rolled X.509 `Certificate` DER for a DSC carrying the
+/// given pre-built `spki` bytes (the full SPKI `SEQUENCE`, including its
+/// `AlgorithmIdentifier` and `BIT STRING` payload), signed by `iaca_key`.
 ///
-/// `rcgen 0.13` does not support Ed448 key generation, so the certificate is built from
-/// raw DER.  The public key payload is all-zeros (57 bytes) — sufficient for the Ed448
-/// OID check in `verify_issuer_signature`, which fires before any key-payload check.
+/// Shared by [`build_ed448_dsc_manual`], [`build_secp256k1_dsc_manual`], and
+/// [`build_explicit_curve_dsc_manual`] — those three differ only in *what SPKI bytes*
+/// they pass in (the part each fixture exists to vary); the surrounding
+/// `TBSCertificate` shape (version, validity, subject, EKU/KU extensions) and the
+/// signing step are identical across all three, so they live here once.
 ///
-/// Hand-assembled DER because rcgen 0.13 cannot generate Ed448 keys, and Ed448 is a
-/// Table 22 curve we must recognize-and-reject. This is the only way to produce an
-/// Ed448 DSC to exercise the OID-rejection path. Do not "simplify" with rcgen — it
-/// cannot do this.
-fn build_ed448_dsc_manual(
+/// `serial` and `common_name` only need to be distinct per caller so the resulting
+/// certs aren't byte-identical; their values carry no semantic weight.
+fn build_manual_dsc(
     iaca_cert_der: &[u8],
     iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+    serial: u8,
+    common_name: &str,
+    spki: Vec<u8>,
 ) -> Vec<u8> {
     use x509_parser::prelude::{FromDer as _, X509Certificate};
 
@@ -665,7 +669,7 @@ fn build_ed448_dsc_manual(
     let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
 
     let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
-    let serial = integer_pos(vec![0x01]); // serialNumber = 1
+    let serial = integer_pos(vec![serial]);
     let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
     let validity = seq({
         let mut b = utc_time("231201000000Z");
@@ -674,14 +678,9 @@ fn build_ed448_dsc_manual(
     });
     let subject = seq(set(seq({
         let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
-        b.extend(tlv(0x0c, b"Ed448DSC".to_vec())); // UTF8String
+        b.extend(tlv(0x0c, common_name.as_bytes().to_vec())); // UTF8String
         b
     })));
-    let spki = seq({
-        let mut b = seq(oid(&[1, 3, 101, 113])); // id-Ed448, no params
-        b.extend(bit_str(vec![0u8; 57])); // fake 57-byte public key
-        b
-    });
     // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
     let eku_ext = seq({
         let mut b = oid(&[2, 5, 29, 37]);
@@ -732,6 +731,33 @@ fn build_ed448_dsc_manual(
     })
 }
 
+/// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
+/// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
+///
+/// `rcgen 0.13` does not support Ed448 key generation, so the certificate is built from
+/// raw DER via [`build_manual_dsc`].  The public key payload is all-zeros (57 bytes) —
+/// sufficient for the Ed448 OID check in `verify_issuer_signature`, which fires before
+/// any key-payload check.
+///
+/// Hand-assembled DER because rcgen 0.13 cannot generate Ed448 keys, and Ed448 is a
+/// Table 22 curve we must recognize-and-reject. This is the only way to produce an
+/// Ed448 DSC to exercise the OID-rejection path. Do not "simplify" with rcgen — it
+/// cannot do this.
+fn build_ed448_dsc_manual(
+    iaca_cert_der: &[u8],
+    iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> Vec<u8> {
+    use self::{der_bit_str as bit_str, der_oid as oid, der_seq as seq};
+
+    let spki = seq({
+        let mut b = seq(oid(&[1, 3, 101, 113])); // id-Ed448, no params
+        b.extend(bit_str(vec![0u8; 57])); // fake 57-byte public key
+        b
+    });
+
+    build_manual_dsc(iaca_cert_der, iaca_key, 0x01, "Ed448DSC", spki)
+}
+
 /// Builds a P-256 IACA root and a minimal Ed448 DSC signed by that root.
 ///
 /// `rcgen 0.13` does not support Ed448 key generation; the DSC is assembled from raw
@@ -771,27 +797,16 @@ fn build_ed448_dsc_chain() -> (Vec<u8>, Vec<u8>) {
 /// `1.3.132.0.10`) in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
 ///
 /// `rcgen 0.14` does not support secp256k1 key generation, so the certificate is built
-/// from raw DER, mirroring [`build_ed448_dsc_manual`]. Unlike the Ed448 fixture, the
-/// public key here is a real secp256k1 point (`cloud_wallet_crypto` does support
-/// secp256k1 for signing/verification elsewhere) — sufficient to exercise the
-/// `check_dsc_curve` allow-list, which fires on the SPKI curve OID before any
-/// signature is checked.
+/// from raw DER via [`build_manual_dsc`]. Unlike the Ed448 fixture, the public key here
+/// is a real secp256k1 point (`cloud_wallet_crypto` does support secp256k1 for
+/// signing/verification elsewhere) — sufficient to exercise the `check_dsc_curve`
+/// allow-list, which fires on the SPKI curve OID before any signature is checked.
 fn build_secp256k1_dsc_manual(
     iaca_cert_der: &[u8],
     iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
     dsc_key: &cloud_wallet_crypto::ecdsa::KeyPair,
 ) -> Vec<u8> {
-    use x509_parser::prelude::{FromDer as _, X509Certificate};
-
-    use self::{
-        der_bit_str as bit_str, der_bool_true as bool_true, der_ctx_explicit as ctx_explicit,
-        der_integer_pos as integer_pos, der_octet_str as octet_str, der_oid as oid, der_seq as seq,
-        der_set as set, der_tlv as tlv, der_utc_time as utc_time,
-    };
-
-    let (_, iaca_x509) =
-        X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
-    let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
+    use self::{der_bit_str as bit_str, der_oid as oid, der_seq as seq};
 
     let mut point_buf = [0u8; 65]; // secp256k1 uncompressed point: 0x04 || X(32) || Y(32)
     let point = dsc_key
@@ -799,19 +814,6 @@ fn build_secp256k1_dsc_manual(
         .to_sec1_uncompressed(&mut point_buf)
         .expect("secp256k1 point encoding must succeed");
 
-    let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
-    let serial = integer_pos(vec![0x02]); // serialNumber = 2 (distinct from Ed448 fixture)
-    let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
-    let validity = seq({
-        let mut b = utc_time("231201000000Z");
-        b.extend(utc_time("241231235959Z"));
-        b
-    });
-    let subject = seq(set(seq({
-        let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
-        b.extend(tlv(0x0c, b"Secp256k1DSC".to_vec())); // UTF8String
-        b
-    })));
     let spki = seq({
         // id-ecPublicKey with secp256k1 named-curve parameters (RFC 5480 §2.1.1).
         let mut b = seq({
@@ -822,51 +824,8 @@ fn build_secp256k1_dsc_manual(
         b.extend(bit_str(point.to_vec()));
         b
     });
-    // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
-    let eku_ext = seq({
-        let mut b = oid(&[2, 5, 29, 37]);
-        b.extend(bool_true());
-        b.extend(octet_str(seq(oid(&[1, 0, 18013, 5, 1, 2]))));
-        b
-    });
-    // keyUsage (2.5.29.15), critical, digitalSignature bit set
-    let ku_ext = seq({
-        let mut b = oid(&[2, 5, 29, 15]);
-        b.extend(bool_true());
-        b.extend(octet_str(tlv(0x03, vec![0x07, 0x80]))); // BIT STRING: 7 unused, bit 0
-        b
-    });
-    let extensions = ctx_explicit(
-        3,
-        seq({
-            let mut b = eku_ext;
-            b.extend(ku_ext);
-            b
-        }),
-    );
-    let tbs = seq({
-        let mut b = version;
-        b.extend(serial);
-        b.extend(sig_alg_id.clone());
-        b.extend(issuer_raw);
-        b.extend(validity);
-        b.extend(subject);
-        b.extend(spki);
-        b.extend(extensions);
-        b
-    });
 
-    let mut sig_buf = [0u8; 80];
-    let sig = iaca_key
-        .sign_sha256_asn1(&tbs, &mut sig_buf)
-        .expect("ECDSA-P256 signing of TBSCertificate must succeed");
-
-    seq({
-        let mut b = tbs;
-        b.extend(sig_alg_id);
-        b.extend(bit_str(sig.to_vec()));
-        b
-    })
+    build_manual_dsc(iaca_cert_der, iaca_key, 0x02, "Secp256k1DSC", spki)
 }
 
 /// Builds a P-256 IACA root and a minimal secp256k1 DSC signed by that root.
@@ -919,31 +878,8 @@ fn build_explicit_curve_dsc_manual(
     iaca_cert_der: &[u8],
     iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
 ) -> Vec<u8> {
-    use x509_parser::prelude::{FromDer as _, X509Certificate};
+    use self::{der_bit_str as bit_str, der_oid as oid, der_seq as seq};
 
-    use self::{
-        der_bit_str as bit_str, der_bool_true as bool_true, der_ctx_explicit as ctx_explicit,
-        der_integer_pos as integer_pos, der_octet_str as octet_str, der_oid as oid, der_seq as seq,
-        der_set as set, der_tlv as tlv, der_utc_time as utc_time,
-    };
-
-    let (_, iaca_x509) =
-        X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
-    let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
-
-    let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
-    let serial = integer_pos(vec![0x03]); // serialNumber = 3 (distinct from other fixtures)
-    let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
-    let validity = seq({
-        let mut b = utc_time("231201000000Z");
-        b.extend(utc_time("241231235959Z"));
-        b
-    });
-    let subject = seq(set(seq({
-        let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
-        b.extend(tlv(0x0c, b"ExplicitCurveDSC".to_vec())); // UTF8String
-        b
-    })));
     let spki = seq({
         // id-ecPublicKey with a SEQUENCE (not OID) in place of the named-curve OID —
         // the PKIX `specifiedCurve` form `check_dsc_curve` must reject as malformed.
@@ -955,51 +891,8 @@ fn build_explicit_curve_dsc_manual(
         b.extend(bit_str(vec![0u8; 65])); // point bytes are irrelevant; never reached
         b
     });
-    // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
-    let eku_ext = seq({
-        let mut b = oid(&[2, 5, 29, 37]);
-        b.extend(bool_true());
-        b.extend(octet_str(seq(oid(&[1, 0, 18013, 5, 1, 2]))));
-        b
-    });
-    // keyUsage (2.5.29.15), critical, digitalSignature bit set
-    let ku_ext = seq({
-        let mut b = oid(&[2, 5, 29, 15]);
-        b.extend(bool_true());
-        b.extend(octet_str(tlv(0x03, vec![0x07, 0x80]))); // BIT STRING: 7 unused, bit 0
-        b
-    });
-    let extensions = ctx_explicit(
-        3,
-        seq({
-            let mut b = eku_ext;
-            b.extend(ku_ext);
-            b
-        }),
-    );
-    let tbs = seq({
-        let mut b = version;
-        b.extend(serial);
-        b.extend(sig_alg_id.clone());
-        b.extend(issuer_raw);
-        b.extend(validity);
-        b.extend(subject);
-        b.extend(spki);
-        b.extend(extensions);
-        b
-    });
 
-    let mut sig_buf = [0u8; 80];
-    let sig = iaca_key
-        .sign_sha256_asn1(&tbs, &mut sig_buf)
-        .expect("ECDSA-P256 signing of TBSCertificate must succeed");
-
-    seq({
-        let mut b = tbs;
-        b.extend(sig_alg_id);
-        b.extend(bit_str(sig.to_vec()));
-        b
-    })
+    build_manual_dsc(iaca_cert_der, iaca_key, 0x03, "ExplicitCurveDSC", spki)
 }
 
 /// Builds a P-256 IACA root and a minimal DSC with an explicit-curve-parameters SPKI

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/tests/verifier.rs
@@ -560,6 +560,82 @@ fn build_three_cert_chain() -> (
     (iaca_der, int_der, dsc_der, dsc_aws_key)
 }
 
+// ── Hand-rolled minimal DER/ASN.1 builders ──────────────────────────────────────
+//
+// Shared by `build_ed448_dsc_manual` and `build_secp256k1_dsc_manual`: both need to
+// hand-assemble an X.509 certificate carrying a key type that the project's certificate
+// generation library cannot produce (rcgen has no Ed448 or secp256k1 support), in order
+// to exercise rejection paths (Ed448 OID guard, non-Table-22 curve allow-list) that can
+// only be reached with a DSC carrying that exact key type.
+
+fn der_len_bytes(n: usize) -> Vec<u8> {
+    if n < 128 {
+        vec![n as u8]
+    } else if n < 256 {
+        vec![0x81, n as u8]
+    } else {
+        vec![0x82, (n >> 8) as u8, (n & 0xff) as u8]
+    }
+}
+fn der_tlv(tag: u8, body: Vec<u8>) -> Vec<u8> {
+    let mut v = vec![tag];
+    v.extend(der_len_bytes(body.len()));
+    v.extend(body);
+    v
+}
+fn der_seq(body: Vec<u8>) -> Vec<u8> {
+    der_tlv(0x30, body)
+}
+fn der_set(body: Vec<u8>) -> Vec<u8> {
+    der_tlv(0x31, body)
+}
+fn der_ctx_explicit(n: u8, body: Vec<u8>) -> Vec<u8> {
+    der_tlv(0xa0 | n, body)
+}
+fn der_oid(components: &[u64]) -> Vec<u8> {
+    fn base128(mut n: u64) -> Vec<u8> {
+        if n == 0 {
+            return vec![0];
+        }
+        let mut b = Vec::new();
+        while n > 0 {
+            b.push((n & 0x7f) as u8);
+            n >>= 7;
+        }
+        b.reverse();
+        for i in 0..b.len() - 1 {
+            b[i] |= 0x80;
+        }
+        b
+    }
+    let mut bytes = base128(components[0] * 40 + components[1]);
+    for &c in &components[2..] {
+        bytes.extend(base128(c));
+    }
+    der_tlv(0x06, bytes)
+}
+fn der_integer_pos(b: Vec<u8>) -> Vec<u8> {
+    let mut content = b;
+    if content.first().is_some_and(|&x| x & 0x80 != 0) {
+        content.insert(0, 0);
+    }
+    der_tlv(0x02, content)
+}
+fn der_bit_str(data: Vec<u8>) -> Vec<u8> {
+    let mut c = vec![0x00]; // 0 unused bits
+    c.extend(data);
+    der_tlv(0x03, c)
+}
+fn der_octet_str(b: Vec<u8>) -> Vec<u8> {
+    der_tlv(0x04, b)
+}
+fn der_bool_true() -> Vec<u8> {
+    vec![0x01, 0x01, 0xff]
+}
+fn der_utc_time(s: &'static str) -> Vec<u8> {
+    der_tlv(0x17, s.as_bytes().to_vec())
+}
+
 /// Constructs a minimal X.509 certificate with an Ed448 public key (OID `1.3.101.113`)
 /// in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
 ///
@@ -577,78 +653,16 @@ fn build_ed448_dsc_manual(
 ) -> Vec<u8> {
     use x509_parser::prelude::{FromDer as _, X509Certificate};
 
+    use self::{
+        der_bit_str as bit_str, der_bool_true as bool_true, der_ctx_explicit as ctx_explicit,
+        der_integer_pos as integer_pos, der_octet_str as octet_str, der_oid as oid, der_seq as seq,
+        der_set as set, der_tlv as tlv, der_utc_time as utc_time,
+    };
+
     // Extract the IACA subject DER bytes — these become the DSC issuer field.
     let (_, iaca_x509) =
         X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
     let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
-
-    fn len_bytes(n: usize) -> Vec<u8> {
-        if n < 128 {
-            vec![n as u8]
-        } else if n < 256 {
-            vec![0x81, n as u8]
-        } else {
-            vec![0x82, (n >> 8) as u8, (n & 0xff) as u8]
-        }
-    }
-    fn tlv(tag: u8, body: Vec<u8>) -> Vec<u8> {
-        let mut v = vec![tag];
-        v.extend(len_bytes(body.len()));
-        v.extend(body);
-        v
-    }
-    fn seq(body: Vec<u8>) -> Vec<u8> {
-        tlv(0x30, body)
-    }
-    fn set(body: Vec<u8>) -> Vec<u8> {
-        tlv(0x31, body)
-    }
-    fn ctx_explicit(n: u8, body: Vec<u8>) -> Vec<u8> {
-        tlv(0xa0 | n, body)
-    }
-    fn oid(components: &[u64]) -> Vec<u8> {
-        fn base128(mut n: u64) -> Vec<u8> {
-            if n == 0 {
-                return vec![0];
-            }
-            let mut b = Vec::new();
-            while n > 0 {
-                b.push((n & 0x7f) as u8);
-                n >>= 7;
-            }
-            b.reverse();
-            for i in 0..b.len() - 1 {
-                b[i] |= 0x80;
-            }
-            b
-        }
-        let mut bytes = base128(components[0] * 40 + components[1]);
-        for &c in &components[2..] {
-            bytes.extend(base128(c));
-        }
-        tlv(0x06, bytes)
-    }
-    fn integer_pos(b: Vec<u8>) -> Vec<u8> {
-        let mut content = b;
-        if content.first().is_some_and(|&x| x & 0x80 != 0) {
-            content.insert(0, 0);
-        }
-        tlv(0x02, content)
-    }
-    fn bit_str(data: Vec<u8>) -> Vec<u8> {
-        let mut c = vec![0x00]; // 0 unused bits
-        c.extend(data);
-        tlv(0x03, c)
-    }
-    fn octet_str(b: Vec<u8>) -> Vec<u8> {
-        tlv(0x04, b)
-    }
-    fn bool_true() -> Vec<u8> {
-        vec![0x01, 0x01, 0xff]
-    }
-    fn utc_time(s: &'static str) -> Vec<u8> {
-        tlv(0x17, s.as_bytes().to_vec())
-    }
 
     let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
     let serial = integer_pos(vec![0x01]); // serialNumber = 1
@@ -749,6 +763,272 @@ fn build_ed448_dsc_chain() -> (Vec<u8>, Vec<u8>) {
     let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
 
     let dsc_der = build_ed448_dsc_manual(&iaca_der, &iaca_aws_key);
+
+    (iaca_der, dsc_der)
+}
+
+/// Constructs a minimal X.509 certificate with a secp256k1 public key (OID
+/// `1.3.132.0.10`) in the SubjectPublicKeyInfo, signed by the provided P-256 IACA key.
+///
+/// `rcgen 0.14` does not support secp256k1 key generation, so the certificate is built
+/// from raw DER, mirroring [`build_ed448_dsc_manual`]. Unlike the Ed448 fixture, the
+/// public key here is a real secp256k1 point (`cloud_wallet_crypto` does support
+/// secp256k1 for signing/verification elsewhere) — sufficient to exercise the
+/// `check_dsc_curve` allow-list, which fires on the SPKI curve OID before any
+/// signature is checked.
+fn build_secp256k1_dsc_manual(
+    iaca_cert_der: &[u8],
+    iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+    dsc_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> Vec<u8> {
+    use x509_parser::prelude::{FromDer as _, X509Certificate};
+
+    use self::{
+        der_bit_str as bit_str, der_bool_true as bool_true, der_ctx_explicit as ctx_explicit,
+        der_integer_pos as integer_pos, der_octet_str as octet_str, der_oid as oid, der_seq as seq,
+        der_set as set, der_tlv as tlv, der_utc_time as utc_time,
+    };
+
+    let (_, iaca_x509) =
+        X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
+    let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
+
+    let mut point_buf = [0u8; 65]; // secp256k1 uncompressed point: 0x04 || X(32) || Y(32)
+    let point = dsc_key
+        .public_key()
+        .to_sec1_uncompressed(&mut point_buf)
+        .expect("secp256k1 point encoding must succeed");
+
+    let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
+    let serial = integer_pos(vec![0x02]); // serialNumber = 2 (distinct from Ed448 fixture)
+    let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
+    let validity = seq({
+        let mut b = utc_time("231201000000Z");
+        b.extend(utc_time("241231235959Z"));
+        b
+    });
+    let subject = seq(set(seq({
+        let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
+        b.extend(tlv(0x0c, b"Secp256k1DSC".to_vec())); // UTF8String
+        b
+    })));
+    let spki = seq({
+        // id-ecPublicKey with secp256k1 named-curve parameters (RFC 5480 §2.1.1).
+        let mut b = seq({
+            let mut alg = oid(&[1, 2, 840, 10045, 2, 1]); // id-ecPublicKey
+            alg.extend(oid(&[1, 3, 132, 0, 10])); // secp256k1
+            alg
+        });
+        b.extend(bit_str(point.to_vec()));
+        b
+    });
+    // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
+    let eku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 37]);
+        b.extend(bool_true());
+        b.extend(octet_str(seq(oid(&[1, 0, 18013, 5, 1, 2]))));
+        b
+    });
+    // keyUsage (2.5.29.15), critical, digitalSignature bit set
+    let ku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 15]);
+        b.extend(bool_true());
+        b.extend(octet_str(tlv(0x03, vec![0x07, 0x80]))); // BIT STRING: 7 unused, bit 0
+        b
+    });
+    let extensions = ctx_explicit(
+        3,
+        seq({
+            let mut b = eku_ext;
+            b.extend(ku_ext);
+            b
+        }),
+    );
+    let tbs = seq({
+        let mut b = version;
+        b.extend(serial);
+        b.extend(sig_alg_id.clone());
+        b.extend(issuer_raw);
+        b.extend(validity);
+        b.extend(subject);
+        b.extend(spki);
+        b.extend(extensions);
+        b
+    });
+
+    let mut sig_buf = [0u8; 80];
+    let sig = iaca_key
+        .sign_sha256_asn1(&tbs, &mut sig_buf)
+        .expect("ECDSA-P256 signing of TBSCertificate must succeed");
+
+    seq({
+        let mut b = tbs;
+        b.extend(sig_alg_id);
+        b.extend(bit_str(sig.to_vec()));
+        b
+    })
+}
+
+/// Builds a P-256 IACA root and a minimal secp256k1 DSC signed by that root.
+///
+/// secp256k1 is not on the ISO 18013-5 Table 22 permitted-curve list; this fixture
+/// exercises `check_dsc_curve`'s rejection of it.
+fn build_secp256k1_dsc_chain() -> (Vec<u8>, Vec<u8>) {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa};
+
+    let iaca_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("P-256 IACA key generation must succeed");
+
+    let iaca_pkcs8 = iaca_aws_key.to_pkcs8_der();
+    let iaca_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            iaca_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading P-256 key into rcgen must succeed");
+
+    let mut iaca_params =
+        CertificateParams::new(vec!["Secp256k1 Test IACA".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_rcgen_key)
+        .expect("IACA self-sign must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256K1)
+            .expect("secp256k1 DSC key generation must succeed");
+    let dsc_der = build_secp256k1_dsc_manual(&iaca_der, &iaca_aws_key, &dsc_key);
+
+    (iaca_der, dsc_der)
+}
+
+/// Constructs a minimal X.509 certificate whose SPKI declares `id-ecPublicKey` but
+/// encodes the curve as an explicit `SEQUENCE` (PKIX `specifiedCurve` form, RFC 3279
+/// §2.3.5) instead of a named-curve OID, signed by the provided P-256 IACA key.
+///
+/// The `SEQUENCE` here is an empty placeholder, not a spec-compliant `ECParameters`
+/// structure — `check_dsc_curve` only needs to observe that `parameters` is present
+/// but is not an OID to reject it, so the placeholder's *content* is irrelevant to
+/// what this fixture proves. Real `specifiedCurve` SPKIs are vanishingly rare (PKIX
+/// strongly discourages them) but must still be rejected rather than silently
+/// mismatched against `check_dsc_curve`'s OID-only allow-list.
+fn build_explicit_curve_dsc_manual(
+    iaca_cert_der: &[u8],
+    iaca_key: &cloud_wallet_crypto::ecdsa::KeyPair,
+) -> Vec<u8> {
+    use x509_parser::prelude::{FromDer as _, X509Certificate};
+
+    use self::{
+        der_bit_str as bit_str, der_bool_true as bool_true, der_ctx_explicit as ctx_explicit,
+        der_integer_pos as integer_pos, der_octet_str as octet_str, der_oid as oid, der_seq as seq,
+        der_set as set, der_tlv as tlv, der_utc_time as utc_time,
+    };
+
+    let (_, iaca_x509) =
+        X509Certificate::from_der(iaca_cert_der).expect("IACA cert must be parseable");
+    let issuer_raw = iaca_x509.tbs_certificate.subject.as_raw().to_vec();
+
+    let version = ctx_explicit(0, integer_pos(vec![0x02])); // [0] INTEGER 2 → v3
+    let serial = integer_pos(vec![0x03]); // serialNumber = 3 (distinct from other fixtures)
+    let sig_alg_id = seq(oid(&[1, 2, 840, 10045, 4, 3, 2])); // ecdsa-with-SHA256
+    let validity = seq({
+        let mut b = utc_time("231201000000Z");
+        b.extend(utc_time("241231235959Z"));
+        b
+    });
+    let subject = seq(set(seq({
+        let mut b = oid(&[2, 5, 4, 3]); // id-at-commonName
+        b.extend(tlv(0x0c, b"ExplicitCurveDSC".to_vec())); // UTF8String
+        b
+    })));
+    let spki = seq({
+        // id-ecPublicKey with a SEQUENCE (not OID) in place of the named-curve OID —
+        // the PKIX `specifiedCurve` form `check_dsc_curve` must reject as malformed.
+        let mut b = seq({
+            let mut alg = oid(&[1, 2, 840, 10045, 2, 1]); // id-ecPublicKey
+            alg.extend(seq(vec![])); // explicit ECParameters placeholder (non-OID)
+            alg
+        });
+        b.extend(bit_str(vec![0u8; 65])); // point bytes are irrelevant; never reached
+        b
+    });
+    // extendedKeyUsage (2.5.29.37), critical — ISO 18013-5 EKU
+    let eku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 37]);
+        b.extend(bool_true());
+        b.extend(octet_str(seq(oid(&[1, 0, 18013, 5, 1, 2]))));
+        b
+    });
+    // keyUsage (2.5.29.15), critical, digitalSignature bit set
+    let ku_ext = seq({
+        let mut b = oid(&[2, 5, 29, 15]);
+        b.extend(bool_true());
+        b.extend(octet_str(tlv(0x03, vec![0x07, 0x80]))); // BIT STRING: 7 unused, bit 0
+        b
+    });
+    let extensions = ctx_explicit(
+        3,
+        seq({
+            let mut b = eku_ext;
+            b.extend(ku_ext);
+            b
+        }),
+    );
+    let tbs = seq({
+        let mut b = version;
+        b.extend(serial);
+        b.extend(sig_alg_id.clone());
+        b.extend(issuer_raw);
+        b.extend(validity);
+        b.extend(subject);
+        b.extend(spki);
+        b.extend(extensions);
+        b
+    });
+
+    let mut sig_buf = [0u8; 80];
+    let sig = iaca_key
+        .sign_sha256_asn1(&tbs, &mut sig_buf)
+        .expect("ECDSA-P256 signing of TBSCertificate must succeed");
+
+    seq({
+        let mut b = tbs;
+        b.extend(sig_alg_id);
+        b.extend(bit_str(sig.to_vec()));
+        b
+    })
+}
+
+/// Builds a P-256 IACA root and a minimal DSC with an explicit-curve-parameters SPKI
+/// signed by that root.
+fn build_explicit_curve_dsc_chain() -> (Vec<u8>, Vec<u8>) {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa};
+
+    let iaca_aws_key =
+        cloud_wallet_crypto::ecdsa::KeyPair::generate(cloud_wallet_crypto::ecdsa::Curve::P256)
+            .expect("P-256 IACA key generation must succeed");
+
+    let iaca_pkcs8 = iaca_aws_key.to_pkcs8_der();
+    let iaca_rcgen_key = rcgen::KeyPair::from_der_and_sign_algo(
+        &rustls_pki_types::PrivateKeyDer::Pkcs8(rustls_pki_types::PrivatePkcs8KeyDer::from(
+            iaca_pkcs8,
+        )),
+        &rcgen::PKCS_ECDSA_P256_SHA256,
+    )
+    .expect("loading P-256 key into rcgen must succeed");
+
+    let mut iaca_params =
+        CertificateParams::new(vec!["Explicit Curve Test IACA".to_string()]).expect("iaca params");
+    iaca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let iaca_cert = iaca_params
+        .self_signed(&iaca_rcgen_key)
+        .expect("IACA self-sign must succeed");
+    let iaca_der: Vec<u8> = iaca_cert.der().to_vec();
+
+    let dsc_der = build_explicit_curve_dsc_manual(&iaca_der, &iaca_aws_key);
 
     (iaca_der, dsc_der)
 }
@@ -893,6 +1173,10 @@ fn parsed_with_device_key(cose_key: Value) -> ParsedMdoc {
 
 // ── Verifier tests ───────────────────────────────────────────────────────────
 
+/// Also the explicit proof that `check_dsc_curve` accepts a P-256 DSC — the ISO
+/// 18013-5 Table 22 curve every other passing test in this file already relies on
+/// implicitly. See `verify_issuer_signature_rejects_secp256k1_curve` for the
+/// corresponding rejection of a non-permitted curve.
 #[tokio::test]
 async fn verify_issuer_signature_accepts_valid_chain() {
     let (iaca_der, dsc_der, signing_key) = build_chain(true);
@@ -1597,6 +1881,68 @@ async fn verify_issuer_signature_rejects_ed448_algorithm_ed25519_identifier() {
     assert!(
         matches!(err, MdocError::UnsupportedAlgorithm { alg: -19 }),
         "expected UnsupportedAlgorithm {{ alg: -19 }}, got: {err:?}"
+    );
+}
+
+/// The fix this test pins: secp256k1 is not on the ISO 18013-5 Table 22 permitted-curve
+/// list (P-256/P-384/P-521), but `cloud_wallet_crypto::ecdsa::get_verification_algorithm`
+/// does define a `(P256K1, Sha256)` verification combination for unrelated reasons, and
+/// `cert_chain.rs` previously had no curve allow-list at all. Without `check_dsc_curve`,
+/// a DSC carrying a secp256k1 key signing under `alg: -7`/`-9` (which both claim P-256)
+/// would verify successfully. `check_dsc_curve` rejects it at chain-validation time,
+/// before signature dispatch is ever reached.
+#[tokio::test]
+async fn verify_issuer_signature_rejects_secp256k1_curve() {
+    let (iaca_der, dsc_der) = build_secp256k1_dsc_chain();
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -7} (ES256): a1 01 26 — alg is irrelevant here; check_dsc_curve fires
+    // before dispatch_verify regardless of which algorithm is declared.
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x26]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with secp256k1 DSC must still parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    let err = verify_issuer_signature(
+        &mdoc,
+        "org.iso.18013.5.1.mDL",
+        &trust_store,
+        RevocationPolicy::Skip,
+        OffsetDateTime::now_utc(),
+    )
+    .await
+    .expect_err("secp256k1 DSC must be rejected as an unsupported curve");
+
+    assert!(
+        matches!(err, MdocError::UnsupportedDscCurve { .. }),
+        "expected UnsupportedDscCurve, got: {err:?}"
+    );
+}
+
+/// Proves the PKIX `specifiedCurve` rejection path in `check_dsc_curve` is real, not
+/// just reasoned about: an EC SPKI whose `parameters` field is a `SEQUENCE` rather than
+/// a named-curve OID must be rejected as malformed, not silently let through because
+/// `Oid::try_from` happened to succeed.
+#[tokio::test]
+async fn verify_issuer_signature_rejects_explicit_curve_parameters() {
+    let (iaca_der, dsc_der) = build_explicit_curve_dsc_chain();
+    let mso_bytes = minimal_mso_cbor();
+    // {1: -7} (ES256): a1 01 26 — alg is irrelevant; check_dsc_curve fires first.
+    let raw = build_issuer_signed_with_custom_alg(mso_bytes, dsc_der, vec![0xa1, 0x01, 0x26]);
+    let mdoc = ParsedMdoc::parse(&raw).expect("mdoc with explicit-curve DSC must still parse");
+    let trust_store = StaticTrustStore::new(vec![iaca_der]);
+
+    let err = verify_issuer_signature(
+        &mdoc,
+        "org.iso.18013.5.1.mDL",
+        &trust_store,
+        RevocationPolicy::Skip,
+        OffsetDateTime::now_utc(),
+    )
+    .await
+    .expect_err("explicit-curve-parameters DSC must be rejected");
+
+    assert!(
+        matches!(err, MdocError::UnsupportedDscCurve { .. }),
+        "expected UnsupportedDscCurve, got: {err:?}"
     );
 }
 

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -13,6 +13,7 @@ use cloud_wallet_crypto::ecdsa::VerifyingKey as EcdsaKey;
 use cloud_wallet_crypto::ed25519::VerifyingKey as Ed25519Key;
 use cloud_wallet_crypto::jwk::{Jwk, Key, OkpCurve};
 use time::OffsetDateTime;
+use x509_parser::der_parser::{Oid, oid};
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::cert_chain::{
@@ -245,9 +246,10 @@ pub(crate) async fn verify_issuer_signature(
     // contain the OID bytes at a non-OID position.  Covers both the deprecated EdDSA
     // (-8) and RFC 9864 fully-specified Ed25519 (-19) identifiers, since both route to
     // the same Ed25519 verification path and must reject Ed448 identically.
-    const ED448_OID: &str = "1.3.101.113";
-    if (alg == ALG_EDDSA || alg == ALG_ED25519)
-        && dsc.public_key().algorithm.algorithm.to_id_string() == ED448_OID
+    // Compile-time `Oid` (not a `&str`) so this compares directly against the parsed
+    // SPKI algorithm OID rather than allocating a `String` via `to_id_string()`.
+    const ED448_OID: Oid<'static> = oid!(1.3.101.113);
+    if (alg == ALG_EDDSA || alg == ALG_ED25519) && dsc.public_key().algorithm.algorithm == ED448_OID
     {
         return Err(MdocError::UnsupportedAlgorithm { alg });
     }

--- a/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
+++ b/crates/cloud-wallet-openid4vc/src/formats/mdoc/verifier.rs
@@ -16,8 +16,8 @@ use time::OffsetDateTime;
 use x509_parser::prelude::{FromDer as _, X509Certificate};
 
 use super::cert_chain::{
-    check_country_consistency, check_dsc_eku, check_dsc_key_usage, check_dsc_validity_period,
-    check_signed_within_dsc_validity, extract_spki, validate_cert_chain,
+    check_country_consistency, check_dsc_curve, check_dsc_eku, check_dsc_key_usage,
+    check_dsc_validity_period, check_signed_within_dsc_validity, extract_spki, validate_cert_chain,
 };
 use super::error::{MdocError, Result};
 use super::parser::ParsedMdoc;
@@ -174,6 +174,8 @@ pub struct IssuerInfo {
 ///   `digitalSignature` bit is not set.
 /// - [`MdocError::NonCriticalKeyUsage`] — DSC Key Usage extension is present and bit is set
 ///   but the extension is not marked critical.
+/// - [`MdocError::UnsupportedDscCurve`] — DSC EC public key curve is not P-256, P-384,
+///   or P-521 (ISO 18013-5 Table 22).
 /// - [`MdocError::DocTypeMismatch`] — outer `docType` differs from MSO `docType`.
 /// - [`MdocError::SignedOutsideDscValidity`] — MSO `signed` is outside DSC validity.
 /// - [`MdocError::InvalidIssuerSignature`] — signature does not verify.
@@ -214,6 +216,11 @@ pub(crate) async fn verify_issuer_signature(
 
     // digitalSignature key usage bit required by ISO 18013-5 Annex B Table B.3.
     check_dsc_key_usage(&dsc)?;
+
+    // EC curve must be on the ISO 18013-5 Table 22 permitted list (P-256/P-384/P-521).
+    // Closes the curve↔algorithm binding gap for every alg at once, rather than relying
+    // on the verification table to happen to fail for a disallowed curve.
+    check_dsc_curve(&dsc)?;
 
     if parsed.doc_type != outer_doc_type {
         return Err(MdocError::DocTypeMismatch {


### PR DESCRIPTION
ISO 18013-5 §9.3 (Table 22) restricts DSC public keys to a fixed set of curves (NIST P-256/P-384/P-521, plus the Brainpool variants when supported). The mdoc verifier does not enforce this: `verify_issuer_signature` validates the DSC's EKU, key usage, and validity period, but never checks the *curve* of the DSC public key. Signature verification is relied on to fail-closed for a wrong curve — but that only holds for the P-384/P-521 cases. The underlying ECDSA verification table (`cloud_wallet_crypto::ecdsa::get_verification_algorithm`) defines a `(secp256k1, SHA-256)` entry (used elsewhere for non-mdoc purposes), and there is no curve allow-list in `cert_chain.rs`. As a result a DSC carrying a **secp256k1** key, signing `issuerAuth` under `alg: -9` (ESP256, which RFC 9864 defines as P-256-specifically), verifies successfully — accepting a curve ISO does not permit, under an identifier that claims a different one.

Threat scope: this requires a *trusted* IACA root to sign a non-compliant DSC (a misbehaving/compromised issuer, not a remote attacker). Pre-existing   the same gap applied to the deprecated `-7` before RFC 9864 support was added. Low practical severity; correctness/hardening.

**Scope**
- Add `check_dsc_curve` in `cert_chain.rs`: reject any DSC whose public-key curve is not on the ISO 18013-5 Table 22 permitted set (P-256, P-384, P-521).
- Call it in `verify_issuer_signature` alongside the other DSC checks (EKU, key usage, validity).
- Add `MdocError::UnsupportedDscCurve { curve: String }` (additive; `MdocError` is `#[non_exhaustive]`).

**Explicitly out of scope**
- Per-algorithm curve↔alg binding in `dispatch_verify`. A single allow-list at chain-validation time closes the gap for all algorithms at once and is the cleaner shape.
- Brainpool curves — add to the allow-list only when Brainpool *verification* is implemented (currently an `UnsupportedAlgorithm` placeholder); permitting the curve without verification support would be inconsistent.

**Acceptance Criteria**
- [ ] `check_dsc_curve` rejects a DSC whose key is not P-256/P-384/P-521
- [ ] Called in `verify_issuer_signature` with the other DSC checks
- [ ] `MdocError::UnsupportedDscCurve { curve }` added
- [ ] Test: P-256 DSC passes
- [ ] Test: secp256k1 DSC is rejected with `UnsupportedDscCurve` (rcgen-generated, hermetic)
- [ ] Existing verification tests pass unchanged