### PR TITLE
Scope based credential configuration selection

### DIFF
--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -676,7 +676,7 @@ impl Oid4vciClient {
         &self,
         context: &ResolvedOfferContext,
         token: &TokenResponse,
-        credential_identifier: impl Into<String>,
+        selector: CredIdOrCredConfigId,
         credential_config_id: &str,
         signer: &S,
         dpop: Option<&DpopOptions<'_>>,
@@ -684,19 +684,13 @@ impl Oid4vciClient {
         let is_anonymous = context.as_metadata.allows_anonymous_pre_authorized_grant()
             && matches!(context.flow, IssuanceFlow::PreAuthorizedCode { .. });
 
+        let config_id = resolve_credential_configuration_id(&selector, credential_config_id);
         let c_nonce = self.resolve_nonce(&context.issuer_metadata).await?;
         let proofs = self
-            .build_proofs(
-                context,
-                c_nonce.as_deref(),
-                is_anonymous,
-                credential_config_id,
-                signer,
-            )
+            .build_proofs(context, c_nonce.as_deref(), is_anonymous, config_id, signer)
             .await?;
 
-        let id = CredIdOrCredConfigId::credential_identifier(credential_identifier);
-        let mut request = CredentialRequest::new(id);
+        let mut request = CredentialRequest::new(selector);
         if let Some(p) = proofs {
             request = request.with_proofs(p);
         }
@@ -706,6 +700,13 @@ impl Oid4vciClient {
     }
 
     /// Request all credentials authorized by the token response.
+    ///
+    /// Issuers vary in how they convey which credentials were authorized, so the
+    /// targets to request are resolved with a 3-tier fallback per OID4VCI §6.2:
+    /// 1. `authorization_details` with `credential_identifiers` (RAR with per-credential ids).
+    /// 2. `scope`, matched against the `scope` advertised on each entry of
+    ///    `credential_configurations_supported`.
+    /// 3. The `credential_configuration_id`s from the original credential offer.
     ///
     /// The caller is responsible for handling individual failures (e.g. deferred
     /// issuance on some credentials while others succeed).
@@ -721,15 +722,12 @@ impl Oid4vciClient {
         signer: &S,
         dpop: Option<&DpopOptions<'_>>,
     ) -> Result<Vec<CredentialResponse>> {
-        let resolved = resolve_credential_ids(token)?;
-        let total: usize = resolved.iter().map(|(_, ids)| ids.len()).sum();
-        let mut results = Vec::with_capacity(total);
+        let targets = resolve_credential_targets(context, token)?;
+        let mut results = Vec::with_capacity(targets.len());
         let mut futures = FuturesUnordered::new();
 
-        for (config_id, identifiers) in resolved {
-            for id in identifiers {
-                futures.push(self.request_credential(context, token, id, config_id, signer, dpop));
-            }
+        for (selector, config_id) in &targets {
+            futures.push(self.request_credential(context, token, selector.clone(), config_id, signer, dpop));
         }
 
         while let Some(res) = futures.next().await {
@@ -1248,12 +1246,7 @@ impl Oid4vciClient {
                     handler.extract_and_store_nonce(&htu, retry_response.headers());
                 }
 
-                return retry_response
-                    .json::<CredentialResponse>()
-                    .await
-                    .map_err(|e| ClientError::InvalidResponse {
-                        message: format!("failed to parse credential response: {e}").into(),
-                    });
+                return parse_credential_response(retry_response).await;
             }
 
             if let Ok(error) = serde_json::from_str::<Oid4vciError<CredentialErrorResponse>>(&body)
@@ -1267,12 +1260,7 @@ impl Oid4vciClient {
             handler.extract_and_store_nonce(&htu, response.headers());
         }
 
-        let credential_response = response.json::<CredentialResponse>().await.map_err(|e| {
-            ClientError::InvalidResponse {
-                message: format!("failed to parse credential response: {e}").into(),
-            }
-        })?;
-        Ok(credential_response)
+        parse_credential_response(response).await
     }
 
     /// Resolve the `c_nonce` to use for proof construction.
@@ -1456,40 +1444,113 @@ fn should_sign_proof<S: ProofSigner>(
     )))
 }
 
-pub fn resolve_credential_ids(token: &TokenResponse) -> Result<Vec<(&str, &[String])>> {
-    let details =
-        token
-            .authorization_details
-            .as_ref()
-            .ok_or_else(|| ClientError::InvalidResponse {
-                message: "missing authorization_details in token response".into(),
-            })?;
-
-    let mut result = Vec::with_capacity(details.len());
-
-    for detail in details {
-        let Some(ids) = detail.credential_identifiers.as_deref() else {
-            continue;
-        };
-
-        if ids.is_empty() {
-            return Err(ClientError::InvalidResponse {
-                message: format!(
-                    "authorization_details entry for '{}' contains empty credential_identifiers",
-                    detail.credential_configuration_id
-                )
-                .into(),
-            });
-        }
-        result.push((detail.credential_configuration_id.as_str(), ids));
+/// Resolve the credential requests to issue for a token response, falling back
+/// across the grant-type shapes issuers use to convey authorized credentials,
+/// per OID4VCI §6.2:
+/// 1. `authorization_details` with `credential_identifiers`.
+/// 2. `scope`, matched against `credential_configurations_supported`.
+/// 3. The credential offer's `credential_configuration_ids`.
+fn resolve_credential_targets(
+    context: &ResolvedOfferContext,
+    token: &TokenResponse,
+) -> Result<Vec<(CredIdOrCredConfigId, String)>> {
+    if let Some(resolved) = resolve_via_authorization_details(token) {
+        return Ok(resolved
+            .into_iter()
+            .flat_map(|(config_id, identifiers)| {
+                identifiers.iter().map(move |id| {
+                    (
+                        CredIdOrCredConfigId::credential_identifier(id.clone()),
+                        config_id.to_owned(),
+                    )
+                })
+            })
+            .collect());
     }
 
-    if result.is_empty() {
+    if let Some(config_ids) = resolve_via_scope(context, token) {
+        return Ok(by_credential_configuration_id(config_ids));
+    }
+
+    let offer_ids = context.offer.credential_configuration_ids.clone();
+    if offer_ids.is_empty() {
         return Err(ClientError::InvalidResponse {
-            message: "no credential_identifiers found in authorization_details".into(),
+            message: "unable to resolve credential targets: no authorization_details, \
+                scope, or offered credential_configuration_ids"
+                .into(),
         });
     }
-    Ok(result)
+    Ok(by_credential_configuration_id(offer_ids))
+}
+
+fn by_credential_configuration_id(ids: Vec<String>) -> Vec<(CredIdOrCredConfigId, String)> {
+    ids.into_iter()
+        .map(|id| {
+            (
+                CredIdOrCredConfigId::credential_configuration_id(id.clone()),
+                id,
+            )
+        })
+        .collect()
+}
+
+/// Tier 1: resolve per-credential identifiers from `authorization_details`.
+///
+/// Returns `None` when `authorization_details` is absent or carries no usable
+/// `credential_identifiers`, so the caller can fall back to scope- or offer-based
+/// resolution.
+fn resolve_via_authorization_details(token: &TokenResponse) -> Option<Vec<(&str, &[String])>> {
+    let details = token.authorization_details.as_ref()?;
+
+    let result: Vec<(&str, &[String])> = details
+        .iter()
+        .filter_map(|detail| {
+            let ids = detail.credential_identifiers.as_deref()?;
+            (!ids.is_empty()).then_some((detail.credential_configuration_id.as_str(), ids))
+        })
+        .collect();
+
+    (!result.is_empty()).then_some(result)
+}
+
+/// Tier 2: resolve credential configuration ids granted via a plain `scope`
+/// token response, matching each space-delimited scope value (RFC 6749 §3.3)
+/// against the `scope` advertised by `credential_configurations_supported`.
+///
+/// Returns `None` when the token carries no `scope`, or no advertised
+/// configuration matches a granted scope, so the caller can fall back to
+/// offer-based resolution.
+fn resolve_via_scope(context: &ResolvedOfferContext, token: &TokenResponse) -> Option<Vec<String>> {
+    let scope = token.scope.as_deref()?;
+    let granted: std::collections::HashSet<&str> = scope.split_whitespace().collect();
+
+    let mut matched: Vec<String> = context
+        .issuer_metadata
+        .credential_configurations_supported
+        .iter()
+        .filter(|(_, config)| config.scope.as_deref().is_some_and(|s| granted.contains(s)))
+        .map(|(id, _)| id.clone())
+        .collect();
+
+    if matched.is_empty() {
+        return None;
+    }
+    matched.sort();
+    Some(matched)
+}
+
+/// Resolve the `credential_configuration_id` to use for proof construction.
+///
+/// When `selector` already carries a `credential_configuration_id` (scope- or
+/// offer-based tiers), it is authoritative. Otherwise (identifier-based tier),
+/// the configuration id resolved separately from `authorization_details` is used.
+fn resolve_credential_configuration_id<'a>(
+    selector: &'a CredIdOrCredConfigId,
+    fallback_config_id: &'a str,
+) -> &'a str {
+    selector
+        .as_credential_configuration_id()
+        .unwrap_or(fallback_config_id)
 }
 
 /// Build the minimal PAR redirect URL.
@@ -1543,6 +1604,21 @@ async fn http_error_response(response: reqwest::Response) -> ClientError {
     let status = response.status().as_u16();
     let body = response.text().await.unwrap_or_default();
     ClientError::http_response(status, body)
+}
+
+/// Parse a successful credential endpoint response.
+///
+/// Reads the body as text first so a parse failure can surface the raw body
+/// for diagnostics, instead of only the serde error.
+async fn parse_credential_response(response: reqwest::Response) -> Result<CredentialResponse> {
+    let body = response
+        .text()
+        .await
+        .map_err(|e| ClientError::http("failed to read credential response body", e))?;
+
+    serde_json::from_str(&body).map_err(|e| ClientError::InvalidResponse {
+        message: format!("failed to parse credential response: {e}; body: {body}").into(),
+    })
 }
 
 impl AlgorithmIdentifier {

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -425,6 +425,19 @@ impl Oid4vciClient {
         // Build the authorization request using the base client_id.
         // The attestation sub is only substituted at the PAR/Token endpoints
         // per HAIP §4.4.1.
+        // Per OID4VCI §5.1.2 / RFC 8707: when using scope-based credential
+        // selection and the issuer delegates to a separate authorization server
+        // (authorization_servers present), the resource parameter MUST be set
+        // to the credential_issuer identifier so the AS can unambiguously route
+        // the request.  The RAR path is unaffected because authorization_details
+        // already carries `locations` in that case (see build_authorization_details).
+        let resource = if scope.is_some() && context.issuer_metadata.authorization_servers.is_some()
+        {
+            Some(context.issuer_metadata.credential_issuer.clone())
+        } else {
+            None
+        };
+
         let authz_request = AuthorizationRequest {
             response_type: OAUTH_RESPONSE_TYPE.into(),
             oauth: OAuthAuthorizationRequest {
@@ -436,7 +449,7 @@ impl Oid4vciClient {
                 code_challenge: Some(code_challenge),
                 code_challenge_method: Some(CodeChallengeMethod::S256),
             },
-            resource: None,
+            resource,
             issuer_state,
             authorization_details: authz_details,
         };
@@ -1514,7 +1527,7 @@ fn prefer_authorization_details(
 fn build_scope(context: &ResolvedOfferContext, selected_config_ids: &[String]) -> Result<String> {
     let selected_ids = selected_credential_config_ids(context, selected_config_ids)?;
 
-    let scopes: Vec<&str> = selected_ids
+    let mut scopes: Vec<&str> = selected_ids
         .iter()
         .map(|id| {
             context
@@ -1533,6 +1546,11 @@ fn build_scope(context: &ResolvedOfferContext, selected_config_ids: &[String]) -
         })
         .collect::<Result<_>>()?;
 
+    // Deduplicate: two selected configs may advertise the same scope value
+    // (OID4VCI §5.1.2 permits this).  Sending a scope token twice in the
+    // `scope` parameter is harmless per RFC 6749 §3.3 but unnecessarily noisy.
+    scopes.sort_unstable();
+    scopes.dedup();
     let scope_string = scopes.join(" ");
 
     // Log the scope→config mapping so operators can trace which credential
@@ -1674,49 +1692,58 @@ fn resolve_via_authorization_details(token: &TokenResponse) -> Option<Vec<(&str,
     Some(result)
 }
 
-/// Build the `scope → credential_configuration_id` map described in
+/// Build the `scope → [credential_configuration_id, …]` map described in
 /// OID4VCI §5.1.2.
 ///
 /// Each entry in `credential_configurations_supported` that both (a) belongs
 /// to `offer_config_ids` and (b) advertises a non-empty `scope` value
-/// contributes one entry to the returned map.  Constraining the map to the
-/// offered subset prevents scope-string collisions with unrelated
-/// configurations in the issuer's full catalog from causing the wallet to
-/// request credentials the user never selected or consented to.
+/// contributes to the returned map.  Constraining the map to the offered
+/// subset prevents scope-string collisions with unrelated configurations in
+/// the issuer's full catalog from causing the wallet to request credentials
+/// the user never selected or consented to.
 ///
-/// If the same scope value is advertised by more than one offered
-/// configuration the last one wins (which configuration ids are considered
-/// is deterministic only within a single `HashMap` iteration, so callers
-/// should not rely on ordering when duplicates are present).
+/// Per OID4VCI §5.1.2, a scope value MAY be shared by more than one
+/// credential configuration (e.g. two format variants of the same credential).
+/// When that happens every matching configuration is included in the `Vec`,
+/// so `resolve_via_scope` will request all of them when the AS grants that
+/// scope.  A structured warning is emitted so operators can observe which
+/// scope values are shared.
 pub(crate) fn build_scope_to_config_id_map(
     issuer_metadata: &CredentialIssuerMetadata,
     offer_config_ids: &[String],
-) -> std::collections::HashMap<String, String> {
+) -> std::collections::HashMap<String, Vec<String>> {
     let offered: std::collections::HashSet<&str> =
         offer_config_ids.iter().map(String::as_str).collect();
 
-    let map: std::collections::HashMap<String, String> = issuer_metadata
+    // Group config IDs by scope value; a single scope may map to multiple configs.
+    let mut map: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
+    for (id, config) in issuer_metadata
         .credential_configurations_supported
         .iter()
         .filter(|(id, _)| offered.contains(id.as_str()))
-        .filter_map(|(id, config)| config.scope.as_ref().map(|s| (s.clone(), id.clone())))
-        .collect();
+    {
+        if let Some(scope) = &config.scope {
+            map.entry(scope.clone()).or_default().push(id.clone());
+        }
+    }
 
-    // A well-formed issuer assigns each scope value to at most one credential
-    // configuration.  If two offered configs share a scope string only one will
-    // appear in the map (last writer wins in HashMap::collect).
-    let configs_with_scope = issuer_metadata
-        .credential_configurations_supported
-        .iter()
-        .filter(|(id, config)| offered.contains(id.as_str()) && config.scope.is_some())
-        .count();
-    if configs_with_scope > map.len() {
+    // Log when any scope value is shared by more than one configuration so
+    // operators can verify this is intentional (e.g. mdoc + JWT-VC variants).
+    let total_configs: usize = map.values().map(Vec::len).sum();
+    if total_configs > map.len() {
+        let mut shared_scopes: Vec<&str> = map
+            .iter()
+            .filter(|(_, ids)| ids.len() > 1)
+            .map(|(s, _)| s.as_str())
+            .collect();
+        shared_scopes.sort();
         tracing::warn!(
-            offered_with_scope = configs_with_scope,
+            offered_with_scope = total_configs,
             unique_scope_values = map.len(),
-            "issuer metadata contains duplicate scope values across offered \
-             credential configurations; only one configuration per scope value \
-             will be matched during scope-based resolution"
+            ?shared_scopes,
+            "issuer metadata contains scope values shared by multiple offered \
+             credential configurations; all matching configurations will be \
+             requested when the AS grants these scope values"
         );
     }
 
@@ -1745,7 +1772,7 @@ fn resolve_via_scope(context: &ResolvedOfferContext, token: &TokenResponse) -> O
     let mut matched: Vec<String> = scope_map
         .iter()
         .filter(|(scope_val, _)| granted.contains(scope_val.as_str()))
-        .map(|(_, config_id)| config_id.clone())
+        .flat_map(|(_, config_ids)| config_ids.iter().cloned())
         .collect();
 
     if matched.is_empty() {
@@ -1822,16 +1849,31 @@ async fn http_error_response(response: reqwest::Response) -> ClientError {
 
 /// Parse a successful credential endpoint response.
 ///
-/// Reads the body as text first so a parse failure can surface the raw body
-/// for diagnostics, instead of only the serde error.
+/// Reads the body as text first so a parse failure can surface context for
+/// diagnostics.  The body is truncated in the error message to avoid
+/// inadvertently logging credential values or PII that a credential response
+/// may contain.
 async fn parse_credential_response(response: reqwest::Response) -> Result<CredentialResponse> {
     let body = response
         .text()
         .await
         .map_err(|e| ClientError::http("failed to read credential response body", e))?;
 
-    serde_json::from_str(&body).map_err(|e| ClientError::InvalidResponse {
-        message: format!("failed to parse credential response: {e}; body: {body}").into(),
+    serde_json::from_str(&body).map_err(|e| {
+        // Credential responses can contain issued credentials or PII.
+        // Truncate rather than including the full body in an error that may
+        // propagate through log pipelines.
+        const MAX_CHARS: usize = 200;
+        let display: String = body.chars().take(MAX_CHARS).collect();
+        let suffix = if body.chars().count() > MAX_CHARS {
+            "…"
+        } else {
+            ""
+        };
+        ClientError::InvalidResponse {
+            message: format!("failed to parse credential response: {e}; body: {display}{suffix}")
+                .into(),
+        }
     })
 }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -407,9 +407,7 @@ impl Oid4vciClient {
         // it does not claim HAIP conformance for the authorization path (HAIP §4.2
         // mandates scope, and §4.3 mandates PAR, neither of which this decision
         // is based on).
-        let (authz_details, scope) = if context
-            .as_metadata
-            .supports_openid_credential_authorization_details()
+        let (authz_details, scope) = if prefer_authorization_details(context, credential_config_ids)
         {
             // Include authorization_details so the AS can return credential_identifiers
             // in the token response per §6.2
@@ -582,10 +580,7 @@ impl Oid4vciClient {
         // grant was already bound to the requested credential type when the
         // user authorized; the token request is a bare code exchange and
         // carries neither `scope` nor `authorization_details`.
-        let authz_details = if context
-            .as_metadata
-            .supports_openid_credential_authorization_details()
-        {
+        let authz_details = if prefer_authorization_details(context, credential_config_ids) {
             // Include authorization_details so the AS can return credential_identifiers
             // in the token response per §6.2
             Some(build_authorization_details(context, credential_config_ids)?)
@@ -642,15 +637,21 @@ impl Oid4vciClient {
             Some(self.attestation_client_id().to_owned())
         };
 
-        // Include authorization_details so the AS can return credential_identifiers
-        // in the token response per §6.2
-        let authz_details = build_authorization_details(context, credential_config_ids)?;
+        // Mirror the scope/RAR decision used at the authorization step (see
+        // `build_authorization_url`).  For scope-only issuers the pre-authorized
+        // code was already bound to the requested credential type via the offer;
+        // the token request carries no `authorization_details` on the scope path.
+        let authz_details = if prefer_authorization_details(context, credential_config_ids) {
+            Some(build_authorization_details(context, credential_config_ids)?)
+        } else {
+            None
+        };
 
         let request = TokenRequest::PreAuthorizedCode(PreAuthorizedCodeRequest {
             pre_authorized_code: pre_authorized_code.into(),
             client_id,
             tx_code: tx_code.map(|t| t.into()),
-            authorization_details: Some(authz_details),
+            authorization_details: authz_details,
         });
         let htu = htu_from_url(token_endpoint)?;
         let nonce = dpop.and_then(|opts| opts.get_nonce(&htu));
@@ -713,7 +714,12 @@ impl Oid4vciClient {
         let is_anonymous = context.as_metadata.allows_anonymous_pre_authorized_grant()
             && matches!(context.flow, IssuanceFlow::PreAuthorizedCode { .. });
 
-        let config_id = resolve_credential_configuration_id(&selector, credential_config_id);
+        // For config-id-addressed selectors (scope/offer tiers) the embedded id
+        // is authoritative.  For identifier-addressed selectors (RAR tier) fall
+        // back to the config id resolved from authorization_details.
+        let config_id = selector
+            .as_credential_configuration_id()
+            .unwrap_or(credential_config_id);
         let c_nonce = self.resolve_nonce(&context.issuer_metadata).await?;
         let proofs = self
             .build_proofs(context, c_nonce.as_deref(), is_anonymous, config_id, signer)
@@ -1301,9 +1307,18 @@ impl Oid4vciClient {
 
     /// Resolve the `c_nonce` to use for proof construction.
     ///
-    /// Per §8.2 and §7: priority order is:
-    /// 1. Fresh nonce from `nonce_endpoint` (if advertised in issuer metadata)
-    /// 2. `None` — issuer does not require a nonce
+    /// Per OID4VCI §8.2 / §7, priority order is:
+    /// 1. Fresh nonce from `nonce_endpoint` (if advertised in issuer metadata).
+    /// 2. `None` — issuer does not require a nonce.
+    ///
+    /// Older OID4VCI draft issuers return a `c_nonce` directly inside the
+    /// credential response (`ImmediateCredentialResponse::c_nonce`) rather than
+    /// via a dedicated endpoint.  That field is parsed and preserved on the
+    /// response type, but it is not yet consumed here as a fallback because
+    /// `request_credentials` issues all credential requests concurrently
+    /// (`FuturesUnordered`), so there is no prior response available when
+    /// each proof is being built.  Supporting nonce-chaining for sequential
+    /// credential issuance is tracked as a follow-up.
     async fn resolve_nonce(
         &self,
         issuer_metadata: &CredentialIssuerMetadata,
@@ -1441,6 +1456,53 @@ fn build_authorization_details(
         .collect()
 }
 
+/// Decide whether to use `authorization_details` (RAR, OID4VCI §5.1.1) or
+/// `scope` (OID4VCI §5.1.2) for credential selection.
+///
+/// Decision order:
+/// 1. `authorization_details_types_supported` explicitly includes
+///    `"openid_credential"` → use RAR.
+/// 2. `authorization_details_types_supported` is present but excludes
+///    `"openid_credential"` → use scope.
+/// 3. `authorization_details_types_supported` is absent (many issuers omit
+///    this RFC 9396 field):
+///    - ALL selected (or offered) credential configurations advertise a
+///      `scope` value → use scope.  Scope-only and legacy issuers typically
+///      omit RFC 9396 metadata while still populating `scope` on each config;
+///      treating published `scope` values as the presence-signal lets the
+///      wallet reach them without a manual allowlist.
+///    - Any selected config lacks a `scope` → use RAR (preserves existing
+///      behavior for issuers that support RAR without publishing the field).
+fn prefer_authorization_details(
+    context: &ResolvedOfferContext,
+    selected_config_ids: &[String],
+) -> bool {
+    match &context.as_metadata.authorization_details_types_supported {
+        Some(types) => types.iter().any(|t| t == "openid_credential"),
+        None => {
+            let effective_ids: &[String] = if selected_config_ids.is_empty() {
+                &context.offer.credential_configuration_ids
+            } else {
+                selected_config_ids
+            };
+            // No configs to inspect: cannot infer scope support, default to RAR.
+            if effective_ids.is_empty() {
+                return true;
+            }
+            // If every config being requested publishes a `scope` value, the
+            // issuer signals scope support — use scope.  Otherwise fall back to
+            // RAR (backward compatible for issuers with no `scope` metadata).
+            !effective_ids.iter().all(|id| {
+                context
+                    .issuer_metadata
+                    .credential_configurations_supported
+                    .get(id)
+                    .is_some_and(|c| c.scope.is_some())
+            })
+        }
+    }
+}
+
 /// Build the `scope` authorization parameter for credential selection,
 /// per OID4VCI §5.1.2, for use when the AS cannot be relied on to accept
 /// `authorization_details` (see `build_authorization_url`).
@@ -1471,7 +1533,17 @@ fn build_scope(context: &ResolvedOfferContext, selected_config_ids: &[String]) -
         })
         .collect::<Result<_>>()?;
 
-    Ok(scopes.join(" "))
+    let scope_string = scopes.join(" ");
+
+    // Log the scope→config mapping so operators can trace which credential
+    // configuration ids were resolved to which scope values (issue observability AC).
+    tracing::debug!(
+        scope = %scope_string,
+        config_ids = ?selected_ids,
+        "scope-based credential selection: using scope parameter"
+    );
+
+    Ok(scope_string)
 }
 
 /// Negotiate the proof algorithm for a credential request.
@@ -1568,6 +1640,10 @@ fn by_credential_configuration_id(ids: Vec<String>) -> Vec<(CredIdOrCredConfigId
 /// Returns `None` when `authorization_details` is absent or carries no usable
 /// `credential_identifiers`, so the caller can fall back to scope- or offer-based
 /// resolution.
+///
+/// When `authorization_details` is present but yields no identifiers, a warning
+/// is emitted so an operator can distinguish a spec-violating AS response from
+/// the ordinary "AS does not use RAR" case where the field is simply absent.
 fn resolve_via_authorization_details(token: &TokenResponse) -> Option<Vec<(&str, &[String])>> {
     let details = token.authorization_details.as_ref()?;
 
@@ -1579,47 +1655,116 @@ fn resolve_via_authorization_details(token: &TokenResponse) -> Option<Vec<(&str,
         })
         .collect();
 
-    (!result.is_empty()).then_some(result)
+    if result.is_empty() {
+        // `authorization_details` was present — the AS signalled RAR intent —
+        // but not a single entry carried usable `credential_identifiers`.
+        // Per OID4VCI §6.2, a RAR-capable AS MUST populate `credential_identifiers`
+        // in the token response when it accepted `authorization_details` at the
+        // authorization step.  An empty or identifier-free response is either a
+        // spec violation or a sign the AS does not implement that part of the flow.
+        tracing::warn!(
+            entry_count = details.len(),
+            "RAR tier: authorization_details present in token response but contains \
+             no credential_identifiers; falling back to scope/offer resolution. \
+             If this issuer supports RAR, this may indicate a malformed AS response."
+        );
+        return None;
+    }
+
+    Some(result)
+}
+
+/// Build the `scope → credential_configuration_id` map described in
+/// OID4VCI §5.1.2.
+///
+/// Each entry in `credential_configurations_supported` that both (a) belongs
+/// to `offer_config_ids` and (b) advertises a non-empty `scope` value
+/// contributes one entry to the returned map.  Constraining the map to the
+/// offered subset prevents scope-string collisions with unrelated
+/// configurations in the issuer's full catalog from causing the wallet to
+/// request credentials the user never selected or consented to.
+///
+/// If the same scope value is advertised by more than one offered
+/// configuration the last one wins (which configuration ids are considered
+/// is deterministic only within a single `HashMap` iteration, so callers
+/// should not rely on ordering when duplicates are present).
+pub(crate) fn build_scope_to_config_id_map(
+    issuer_metadata: &CredentialIssuerMetadata,
+    offer_config_ids: &[String],
+) -> std::collections::HashMap<String, String> {
+    let offered: std::collections::HashSet<&str> =
+        offer_config_ids.iter().map(String::as_str).collect();
+
+    let map: std::collections::HashMap<String, String> = issuer_metadata
+        .credential_configurations_supported
+        .iter()
+        .filter(|(id, _)| offered.contains(id.as_str()))
+        .filter_map(|(id, config)| config.scope.as_ref().map(|s| (s.clone(), id.clone())))
+        .collect();
+
+    // A well-formed issuer assigns each scope value to at most one credential
+    // configuration.  If two offered configs share a scope string only one will
+    // appear in the map (last writer wins in HashMap::collect).
+    let configs_with_scope = issuer_metadata
+        .credential_configurations_supported
+        .iter()
+        .filter(|(id, config)| offered.contains(id.as_str()) && config.scope.is_some())
+        .count();
+    if configs_with_scope > map.len() {
+        tracing::warn!(
+            offered_with_scope = configs_with_scope,
+            unique_scope_values = map.len(),
+            "issuer metadata contains duplicate scope values across offered \
+             credential configurations; only one configuration per scope value \
+             will be matched during scope-based resolution"
+        );
+    }
+
+    map
 }
 
 /// Tier 2: resolve credential configuration ids granted via a plain `scope`
-/// token response, matching each space-delimited scope value (RFC 6749 §3.3)
-/// against the `scope` advertised by `credential_configurations_supported`.
+/// token response, using the scope → config-id map built from the issuer's
+/// `credential_configurations_supported` (OID4VCI §5.1.2, RFC 6749 §3.3).
 ///
-/// Returns `None` when the token carries no `scope`, or no advertised
+/// Only configurations that were part of the original credential offer are
+/// considered — see [`build_scope_to_config_id_map`].
+///
+/// Returns `None` when the token carries no `scope`, or no offered
 /// configuration matches a granted scope, so the caller can fall back to
 /// offer-based resolution.
 fn resolve_via_scope(context: &ResolvedOfferContext, token: &TokenResponse) -> Option<Vec<String>> {
     let scope = token.scope.as_deref()?;
     let granted: std::collections::HashSet<&str> = scope.split_whitespace().collect();
 
-    let mut matched: Vec<String> = context
-        .issuer_metadata
-        .credential_configurations_supported
+    let scope_map = build_scope_to_config_id_map(
+        &context.issuer_metadata,
+        &context.offer.credential_configuration_ids,
+    );
+
+    let mut matched: Vec<String> = scope_map
         .iter()
-        .filter(|(_, config)| config.scope.as_deref().is_some_and(|s| granted.contains(s)))
-        .map(|(id, _)| id.clone())
+        .filter(|(scope_val, _)| granted.contains(scope_val.as_str()))
+        .map(|(_, config_id)| config_id.clone())
         .collect();
 
     if matched.is_empty() {
+        tracing::debug!(
+            granted_scope = scope,
+            "scope tier: no offered credential configurations matched granted scope"
+        );
         return None;
     }
+
+    tracing::debug!(
+        granted_scope = scope,
+        matched_config_ids = ?matched,
+        "scope tier: resolved {} credential configuration(s) from granted scope",
+        matched.len()
+    );
+
     matched.sort();
     Some(matched)
-}
-
-/// Resolve the `credential_configuration_id` to use for proof construction.
-///
-/// When `selector` already carries a `credential_configuration_id` (scope- or
-/// offer-based tiers), it is authoritative. Otherwise (identifier-based tier),
-/// the configuration id resolved separately from `authorization_details` is used.
-fn resolve_credential_configuration_id<'a>(
-    selector: &'a CredIdOrCredConfigId,
-    fallback_config_id: &'a str,
-) -> &'a str {
-    selector
-        .as_credential_configuration_id()
-        .unwrap_or(fallback_config_id)
 }
 
 /// Build the minimal PAR redirect URL.

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/mod.rs
@@ -399,9 +399,26 @@ impl Oid4vciClient {
                 message: "authorization server does not have an authorization endpoint".into(),
             })?;
 
-        // Include authorization_details so the AS can return credential_identifiers
-        // in the token response per §6.2
-        let authz_details = build_authorization_details(context, credential_config_ids)?;
+        // Resolve which credential-selection mechanism to use, per OID4VCI §5.1.
+        // RAR is preferred when the AS can be relied on to accept it, because it
+        // additionally lets the AS return per-credential `credential_identifiers`
+        // in the token response (§6.2), which is what `resolve_credential_targets`
+        // checks first. This preference is grounded in the base OID4VCI spec only;
+        // it does not claim HAIP conformance for the authorization path (HAIP §4.2
+        // mandates scope, and §4.3 mandates PAR, neither of which this decision
+        // is based on).
+        let (authz_details, scope) = if context
+            .as_metadata
+            .supports_openid_credential_authorization_details()
+        {
+            // Include authorization_details so the AS can return credential_identifiers
+            // in the token response per §6.2
+            let details = build_authorization_details(context, credential_config_ids)?;
+            (Some(details), None)
+        } else {
+            let scope = build_scope(context, credential_config_ids)?;
+            (None, Some(scope))
+        };
 
         // Generate PKCE parameters
         let pkce_verifier = generate_pkce_verifier();
@@ -416,14 +433,14 @@ impl Oid4vciClient {
                 client_id: self.base_client_id().to_owned(),
                 redirect_uri: Some(self.inner_client.config().redirect_uri.clone()),
                 state: Some(state.into()),
-                scope: None,
+                scope,
                 nonce: None,
                 code_challenge: Some(code_challenge),
                 code_challenge_method: Some(CodeChallengeMethod::S256),
             },
             resource: None,
             issuer_state,
-            authorization_details: Some(authz_details),
+            authorization_details: authz_details,
         };
 
         let authz_url = if context
@@ -560,16 +577,28 @@ impl Oid4vciClient {
             ClientError::configuration("authorization server does not have a token endpoint")
         })?;
 
-        // Include authorization_details so the AS can return credential_identifiers
-        // in the token response per §6.2
-        let authz_details = build_authorization_details(context, credential_config_ids)?;
+        // Mirror the credential-selection mechanism used at the authorization
+        // endpoint (see `build_authorization_url`). On the scope path, the
+        // grant was already bound to the requested credential type when the
+        // user authorized; the token request is a bare code exchange and
+        // carries neither `scope` nor `authorization_details`.
+        let authz_details = if context
+            .as_metadata
+            .supports_openid_credential_authorization_details()
+        {
+            // Include authorization_details so the AS can return credential_identifiers
+            // in the token response per §6.2
+            Some(build_authorization_details(context, credential_config_ids)?)
+        } else {
+            None
+        };
 
         let request = TokenRequest::AuthorizationCode(AuthorizationCodeRequest {
             code: code.into(),
             redirect_uri: Some(self.inner_client.config().redirect_uri.clone()),
             client_id: self.attestation_client_id().to_owned(),
             code_verifier: Some(pkce_verifier.into()),
-            authorization_details: Some(authz_details),
+            authorization_details: authz_details,
         });
         let htu = htu_from_url(token_endpoint)?;
         let nonce = dpop.and_then(|opts| opts.get_nonce(&htu));
@@ -727,7 +756,14 @@ impl Oid4vciClient {
         let mut futures = FuturesUnordered::new();
 
         for (selector, config_id) in &targets {
-            futures.push(self.request_credential(context, token, selector.clone(), config_id, signer, dpop));
+            futures.push(self.request_credential(
+                context,
+                token,
+                selector.clone(),
+                config_id,
+                signer,
+                dpop,
+            ));
         }
 
         while let Some(res) = futures.next().await {
@@ -1403,6 +1439,39 @@ fn build_authorization_details(
             Ok(detail)
         })
         .collect()
+}
+
+/// Build the `scope` authorization parameter for credential selection,
+/// per OID4VCI §5.1.2, for use when the AS cannot be relied on to accept
+/// `authorization_details` (see `build_authorization_url`).
+///
+/// Every selected credential configuration must advertise a `scope` value
+/// in `credential_configurations_supported`; if any does not, scope-based
+/// selection cannot represent the full selection, so this fails rather than
+/// silently omitting that credential from the request.
+fn build_scope(context: &ResolvedOfferContext, selected_config_ids: &[String]) -> Result<String> {
+    let selected_ids = selected_credential_config_ids(context, selected_config_ids)?;
+
+    let scopes: Vec<&str> = selected_ids
+        .iter()
+        .map(|id| {
+            context
+                .issuer_metadata
+                .credential_configurations_supported
+                .get(id)
+                .and_then(|config| config.scope.as_deref())
+                .ok_or_else(|| ClientError::Configuration {
+                    message: format!(
+                        "credential configuration '{id}' has no scope and the authorization \
+                         server does not support authorization_details: \
+                         unable to request this credential"
+                    )
+                    .into(),
+                })
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(scopes.join(" "))
 }
 
 /// Negotiate the proof algorithm for a credential request.

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
@@ -1241,8 +1241,14 @@ fn scope_map_contains_offered_configs_with_scope() {
 
     let map = build_scope_to_config_id_map(&issuer_metadata, &offer_ids);
 
-    assert_eq!(map.get("scope_a").map(String::as_str), Some("CredA"));
-    assert_eq!(map.get("scope_b").map(String::as_str), Some("CredB"));
+    assert_eq!(
+        map.get("scope_a").map(Vec::as_slice),
+        Some(["CredA".to_string()].as_slice())
+    );
+    assert_eq!(
+        map.get("scope_b").map(Vec::as_slice),
+        Some(["CredB".to_string()].as_slice())
+    );
     assert!(
         !map.contains_key("scope_not_offered"),
         "CredNotOffered is not in the offer and must not appear in the map"
@@ -1252,6 +1258,29 @@ fn scope_map_contains_offered_configs_with_scope() {
         2,
         "CredNoScope has no scope value and must be excluded"
     );
+}
+
+#[test]
+fn scope_map_groups_multiple_configs_under_shared_scope() {
+    // OID4VCI §5.1.2 permits a scope value to appear on more than one
+    // credential configuration (e.g. mdoc + JWT-VC variants of the same
+    // credential).  Both config IDs must be present in the Vec.
+    let issuer_url = "https://issuer.example.com";
+    let issuer_metadata = issuer_metadata_with_configs(
+        issuer_url,
+        &[
+            ("CredMdoc", Some("identity")),
+            ("CredJwt", Some("identity")),
+        ],
+    );
+    let offer_ids = vec!["CredMdoc".to_string(), "CredJwt".to_string()];
+
+    let map = build_scope_to_config_id_map(&issuer_metadata, &offer_ids);
+
+    assert_eq!(map.len(), 1, "both configs share one scope key");
+    let mut ids = map["identity"].clone();
+    ids.sort();
+    assert_eq!(ids, vec!["CredJwt".to_string(), "CredMdoc".to_string()]);
 }
 
 #[test]
@@ -1295,7 +1324,8 @@ fn build_scope_joins_scopes_of_selected_configurations() {
     )
     .expect("scope should build when every selected config has a scope");
 
-    assert_eq!(scope, "university_degree drivers_license");
+    // Scopes are sorted and deduplicated before joining (see build_scope).
+    assert_eq!(scope, "drivers_license university_degree");
 }
 
 #[test]
@@ -1327,6 +1357,59 @@ fn build_scope_errors_when_a_selected_configuration_has_no_scope() {
         ],
     );
     assert!(result.is_err());
+}
+
+#[test]
+fn build_scope_deduplicates_when_two_configs_share_a_scope() {
+    // Two configs (e.g. mdoc + JWT-VC) sharing the same scope value should
+    // produce only one occurrence of that scope in the scope string.
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("CredMdoc", Some("identity")),
+                ("CredJwt", Some("identity")),
+            ],
+        ),
+        vec!["CredMdoc".to_string(), "CredJwt".to_string()],
+    );
+
+    let scope = build_scope(&context, &["CredMdoc".to_string(), "CredJwt".to_string()])
+        .expect("scope should build");
+
+    assert_eq!(
+        scope, "identity",
+        "duplicate scope value must appear only once"
+    );
+}
+
+#[test]
+fn resolve_via_scope_returns_all_configs_for_shared_scope() {
+    // When two offered configs share a scope value and the AS grants that
+    // scope, the wallet must request BOTH credentials — not silently drop one.
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("CredMdoc", Some("identity")),
+                ("CredJwt", Some("identity")),
+            ],
+        ),
+        vec!["CredMdoc".to_string(), "CredJwt".to_string()],
+    );
+    let token = token_response(Some("identity"), None);
+
+    let mut matched = resolve_via_scope(&context, &token).expect("scope tier should resolve");
+    matched.sort();
+    assert_eq!(
+        matched,
+        vec!["CredJwt".to_string(), "CredMdoc".to_string()],
+        "all configurations sharing the granted scope must be returned"
+    );
 }
 
 //  build_authorization_url: RAR vs scope preference
@@ -1452,6 +1535,129 @@ async fn build_authorization_url_errors_when_neither_rar_nor_scope_available() {
 }
 
 #[tokio::test]
+async fn build_authorization_url_sets_resource_when_scope_path_and_authorization_servers_present() {
+    // OID4VCI §5.1.2 / RFC 8707: when the issuer delegates authorization to a
+    // separate AS (authorization_servers present) and scope-based selection is
+    // used, the resource parameter MUST be set to credential_issuer so the AS
+    // can route the request to the correct issuer.
+    let issuer_url = "https://issuer.example.com";
+    let as_url = "https://as.example.com";
+
+    let mut issuer_metadata = issuer_metadata_with_configs(
+        issuer_url,
+        &[("UniversityDegreeCredential", Some("university_degree"))],
+    );
+    issuer_metadata.authorization_servers = Some(vec![Url::parse(as_url).unwrap()]);
+
+    // AS does not advertise RAR — scope path will be taken.
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata,
+        vec!["UniversityDegreeCredential".to_string()],
+        Some(vec!["some_other_type".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await
+        .expect("should build authorization url");
+
+    let params = query_pairs(&result.authz_url);
+    assert_eq!(
+        params.get("scope").map(String::as_str),
+        Some("university_degree"),
+        "scope path must include scope param, got: {params:?}"
+    );
+    let resource = params.get("resource").expect(
+        "resource must be set when authorization_servers is present and scope path is taken",
+    );
+    assert!(
+        resource.starts_with(issuer_url),
+        "resource must be the credential_issuer, got: {resource}"
+    );
+}
+
+#[tokio::test]
+async fn build_authorization_url_omits_resource_when_no_authorization_servers() {
+    // When authorization_servers is absent the credential issuer IS the AS —
+    // no resource indicator is needed.
+    let issuer_url = "https://issuer.example.com";
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
+        vec!["UniversityDegreeCredential".to_string()],
+        Some(vec!["some_other_type".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await
+        .expect("should build authorization url");
+
+    let params = query_pairs(&result.authz_url);
+    assert!(
+        !params.contains_key("resource"),
+        "resource must not be set when authorization_servers is absent, got: {params:?}"
+    );
+}
+
+#[tokio::test]
+async fn build_authorization_url_omits_resource_on_rar_path_even_when_authorization_servers_present()
+ {
+    // On the RAR path, locations already carries the issuer identifier inside
+    // authorization_details; adding resource would be redundant.
+    let issuer_url = "https://issuer.example.com";
+    let as_url = "https://as.example.com";
+
+    let mut issuer_metadata = issuer_metadata_with_configs(
+        issuer_url,
+        &[("UniversityDegreeCredential", Some("university_degree"))],
+    );
+    issuer_metadata.authorization_servers = Some(vec![Url::parse(as_url).unwrap()]);
+
+    // AS explicitly supports RAR — RAR path will be taken.
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata,
+        vec!["UniversityDegreeCredential".to_string()],
+        Some(vec!["openid_credential".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await
+        .expect("should build authorization url");
+
+    let params = query_pairs(&result.authz_url);
+    assert!(
+        params.contains_key("authorization_details"),
+        "expected RAR path, got: {params:?}"
+    );
+    assert!(
+        !params.contains_key("resource"),
+        "resource must not be set on RAR path (locations is used instead), got: {params:?}"
+    );
+}
+
+#[tokio::test]
 async fn credential_response_parse_failure_includes_raw_body() {
     let mock_server = setup_mock_server().await;
     let issuer_url = mock_server.uri();
@@ -1484,6 +1690,50 @@ async fn credential_response_parse_failure_includes_raw_body() {
     assert!(
         message.contains("not valid json"),
         "error should include the raw response body, got: {message}"
+    );
+}
+
+#[tokio::test]
+async fn credential_response_parse_failure_truncates_long_body() {
+    let mock_server = setup_mock_server().await;
+    let issuer_url = mock_server.uri();
+
+    // Body longer than the 200-char truncation limit; must appear truncated
+    // in the error message to avoid logging credential data or PII.
+    let long_body = "x".repeat(300);
+    Mock::given(method("POST"))
+        .and(path("/credential"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(long_body.clone()))
+        .mount(&mock_server)
+        .await;
+
+    let client = create_client();
+    let mut issuer_metadata =
+        issuer_metadata_with_configs(&issuer_url, &[("TestCredential", None)]);
+    issuer_metadata.credential_endpoint = Url::parse(&format!("{issuer_url}/credential")).unwrap();
+    let context = minimal_context(
+        &issuer_url,
+        issuer_metadata,
+        vec!["TestCredential".to_string()],
+    );
+    let token = token_response(None, None);
+    let signer = get_ecdsa_signer();
+
+    let selector = CredIdOrCredConfigId::credential_configuration_id("TestCredential");
+    let result = client
+        .request_credential(&context, &token, selector, "TestCredential", &signer, None)
+        .await;
+
+    let err = result.expect_err("expected a parse failure");
+    let message = err.to_string();
+    assert!(
+        message.contains('…'),
+        "error message must contain the truncation ellipsis for long bodies, got: {message}"
+    );
+    assert!(
+        !message.contains(&long_body),
+        "error message must not contain the full long body, got message length {}",
+        message.len()
     );
 }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
@@ -547,6 +547,281 @@ fn minimal_issuer_metadata(issuer_url: &str) -> CredentialIssuerMetadata {
     }
 }
 
+/// Builds issuer metadata with one `CredentialConfiguration` entry per
+/// `(config_id, scope)` pair, for exercising scope-based resolution.
+fn issuer_metadata_with_configs(
+    issuer_url: &str,
+    configs: &[(&str, Option<&str>)],
+) -> CredentialIssuerMetadata {
+    let mut metadata = minimal_issuer_metadata(issuer_url);
+    metadata.credential_configurations_supported = configs
+        .iter()
+        .map(|(id, scope)| {
+            (
+                id.to_string(),
+                CredentialConfiguration {
+                    id: None,
+                    format_details: CredentialFormatDetails::JwtVcJson(
+                        JwtVcJsonCredentialConfiguration {
+                            credential_definition: CredentialDefinition {
+                                types: vec!["TestType".to_string()],
+                            },
+                        },
+                    ),
+                    scope: scope.map(str::to_string),
+                    cryptographic_binding_methods_supported: None,
+                    credential_signing_alg_values_supported: None,
+                    proof_types_supported: None,
+                    credential_metadata: None,
+                },
+            )
+        })
+        .collect();
+    metadata
+}
+
+fn minimal_offer(issuer_url: &str, credential_configuration_ids: Vec<String>) -> CredentialOffer {
+    CredentialOffer {
+        credential_issuer: Url::parse(issuer_url).unwrap(),
+        credential_configuration_ids,
+        grants: None,
+    }
+}
+
+fn minimal_context(
+    issuer_url: &str,
+    issuer_metadata: CredentialIssuerMetadata,
+    offer_config_ids: Vec<String>,
+) -> ResolvedOfferContext {
+    ResolvedOfferContext {
+        offer: minimal_offer(issuer_url, offer_config_ids),
+        issuer_metadata,
+        as_metadata: minimal_as_metadata(&format!("{issuer_url}/par")),
+        flow: IssuanceFlow::PreAuthorizedCode {
+            pre_authorized_code: "test_code".to_string(),
+            tx_code: None,
+        },
+    }
+}
+
+fn token_response(scope: Option<&str>, authorization_details: Option<Vec<AuthorizationDetails>>) -> TokenResponse {
+    TokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: Some(3600),
+        refresh_token: None,
+        scope: scope.map(str::to_string),
+        authorization_details,
+    }
+}
+
+#[test]
+fn resolve_via_authorization_details_returns_none_when_absent() {
+    let token = token_response(None, None);
+    assert!(resolve_via_authorization_details(&token).is_none());
+}
+
+#[test]
+fn resolve_via_authorization_details_skips_entries_without_identifiers() {
+    let details = AuthorizationDetails::for_configuration("NoIds");
+    let token = token_response(None, Some(vec![details]));
+
+    assert!(resolve_via_authorization_details(&token).is_none());
+}
+
+#[test]
+fn resolve_via_authorization_details_returns_targets_when_identifiers_present() {
+    let mut details = AuthorizationDetails::for_configuration("UniversityDegreeCredential");
+    details.credential_identifiers = Some(vec!["cred-1".to_string(), "cred-2".to_string()]);
+    let token = token_response(None, Some(vec![details]));
+
+    let resolved = resolve_via_authorization_details(&token).expect("tier 1 should resolve");
+    assert_eq!(resolved.len(), 1);
+    let (config_id, ids) = resolved[0];
+    assert_eq!(config_id, "UniversityDegreeCredential");
+    assert_eq!(ids, &["cred-1".to_string(), "cred-2".to_string()]);
+}
+
+#[test]
+fn resolve_via_scope_returns_none_when_no_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        vec!["UniversityDegreeCredential".to_string()],
+    );
+    let token = token_response(None, None);
+
+    assert!(resolve_via_scope(&context, &token).is_none());
+}
+
+#[test]
+fn resolve_via_scope_returns_none_when_no_configuration_matches() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        vec!["UniversityDegreeCredential".to_string()],
+    );
+    let token = token_response(Some("unrelated_scope"), None);
+
+    assert!(resolve_via_scope(&context, &token).is_none());
+}
+
+#[test]
+fn resolve_via_scope_matches_configurations_by_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("UniversityDegreeCredential", Some("university_degree")),
+                ("DriversLicenseCredential", Some("drivers_license")),
+                ("UnrelatedCredential", Some("unrelated")),
+            ],
+        ),
+        vec![
+            "UniversityDegreeCredential".to_string(),
+            "DriversLicenseCredential".to_string(),
+        ],
+    );
+    // Scopes are space-delimited per RFC 6749 §3.3.
+    let token = token_response(Some("university_degree drivers_license"), None);
+
+    let mut matched = resolve_via_scope(&context, &token).expect("tier 2 should resolve");
+    matched.sort();
+    assert_eq!(
+        matched,
+        vec![
+            "DriversLicenseCredential".to_string(),
+            "UniversityDegreeCredential".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn resolve_credential_targets_uses_authorization_details_when_present() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", None)]),
+        vec!["UniversityDegreeCredential".to_string()],
+    );
+    let mut details = AuthorizationDetails::for_configuration("UniversityDegreeCredential");
+    details.credential_identifiers = Some(vec!["cred-1".to_string()]);
+    let token = token_response(Some("ignored_scope"), Some(vec![details]));
+
+    let targets = resolve_credential_targets(&context, &token).expect("should resolve");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].0.as_credential_identifier(), Some("cred-1"));
+    assert_eq!(targets[0].1, "UniversityDegreeCredential");
+}
+
+#[test]
+fn resolve_credential_targets_falls_back_to_scope_when_no_authorization_details() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        vec!["UniversityDegreeCredential".to_string()],
+    );
+    let token = token_response(Some("university_degree"), None);
+
+    let targets = resolve_credential_targets(&context, &token).expect("should resolve");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(
+        targets[0].0.as_credential_configuration_id(),
+        Some("UniversityDegreeCredential")
+    );
+    assert_eq!(targets[0].1, "UniversityDegreeCredential");
+}
+
+#[test]
+fn resolve_credential_targets_falls_back_to_offer_when_no_authorization_details_or_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", None)]),
+        vec!["UniversityDegreeCredential".to_string()],
+    );
+    let token = token_response(None, None);
+
+    let targets = resolve_credential_targets(&context, &token).expect("should resolve");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(
+        targets[0].0.as_credential_configuration_id(),
+        Some("UniversityDegreeCredential")
+    );
+}
+
+#[test]
+fn resolve_credential_targets_errors_when_nothing_resolvable() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", None)]),
+        vec![],
+    );
+    let token = token_response(None, None);
+
+    let result = resolve_credential_targets(&context, &token);
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_credential_configuration_id_prefers_config_based_selector() {
+    let selector = CredIdOrCredConfigId::credential_configuration_id("FromSelector");
+    assert_eq!(
+        resolve_credential_configuration_id(&selector, "FromFallback"),
+        "FromSelector"
+    );
+}
+
+#[test]
+fn resolve_credential_configuration_id_falls_back_for_identifier_selector() {
+    let selector = CredIdOrCredConfigId::credential_identifier("cred-1");
+    assert_eq!(
+        resolve_credential_configuration_id(&selector, "FromFallback"),
+        "FromFallback"
+    );
+}
+
+#[tokio::test]
+async fn credential_response_parse_failure_includes_raw_body() {
+    let mock_server = setup_mock_server().await;
+    let issuer_url = mock_server.uri();
+
+    Mock::given(method("POST"))
+        .and(path("/credential"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("not valid json"))
+        .mount(&mock_server)
+        .await;
+
+    let client = create_client();
+    let mut issuer_metadata = issuer_metadata_with_configs(&issuer_url, &[("TestCredential", None)]);
+    issuer_metadata.credential_endpoint = Url::parse(&format!("{issuer_url}/credential")).unwrap();
+    let context = minimal_context(
+        &issuer_url,
+        issuer_metadata,
+        vec!["TestCredential".to_string()],
+    );
+    let token = token_response(None, None);
+    let signer = get_ecdsa_signer();
+
+    let selector = CredIdOrCredConfigId::credential_configuration_id("TestCredential");
+    let result = client
+        .request_credential(&context, &token, selector, "TestCredential", &signer, None)
+        .await;
+
+    let err = result.expect_err("expected a parse failure");
+    let message = err.to_string();
+    assert!(
+        message.contains("not valid json"),
+        "error should include the raw response body, got: {message}"
+    );
+}
+
 fn minimal_authz_request() -> AuthorizationRequest {
     AuthorizationRequest {
         response_type: "code".to_string(),

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
@@ -424,6 +424,422 @@ async fn test_issuance_flow() {
     }
 }
 
+/// Integration test: end-to-end scope-based issuance with a mock AS that
+/// explicitly does not support `authorization_details` for OID4VCI credentials.
+///
+/// Covers the acceptance criterion: "Integration test: end-to-end flow with a
+/// mock AS that only supports scope-based auth."
+///
+/// The test verifies:
+/// 1. The AS metadata declares `authorization_details_types_supported` without
+///    `"openid_credential"`, so the scope path is chosen.
+/// 2. The token response carries `scope` (no `authorization_details`).
+/// 3. `resolve_credential_targets` falls through to tier 2 (scope) and
+///    addresses the credential endpoint with `credential_configuration_id`.
+/// 4. `request_credentials` successfully parses and returns the credential.
+#[tokio::test]
+async fn test_scope_based_issuance_flow() {
+    let mock_server = setup_mock_server().await;
+    let issuer_url = mock_server.uri();
+
+    // Mock Issuer Metadata — credential config advertises a scope value.
+    let metadata_json = serde_json::json!({
+        "credential_issuer": issuer_url,
+        "credential_endpoint": format!("{issuer_url}/credential"),
+        "nonce_endpoint": format!("{issuer_url}/nonce"),
+        "authorization_servers": [issuer_url],
+        "credential_configurations_supported": {
+            "UniversityDegreeCredential": {
+                "format": "jwt_vc_json",
+                "scope": "university_degree",
+                "cryptographic_binding_methods_supported": ["jwk"],
+                "credential_signing_alg_values_supported": ["ES256"],
+                "proof_types_supported": {
+                    "jwt": {
+                        "proof_signing_alg_values_supported": ["ES256"]
+                    }
+                }
+            }
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/.well-known/openid-credential-issuer"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(metadata_json))
+        .mount(&mock_server)
+        .await;
+
+    // Mock AS Metadata — AS explicitly does NOT support openid_credential RAR.
+    // This forces the scope-based path in build_authorization_url /
+    // exchange_authorization_code.
+    let as_metadata_json = serde_json::json!({
+        "issuer": issuer_url.replace("http://", "https://"),
+        "authorization_endpoint": format!("{issuer_url}/authorize").replace("http://", "https://"),
+        "token_endpoint": format!("{issuer_url}/token").replace("http://", "https://"),
+        "pushed_authorization_request_endpoint": format!("{issuer_url}/par").replace("http://", "https://"),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["authorization_code", "urn:ietf:params:oauth:grant-type:pre-authorized_code"],
+        "code_challenge_methods_supported": ["S256"],
+        // Present but does NOT include "openid_credential" → wallet must use scope.
+        "authorization_details_types_supported": ["some_other_rar_type"]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(as_metadata_json))
+        .mount(&mock_server)
+        .await;
+
+    // Mock Token Response — AS returns granted `scope`, no `authorization_details`.
+    // This is the shape a scope-only AS produces (OID4VCI §6.2 tier 2).
+    let token_response_json = serde_json::json!({
+        "access_token": "scope_access_token_xyz",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+        "scope": "university_degree"
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(token_response_json))
+        .mount(&mock_server)
+        .await;
+
+    // Mock Nonce Response.
+    Mock::given(method("POST"))
+        .and(path("/nonce"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"c_nonce": "scope-test-nonce"})),
+        )
+        .mount(&mock_server)
+        .await;
+
+    // Mock Credential Endpoint — expects a request with credential_configuration_id
+    // (scope/offer tier uses config id, not credential identifier).
+    let credential_response_json = serde_json::json!({
+        "credentials": [{"credential": "scope_issued_credential_jwt"}]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/credential"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(credential_response_json))
+        .mount(&mock_server)
+        .await;
+
+    let client = create_client();
+
+    // Build context the same way test_issuance_flow does (fetch real metadata,
+    // then patch endpoints back to HTTP for reqwest to reach the mock server).
+    let offer = CredentialOffer {
+        credential_issuer: Url::parse(&issuer_url).unwrap(),
+        credential_configuration_ids: vec!["UniversityDegreeCredential".to_string()],
+        grants: Some(Grants {
+            authorization_code: None,
+            pre_authorized_code: Some(PreAuthorizedCodeGrant {
+                pre_authorized_code: "scope_pre_auth_code".to_string(),
+                tx_code: None,
+                authorization_server: None,
+            }),
+        }),
+    };
+
+    let issuer_metadata = client
+        .fetch_issuer_metadata(&Url::parse(&issuer_url).unwrap())
+        .await
+        .unwrap();
+
+    let mut as_metadata = client
+        .fetch_as_metadata(&Url::parse(&issuer_url).unwrap(), &issuer_metadata, &offer)
+        .await
+        .unwrap();
+
+    as_metadata.token_endpoint = Some(Url::parse(&format!("{issuer_url}/token")).unwrap());
+    as_metadata.pushed_authorization_request_endpoint =
+        Some(Url::parse(&format!("{issuer_url}/par")).unwrap());
+
+    let mut issuer_metadata = issuer_metadata;
+    issuer_metadata.credential_endpoint = Url::parse(&format!("{issuer_url}/credential")).unwrap();
+    issuer_metadata.nonce_endpoint = Some(Url::parse(&format!("{issuer_url}/nonce")).unwrap());
+
+    let context = ResolvedOfferContext {
+        offer,
+        issuer_metadata,
+        as_metadata,
+        flow: IssuanceFlow::PreAuthorizedCode {
+            pre_authorized_code: "scope_pre_auth_code".to_string(),
+            tx_code: None,
+        },
+    };
+
+    // Exchange token — scope-based issuers don't need authorization_details in
+    // the token request; any AS-side RAR rejection would surface here.
+    let token = client
+        .exchange_pre_authorized_code(
+            &context,
+            "scope_pre_auth_code",
+            None::<String>,
+            &["UniversityDegreeCredential".to_string()],
+            None,
+        )
+        .await
+        .expect("token exchange should succeed");
+
+    assert_eq!(token.access_token, "scope_access_token_xyz");
+    assert_eq!(token.scope.as_deref(), Some("university_degree"));
+    assert!(
+        token.authorization_details.is_none(),
+        "scope-only AS must not return authorization_details"
+    );
+
+    // Verify the token REQUEST sent to /token did not contain authorization_details.
+    // This is the machine-checkable proof that exchange_pre_authorized_code respects
+    // the scope path and does not pollute scope-only ASes with unsupported RAR params.
+    let token_requests: Vec<_> = mock_server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.url.path() == "/token")
+        .collect();
+    assert_eq!(
+        token_requests.len(),
+        1,
+        "expected exactly one /token request"
+    );
+    let token_body = std::str::from_utf8(&token_requests[0].body).unwrap();
+    assert!(
+        !token_body.contains("authorization_details"),
+        "scope-path token request must not include authorization_details; body: {token_body}"
+    );
+
+    let signer = get_ecdsa_signer();
+
+    // request_credentials must fall through to tier 2 (scope), match
+    // "university_degree" → "UniversityDegreeCredential", and issue a
+    // credential_configuration_id-addressed credential request.
+    let credentials = client
+        .request_credentials(&context, &token, &signer, None)
+        .await
+        .expect("credential request should succeed via scope tier");
+
+    assert_eq!(credentials.len(), 1);
+    match &credentials[0] {
+        CredentialResponse::Immediate(cred) => {
+            assert_eq!(
+                cred.credentials[0].credential.as_str().unwrap(),
+                "scope_issued_credential_jwt"
+            );
+        }
+        _ => panic!("expected immediate credential response"),
+    }
+}
+
+/// Integration test: scope-based issuance when AS omits
+/// `authorization_details_types_supported` entirely but all credential
+/// configurations advertise a `scope` value.
+///
+/// Verifies the new `prefer_authorization_details` heuristic (Fix 2): absent
+/// field + all configs have scope → use scope path rather than defaulting to RAR.
+#[tokio::test]
+async fn test_scope_based_issuance_flow_absent_rar_metadata() {
+    let mock_server = setup_mock_server().await;
+    let issuer_url = mock_server.uri();
+
+    // Issuer metadata: credential config has a scope value.
+    let metadata_json = serde_json::json!({
+        "credential_issuer": issuer_url,
+        "credential_endpoint": format!("{issuer_url}/credential"),
+        "nonce_endpoint": format!("{issuer_url}/nonce"),
+        "authorization_servers": [issuer_url],
+        "credential_configurations_supported": {
+            "DriverLicenseCredential": {
+                "format": "jwt_vc_json",
+                "scope": "drivers_license",
+                "cryptographic_binding_methods_supported": ["jwk"],
+                "credential_signing_alg_values_supported": ["ES256"],
+                "proof_types_supported": {
+                    "jwt": { "proof_signing_alg_values_supported": ["ES256"] }
+                }
+            }
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/.well-known/openid-credential-issuer"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(metadata_json))
+        .mount(&mock_server)
+        .await;
+
+    // AS metadata: authorization_details_types_supported is absent entirely.
+    // Legacy issuers (and national-eID scope-only issuers) typically omit it.
+    let as_metadata_json = serde_json::json!({
+        "issuer": issuer_url.replace("http://", "https://"),
+        "authorization_endpoint": format!("{issuer_url}/authorize").replace("http://", "https://"),
+        "token_endpoint": format!("{issuer_url}/token").replace("http://", "https://"),
+        "pushed_authorization_request_endpoint": format!("{issuer_url}/par").replace("http://", "https://"),
+        "response_types_supported": ["code"],
+        "grant_types_supported": ["urn:ietf:params:oauth:grant-type:pre-authorized_code"],
+        "code_challenge_methods_supported": ["S256"]
+        // authorization_details_types_supported intentionally absent
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(as_metadata_json))
+        .mount(&mock_server)
+        .await;
+
+    // Token response: scope echoed back, no authorization_details.
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "legacy_scope_token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "drivers_license"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/nonce"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "c_nonce": "legacy-nonce"
+        })))
+        .mount(&mock_server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/credential"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "credentials": [{"credential": "legacy_scope_credential_jwt"}]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = create_client();
+
+    let offer = CredentialOffer {
+        credential_issuer: Url::parse(&issuer_url).unwrap(),
+        credential_configuration_ids: vec!["DriverLicenseCredential".to_string()],
+        grants: Some(Grants {
+            authorization_code: None,
+            pre_authorized_code: Some(PreAuthorizedCodeGrant {
+                pre_authorized_code: "legacy_pre_auth_code".to_string(),
+                tx_code: None,
+                authorization_server: None,
+            }),
+        }),
+    };
+
+    let issuer_metadata = client
+        .fetch_issuer_metadata(&Url::parse(&issuer_url).unwrap())
+        .await
+        .unwrap();
+
+    let mut as_metadata = client
+        .fetch_as_metadata(&Url::parse(&issuer_url).unwrap(), &issuer_metadata, &offer)
+        .await
+        .unwrap();
+
+    as_metadata.token_endpoint = Some(Url::parse(&format!("{issuer_url}/token")).unwrap());
+    as_metadata.pushed_authorization_request_endpoint =
+        Some(Url::parse(&format!("{issuer_url}/par")).unwrap());
+
+    // Verify the heuristic: absent field + all configs have scope → scope path.
+    assert!(
+        as_metadata.authorization_details_types_supported.is_none(),
+        "test requires AS metadata without authorization_details_types_supported"
+    );
+    assert!(
+        !prefer_authorization_details(
+            &ResolvedOfferContext {
+                offer: CredentialOffer {
+                    credential_issuer: Url::parse(&issuer_url).unwrap(),
+                    credential_configuration_ids: vec!["DriverLicenseCredential".to_string()],
+                    grants: None,
+                },
+                issuer_metadata: issuer_metadata.clone(),
+                as_metadata: as_metadata.clone(),
+                flow: IssuanceFlow::PreAuthorizedCode {
+                    pre_authorized_code: "x".to_string(),
+                    tx_code: None,
+                },
+            },
+            &["DriverLicenseCredential".to_string()]
+        ),
+        "absent field + config has scope → prefer_authorization_details must return false (use scope)"
+    );
+
+    let mut issuer_metadata = issuer_metadata;
+    issuer_metadata.credential_endpoint = Url::parse(&format!("{issuer_url}/credential")).unwrap();
+    issuer_metadata.nonce_endpoint = Some(Url::parse(&format!("{issuer_url}/nonce")).unwrap());
+
+    let context = ResolvedOfferContext {
+        offer,
+        issuer_metadata,
+        as_metadata,
+        flow: IssuanceFlow::PreAuthorizedCode {
+            pre_authorized_code: "legacy_pre_auth_code".to_string(),
+            tx_code: None,
+        },
+    };
+
+    let token = client
+        .exchange_pre_authorized_code(
+            &context,
+            "legacy_pre_auth_code",
+            None::<String>,
+            &["DriverLicenseCredential".to_string()],
+            None,
+        )
+        .await
+        .expect("token exchange should succeed for legacy scope-only issuer");
+
+    assert_eq!(token.scope.as_deref(), Some("drivers_license"));
+
+    // Verify the token REQUEST body does not carry authorization_details.
+    // This is the B1 regression test: the pre-authorized code token exchange
+    // must respect the scope path even when authorization_details_types_supported
+    // is absent (legacy issuers that only support scope).
+    let token_requests: Vec<_> = mock_server
+        .received_requests()
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|r| r.url.path() == "/token")
+        .collect();
+    assert_eq!(
+        token_requests.len(),
+        1,
+        "expected exactly one /token request"
+    );
+    let token_body = std::str::from_utf8(&token_requests[0].body).unwrap();
+    assert!(
+        !token_body.contains("authorization_details"),
+        "scope-path token request must not include authorization_details; body: {token_body}"
+    );
+
+    let signer = get_ecdsa_signer();
+
+    let credentials = client
+        .request_credentials(&context, &token, &signer, None)
+        .await
+        .expect("credential request should succeed via scope tier for legacy issuer");
+
+    assert_eq!(credentials.len(), 1);
+    match &credentials[0] {
+        CredentialResponse::Immediate(cred) => {
+            assert_eq!(
+                cred.credentials[0].credential.as_str().unwrap(),
+                "legacy_scope_credential_jwt"
+            );
+        }
+        _ => panic!("expected immediate credential response"),
+    }
+}
+
 fn create_wallet_attestation_signer() -> WalletAttestationSigner {
     let provider_keypair = EcdsaKeyPair::generate(Curve::P256).unwrap();
     let provider_der = provider_keypair.to_pkcs8_der().to_vec();
@@ -627,10 +1043,31 @@ fn resolve_via_authorization_details_returns_none_when_absent() {
 
 #[test]
 fn resolve_via_authorization_details_skips_entries_without_identifiers() {
+    // authorization_details present but no credential_identifiers on any entry.
+    // Must return None so the caller falls back to scope/offer tier, and must
+    // not panic.  The warn! log is the operator-facing signal (not testable
+    // here without a tracing subscriber, but covered by the function contract).
     let details = AuthorizationDetails::for_configuration("NoIds");
     let token = token_response(None, Some(vec![details]));
 
     assert!(resolve_via_authorization_details(&token).is_none());
+}
+
+#[test]
+fn resolve_via_authorization_details_returns_none_and_falls_back_when_all_identifiers_empty() {
+    // Some ASes emit authorization_details with credential_identifiers: []
+    // (explicitly empty rather than absent).  The wallet must treat this the
+    // same as missing identifiers — fall back — not treat it as "zero credentials."
+    let mut detail_a = AuthorizationDetails::for_configuration("CredA");
+    detail_a.credential_identifiers = Some(vec![]); // explicitly empty
+    let mut detail_b = AuthorizationDetails::for_configuration("CredB");
+    detail_b.credential_identifiers = Some(vec![]); // explicitly empty
+    let token = token_response(None, Some(vec![detail_a, detail_b]));
+
+    assert!(
+        resolve_via_authorization_details(&token).is_none(),
+        "explicitly empty credential_identifiers arrays must also trigger fallback"
+    );
 }
 
 #[test]
@@ -780,6 +1217,53 @@ fn resolve_credential_targets_errors_when_nothing_resolvable() {
 
     let result = resolve_credential_targets(&context, &token);
     assert!(result.is_err());
+}
+
+// build_scope_to_config_id_map
+
+#[test]
+fn scope_map_contains_offered_configs_with_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let issuer_metadata = issuer_metadata_with_configs(
+        issuer_url,
+        &[
+            ("CredA", Some("scope_a")),
+            ("CredB", Some("scope_b")),
+            ("CredNoScope", None),
+            ("CredNotOffered", Some("scope_not_offered")),
+        ],
+    );
+    let offer_ids = vec![
+        "CredA".to_string(),
+        "CredB".to_string(),
+        "CredNoScope".to_string(),
+    ];
+
+    let map = build_scope_to_config_id_map(&issuer_metadata, &offer_ids);
+
+    assert_eq!(map.get("scope_a").map(String::as_str), Some("CredA"));
+    assert_eq!(map.get("scope_b").map(String::as_str), Some("CredB"));
+    assert!(
+        !map.contains_key("scope_not_offered"),
+        "CredNotOffered is not in the offer and must not appear in the map"
+    );
+    assert_eq!(
+        map.len(),
+        2,
+        "CredNoScope has no scope value and must be excluded"
+    );
+}
+
+#[test]
+fn scope_map_is_empty_when_no_offered_config_has_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let issuer_metadata =
+        issuer_metadata_with_configs(issuer_url, &[("CredA", None), ("CredB", None)]);
+    let offer_ids = vec!["CredA".to_string(), "CredB".to_string()];
+
+    let map = build_scope_to_config_id_map(&issuer_metadata, &offer_ids);
+
+    assert!(map.is_empty());
 }
 
 //  build_scope
@@ -967,24 +1451,6 @@ async fn build_authorization_url_errors_when_neither_rar_nor_scope_available() {
     assert!(result.is_err());
 }
 
-#[test]
-fn resolve_credential_configuration_id_prefers_config_based_selector() {
-    let selector = CredIdOrCredConfigId::credential_configuration_id("FromSelector");
-    assert_eq!(
-        resolve_credential_configuration_id(&selector, "FromFallback"),
-        "FromSelector"
-    );
-}
-
-#[test]
-fn resolve_credential_configuration_id_falls_back_for_identifier_selector() {
-    let selector = CredIdOrCredConfigId::credential_identifier("cred-1");
-    assert_eq!(
-        resolve_credential_configuration_id(&selector, "FromFallback"),
-        "FromFallback"
-    );
-}
-
 #[tokio::test]
 async fn credential_response_parse_failure_includes_raw_body() {
     let mock_server = setup_mock_server().await;
@@ -1018,6 +1484,107 @@ async fn credential_response_parse_failure_includes_raw_body() {
     assert!(
         message.contains("not valid json"),
         "error should include the raw response body, got: {message}"
+    );
+}
+
+// prefer_authorization_details
+
+#[test]
+fn prefer_rar_when_openid_credential_explicitly_listed() {
+    let issuer_url = "https://issuer.example.com";
+    let mut context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("CredA", Some("scope_a"))]),
+        vec!["CredA".to_string()],
+        Some(vec!["openid_credential".to_string()]),
+    );
+    context.as_metadata.authorization_details_types_supported =
+        Some(vec!["openid_credential".to_string()]);
+    assert!(
+        prefer_authorization_details(&context, &["CredA".to_string()]),
+        "explicit openid_credential support must use RAR"
+    );
+}
+
+#[test]
+fn prefer_scope_when_openid_credential_explicitly_absent() {
+    let issuer_url = "https://issuer.example.com";
+    let mut context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("CredA", Some("scope_a"))]),
+        vec!["CredA".to_string()],
+        Some(vec!["other_type".to_string()]),
+    );
+    context.as_metadata.authorization_details_types_supported =
+        Some(vec!["other_type".to_string()]);
+    assert!(
+        !prefer_authorization_details(&context, &["CredA".to_string()]),
+        "explicit exclusion of openid_credential must use scope"
+    );
+}
+
+#[test]
+fn prefer_scope_when_field_absent_and_all_configs_have_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let mut context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("CredA", Some("scope_a")), ("CredB", Some("scope_b"))],
+        ),
+        vec!["CredA".to_string(), "CredB".to_string()],
+        None,
+    );
+    context.as_metadata.authorization_details_types_supported = None;
+    assert!(
+        !prefer_authorization_details(&context, &["CredA".to_string(), "CredB".to_string()]),
+        "absent field + all configs have scope → must prefer scope (legacy issuer heuristic)"
+    );
+}
+
+#[test]
+fn prefer_rar_when_field_absent_and_a_config_has_no_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let mut context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("CredA", Some("scope_a")), ("CredB", None)]),
+        vec!["CredA".to_string(), "CredB".to_string()],
+        None,
+    );
+    context.as_metadata.authorization_details_types_supported = None;
+    assert!(
+        prefer_authorization_details(&context, &["CredA".to_string(), "CredB".to_string()]),
+        "absent field + any config without scope → must fall back to RAR"
+    );
+}
+
+// resolve_via_scope offer-boundary enforcement (Fix 1)
+
+#[test]
+fn resolve_via_scope_does_not_match_configs_outside_the_offer() {
+    let issuer_url = "https://issuer.example.com";
+    // Issuer publishes two configs: only OfferedCred is in the offer.
+    // UnofferedCred is present in the catalog but was never offered/selected.
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("OfferedCred", Some("offered_scope")),
+                ("UnofferedCred", Some("unoffered_scope")),
+            ],
+        ),
+        vec!["OfferedCred".to_string()], // offer only contains OfferedCred
+    );
+    // Token response grants both scopes (e.g. AS echoes default scopes).
+    let token = token_response(Some("offered_scope unoffered_scope"), None);
+
+    let matched = resolve_via_scope(&context, &token).expect("should resolve OfferedCred");
+
+    assert_eq!(
+        matched,
+        vec!["OfferedCred".to_string()],
+        "UnofferedCred must not be included even though its scope matches the granted scope"
     );
 }
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/client/tests.rs
@@ -505,6 +505,7 @@ fn minimal_as_metadata(par_url: &str) -> AuthorizationServerMetadata {
         pushed_authorization_request_endpoint: Some(Url::parse(par_url).unwrap()),
         require_pushed_authorization_requests: None,
         pre_authorized_grant_anonymous_access_supported: None,
+        authorization_details_types_supported: None,
         extra_fields: HashMap::new(),
     }
 }
@@ -604,7 +605,10 @@ fn minimal_context(
     }
 }
 
-fn token_response(scope: Option<&str>, authorization_details: Option<Vec<AuthorizationDetails>>) -> TokenResponse {
+fn token_response(
+    scope: Option<&str>,
+    authorization_details: Option<Vec<AuthorizationDetails>>,
+) -> TokenResponse {
     TokenResponse {
         access_token: "test_access_token".to_string(),
         token_type: "Bearer".to_string(),
@@ -647,7 +651,10 @@ fn resolve_via_scope_returns_none_when_no_scope() {
     let issuer_url = "https://issuer.example.com";
     let context = minimal_context(
         issuer_url,
-        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
         vec!["UniversityDegreeCredential".to_string()],
     );
     let token = token_response(None, None);
@@ -660,7 +667,10 @@ fn resolve_via_scope_returns_none_when_no_configuration_matches() {
     let issuer_url = "https://issuer.example.com";
     let context = minimal_context(
         issuer_url,
-        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
         vec!["UniversityDegreeCredential".to_string()],
     );
     let token = token_response(Some("unrelated_scope"), None);
@@ -723,7 +733,10 @@ fn resolve_credential_targets_falls_back_to_scope_when_no_authorization_details(
     let issuer_url = "https://issuer.example.com";
     let context = minimal_context(
         issuer_url,
-        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", Some("university_degree"))]),
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
         vec!["UniversityDegreeCredential".to_string()],
     );
     let token = token_response(Some("university_degree"), None);
@@ -769,6 +782,191 @@ fn resolve_credential_targets_errors_when_nothing_resolvable() {
     assert!(result.is_err());
 }
 
+//  build_scope
+
+#[test]
+fn build_scope_joins_scopes_of_selected_configurations() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("UniversityDegreeCredential", Some("university_degree")),
+                ("DriversLicenseCredential", Some("drivers_license")),
+            ],
+        ),
+        vec![
+            "UniversityDegreeCredential".to_string(),
+            "DriversLicenseCredential".to_string(),
+        ],
+    );
+
+    let scope = build_scope(
+        &context,
+        &[
+            "UniversityDegreeCredential".to_string(),
+            "DriversLicenseCredential".to_string(),
+        ],
+    )
+    .expect("scope should build when every selected config has a scope");
+
+    assert_eq!(scope, "university_degree drivers_license");
+}
+
+#[test]
+fn build_scope_errors_when_a_selected_configuration_has_no_scope() {
+    let issuer_url = "https://issuer.example.com";
+    let context = minimal_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[
+                ("UniversityDegreeCredential", Some("university_degree")),
+                ("DriversLicenseCredential", None),
+            ],
+        ),
+        vec![
+            "UniversityDegreeCredential".to_string(),
+            "DriversLicenseCredential".to_string(),
+        ],
+    );
+
+    // Must fail loud rather than silently building a scope string that omits
+    // DriversLicenseCredential - a partial scope grant would silently drop a
+    // credential the user selected.
+    let result = build_scope(
+        &context,
+        &[
+            "UniversityDegreeCredential".to_string(),
+            "DriversLicenseCredential".to_string(),
+        ],
+    );
+    assert!(result.is_err());
+}
+
+//  build_authorization_url: RAR vs scope preference
+
+/// Builds a [`ResolvedOfferContext`] for the authorization code flow, with no
+/// `pushed_authorization_request_endpoint` so `build_authorization_url` takes
+/// the plain (non-PAR) path and can be exercised without a mock server.
+fn authz_code_context(
+    issuer_url: &str,
+    issuer_metadata: CredentialIssuerMetadata,
+    offer_config_ids: Vec<String>,
+    authorization_details_types_supported: Option<Vec<String>>,
+) -> ResolvedOfferContext {
+    let mut as_metadata = minimal_as_metadata(&format!("{issuer_url}/par"));
+    as_metadata.authorization_endpoint =
+        Some(Url::parse(&format!("{issuer_url}/authorize")).unwrap());
+    as_metadata.pushed_authorization_request_endpoint = None;
+    as_metadata.authorization_details_types_supported = authorization_details_types_supported;
+
+    ResolvedOfferContext {
+        offer: minimal_offer(issuer_url, offer_config_ids),
+        issuer_metadata,
+        as_metadata,
+        flow: IssuanceFlow::AuthorizationCode { issuer_state: None },
+    }
+}
+
+fn query_pairs(url: &Url) -> HashMap<String, String> {
+    url.query_pairs()
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect()
+}
+
+#[tokio::test]
+async fn build_authorization_url_prefers_authorization_details_when_as_supports_it() {
+    let issuer_url = "https://issuer.example.com";
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
+        vec!["UniversityDegreeCredential".to_string()],
+        Some(vec!["openid_credential".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await
+        .expect("should build authorization url");
+
+    let params = query_pairs(&result.authz_url);
+    assert!(
+        params.contains_key("authorization_details"),
+        "expected authorization_details param, got: {params:?}"
+    );
+    assert!(
+        !params.contains_key("scope"),
+        "RAR path must not also send scope, got: {params:?}"
+    );
+}
+
+#[tokio::test]
+async fn build_authorization_url_falls_back_to_scope_when_as_does_not_support_rar() {
+    let issuer_url = "https://issuer.example.com";
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(
+            issuer_url,
+            &[("UniversityDegreeCredential", Some("university_degree"))],
+        ),
+        vec!["UniversityDegreeCredential".to_string()],
+        // AS explicitly advertises RAR support for a different type only.
+        Some(vec!["some_other_type".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await
+        .expect("should build authorization url");
+
+    let params = query_pairs(&result.authz_url);
+    assert_eq!(
+        params.get("scope").map(String::as_str),
+        Some("university_degree")
+    );
+    assert!(
+        !params.contains_key("authorization_details"),
+        "scope path must not also send authorization_details, got: {params:?}"
+    );
+}
+
+#[tokio::test]
+async fn build_authorization_url_errors_when_neither_rar_nor_scope_available() {
+    let issuer_url = "https://issuer.example.com";
+    let context = authz_code_context(
+        issuer_url,
+        issuer_metadata_with_configs(issuer_url, &[("UniversityDegreeCredential", None)]),
+        vec!["UniversityDegreeCredential".to_string()],
+        Some(vec!["some_other_type".to_string()]),
+    );
+    let client = create_client();
+
+    let result = client
+        .build_authorization_url(
+            &context,
+            "state123",
+            &["UniversityDegreeCredential".to_string()],
+        )
+        .await;
+
+    assert!(result.is_err());
+}
+
 #[test]
 fn resolve_credential_configuration_id_prefers_config_based_selector() {
     let selector = CredIdOrCredConfigId::credential_configuration_id("FromSelector");
@@ -799,7 +997,8 @@ async fn credential_response_parse_failure_includes_raw_body() {
         .await;
 
     let client = create_client();
-    let mut issuer_metadata = issuer_metadata_with_configs(&issuer_url, &[("TestCredential", None)]);
+    let mut issuer_metadata =
+        issuer_metadata_with_configs(&issuer_url, &[("TestCredential", None)]);
     issuer_metadata.credential_endpoint = Url::parse(&format!("{issuer_url}/credential")).unwrap();
     let context = minimal_context(
         &issuer_url,

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/credential/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/credential/response.rs
@@ -52,14 +52,22 @@ pub struct ImmediateCredentialResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_id: Option<String>,
 
-    /// Fresh `c_nonce` for subsequent credential requests.
+    /// Fresh `c_nonce` returned directly in the credential response.
     ///
-    /// Returned directly in the credential response by issuers on older
-    /// OID4VCI drafts, before the dedicated nonce endpoint was introduced.
+    /// Some issuers on older OID4VCI drafts return a nonce here instead of
+    /// (or in addition to) the dedicated nonce endpoint introduced in later
+    /// drafts.  The field is parsed for wire compatibility and round-trip
+    /// fidelity, but the wallet's nonce-resolution logic (`resolve_nonce`)
+    /// currently uses the dedicated `nonce_endpoint` only.  Reading this
+    /// field directly is valid; it does not affect proof construction in the
+    /// current implementation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub c_nonce: Option<String>,
 
-    /// Lifetime in seconds of `c_nonce`.
+    /// Lifetime in seconds of [`Self::c_nonce`].
+    ///
+    /// Parsed for wire compatibility; see [`Self::c_nonce`] for the current
+    /// consumption caveat.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub c_nonce_expires_in: Option<u64>,
 }
@@ -76,12 +84,6 @@ impl ImmediateCredentialResponse {
 
     pub fn with_notification_id(mut self, id: impl Into<String>) -> Self {
         self.notification_id = Some(id.into());
-        self
-    }
-
-    pub fn with_c_nonce(mut self, c_nonce: impl Into<String>, expires_in: Option<u64>) -> Self {
-        self.c_nonce = Some(c_nonce.into());
-        self.c_nonce_expires_in = expires_in;
         self
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/credential/response.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/credential/response.rs
@@ -51,6 +51,17 @@ pub struct ImmediateCredentialResponse {
     /// Identifier for notification requests.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_id: Option<String>,
+
+    /// Fresh `c_nonce` for subsequent credential requests.
+    ///
+    /// Returned directly in the credential response by issuers on older
+    /// OID4VCI drafts, before the dedicated nonce endpoint was introduced.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub c_nonce: Option<String>,
+
+    /// Lifetime in seconds of `c_nonce`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub c_nonce_expires_in: Option<u64>,
 }
 
 impl ImmediateCredentialResponse {
@@ -58,11 +69,19 @@ impl ImmediateCredentialResponse {
         Self {
             credentials,
             notification_id: None,
+            c_nonce: None,
+            c_nonce_expires_in: None,
         }
     }
 
     pub fn with_notification_id(mut self, id: impl Into<String>) -> Self {
         self.notification_id = Some(id.into());
+        self
+    }
+
+    pub fn with_c_nonce(mut self, c_nonce: impl Into<String>, expires_in: Option<u64>) -> Self {
+        self.c_nonce = Some(c_nonce.into());
+        self.c_nonce_expires_in = expires_in;
         self
     }
 }
@@ -266,5 +285,36 @@ mod tests {
         }"#;
 
         assert!(serde_json::from_str::<DeferredCredentialResult>(json).is_err());
+    }
+
+    #[test]
+    fn deserialize_immediate_response_with_c_nonce() {
+        // Older OID4VCI drafts returned a fresh c_nonce directly in the
+        // credential response, before the dedicated nonce endpoint existed.
+        let json = r#"{
+            "credentials": [
+                {"credential": "eyJhbGciOiJFUzI1NiJ9..."}
+            ],
+            "c_nonce": "fresh-nonce",
+            "c_nonce_expires_in": 86400
+        }"#;
+
+        let response: ImmediateCredentialResponse =
+            serde_json::from_str(json).expect("Failed to deserialize");
+
+        assert_eq!(response.c_nonce.as_deref(), Some("fresh-nonce"));
+        assert_eq!(response.c_nonce_expires_in, Some(86400));
+    }
+
+    #[test]
+    fn immediate_response_omits_c_nonce_when_absent() {
+        let response = ImmediateCredentialResponse::new(vec![CredentialObject::new_string(
+            "eyJhbGciOiJFUzI1NiJ9...",
+        )]);
+
+        let json = serde_json::to_value(&response).expect("Failed to serialize");
+
+        assert!(json.get("c_nonce").is_none());
+        assert!(json.get("c_nonce_expires_in").is_none());
     }
 }

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/metadata/authz_server.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/metadata/authz_server.rs
@@ -124,6 +124,17 @@ pub struct AuthorizationServerMetadata {
     #[serde(rename = "pre-authorized_grant_anonymous_access_supported")]
     pub pre_authorized_grant_anonymous_access_supported: Option<bool>,
 
+    //  RFC 9396 (Rich Authorization Requests) parameter
+    /// OPTIONAL. Authorization details type values this server supports.
+    ///
+    /// Defined in [RFC 9396 §9.1](https://www.rfc-editor.org/rfc/rfc9396.html#section-9.1).
+    /// For OID4VCI, a wallet should only rely on RAR (`authorization_details`)
+    /// to request credentials when this list contains `"openid_credential"`
+    /// (OID4VCI §5.1.1). Many issuers do not publish this parameter at all
+    /// despite supporting RAR, so its absence is treated as "unknown" rather
+    /// than "unsupported" by [`Self::supports_openid_credential_authorization_details`].
+    pub authorization_details_types_supported: Option<Vec<String>>,
+
     /// Catch-all for additional metadata parameters defined by other
     /// specifications or by the AS itself.
     ///
@@ -221,6 +232,18 @@ impl AuthorizationServerMetadata {
         self.pre_authorized_grant_anonymous_access_supported
             .unwrap_or(false)
     }
+
+    /// Returns true if the AS can be relied on to accept `authorization_details`
+    /// of type `openid_credential` (OID4VCI §5.1.1).
+    ///
+    /// When `authorization_details_types_supported` is absent, support is
+    /// assumed (many issuers implement RAR without publishing this RFC 9396
+    /// metadata field). When present, `"openid_credential"` must be listed.
+    pub fn supports_openid_credential_authorization_details(&self) -> bool {
+        self.authorization_details_types_supported
+            .as_ref()
+            .is_none_or(|types| types.iter().any(|t| t == "openid_credential"))
+    }
 }
 
 #[cfg(test)]
@@ -258,6 +281,7 @@ mod tests {
             pushed_authorization_request_endpoint: None,
             require_pushed_authorization_requests: None,
             pre_authorized_grant_anonymous_access_supported: None,
+            authorization_details_types_supported: None,
             extra_fields: std::collections::HashMap::new(),
         }
     }
@@ -383,6 +407,44 @@ mod tests {
         let mut m = minimal_metadata();
         m.pre_authorized_grant_anonymous_access_supported = Some(false);
         assert!(!m.allows_anonymous_pre_authorized_grant());
+    }
+
+    //  supports_openid_credential_authorization_details
+
+    #[test]
+    fn rar_support_assumed_when_field_absent() {
+        assert!(
+            minimal_metadata().supports_openid_credential_authorization_details(),
+            "absence of authorization_details_types_supported must not be read as unsupported"
+        );
+    }
+
+    #[test]
+    fn rar_support_true_when_openid_credential_listed() {
+        let mut m = minimal_metadata();
+        m.authorization_details_types_supported = Some(vec![
+            "openid_credential".to_string(),
+            "other_type".to_string(),
+        ]);
+        assert!(m.supports_openid_credential_authorization_details());
+    }
+
+    #[test]
+    fn rar_support_false_when_openid_credential_not_listed() {
+        let mut m = minimal_metadata();
+        m.authorization_details_types_supported = Some(vec!["other_type".to_string()]);
+        assert!(!m.supports_openid_credential_authorization_details());
+    }
+
+    #[test]
+    fn parses_authorization_details_types_supported_from_real_keycloak_metadata() {
+        let original = include_str!("../../../test_data/keycloak_as_metadata.json");
+        let metadata: AuthorizationServerMetadata = serde_json::from_str(original).unwrap();
+        assert_eq!(
+            metadata.authorization_details_types_supported,
+            Some(vec!["openid_credential".to_string()])
+        );
+        assert!(metadata.supports_openid_credential_authorization_details());
     }
 
     // AuthorizationServerMetadata serialization

--- a/crates/cloud-wallet-openid4vc/src/oid4vci/metadata/authz_server.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vci/metadata/authz_server.rs
@@ -239,6 +239,18 @@ impl AuthorizationServerMetadata {
     /// When `authorization_details_types_supported` is absent, support is
     /// assumed (many issuers implement RAR without publishing this RFC 9396
     /// metadata field). When present, `"openid_credential"` must be listed.
+    ///
+    /// # HAIP profile note
+    ///
+    /// HAIP §4.2 mandates `scope`-based credential selection and does **not**
+    /// require `authorization_details` support.  HAIP-profile issuers (e.g.
+    /// national eID ecosystems) typically do not publish
+    /// `authorization_details_types_supported`, so this method returns `true`
+    /// for them — which is incorrect for that profile.  Call sites that need
+    /// to account for scope-only issuers should use
+    /// `prefer_authorization_details` in `client/mod.rs` instead; it
+    /// cross-checks credential configuration `scope` values as a tie-breaker
+    /// when this field is absent.
     pub fn supports_openid_credential_authorization_details(&self) -> bool {
         self.authorization_details_types_supported
             .as_ref()

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/request_uri.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/authorization/request_uri.rs
@@ -278,6 +278,7 @@ mod tests {
             pushed_authorization_request_endpoint: None,
             require_pushed_authorization_requests: None,
             pre_authorized_grant_anonymous_access_supported: None,
+            authorization_details_types_supported: None,
             extra_fields: HashMap::new(),
         };
 

--- a/crates/cloud-wallet-openid4vc/src/oid4vp/metadata/wallet.rs
+++ b/crates/cloud-wallet-openid4vc/src/oid4vp/metadata/wallet.rs
@@ -266,6 +266,7 @@ mod tests {
             pushed_authorization_request_endpoint: None,
             require_pushed_authorization_requests: None,
             pre_authorized_grant_anonymous_access_supported: None,
+            authorization_details_types_supported: None,
             extra_fields: HashMap::new(),
         }
     }

--- a/src/domain/models/issuance/tests.rs
+++ b/src/domain/models/issuance/tests.rs
@@ -1176,6 +1176,7 @@ async fn ldp_vc_json_object_credential_is_converted_to_string_not_rejected_as_in
             pushed_authorization_request_endpoint: None,
             require_pushed_authorization_requests: None,
             pre_authorized_grant_anonymous_access_supported: None,
+            authorization_details_types_supported: None,
             extra_fields: HashMap::new(),
         },
         flow: IssuanceFlow::PreAuthorizedCode {


### PR DESCRIPTION
Add support for scope-based credential configuration selection per [OID4VCI §5.1.2](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-5.1.2). Currently the wallet only selects credentials using `credential_configuration_ids` from the offer (the Rich Authorization Request style). This leaves scope-based issuers unsupported.

### Background

Per OID4VCI, there are two ways a wallet can communicate which credentials it wants:

1. **RAR / `authorization_details`** (currently implemented): The credential offer lists `credential_configuration_ids`, and the wallet passes `authorization_details` with `type: "openid_credential"` and the chosen configuration IDs in the authorization request.

2. **Scope-based** (not yet implemented): The authorization request includes one or more `scope` values that map to `credential_configuration_ids` via the issuer's `scope` metadata field. The wallet resolves scope → credential configuration ID and proceeds.

Some issuers (notably older OID4VCI draft implementations and certain national eID ecosystems) only advertise `scope` mappings and do not support `authorization_details`. The wallet must support both.

### Scope

1. **Parse scope mappings from issuer metadata**:
   - When resolving `credential_configurations_supported`, check each entry for a `scope` field
   - Build a `HashMap<String, String>` mapping `scope → credential_configuration_id`

2. **Authorization request construction**:
   - If `authorization_details` is supported (per AS metadata `authorization_details_types_supported`), use the current RAR flow
   - If the AS does not advertise `authorization_details` support but does advertise `scope` values, construct a standard OAuth2 authorization request with `scope=<space-separated scoped-values>`
   - If both are available, prefer `authorization_details` (per HAIP §4.3)

3. **Token exchange**:
   - When using scope-based flow, the token request includes `scope` and must NOT include `authorization_details`
   - When using RAR flow, the token request includes `authorization_details` as today

4. **Fallback logic** (`request_credentials` refactoring):
   - Extend the existing `request_credentials` to try three resolution strategies in order:
     1. `authorization_details` with `credential_configuration_ids` (current behavior)
     2. Scope-based resolution using `scope` → `credential_configuration_id` mapping
     3. Offer-based credential selection when no scope or auth details are present
   - This aligns with and extends #364 (which already introduces the 3-tier fallback pattern for `request_credentials`)

5. **Configuration**:
   - No new configuration needed — scope values are resolved dynamically from issuer metadata
   - Logging: when scope-based resolution is used, log the scope → config ID mapping for observability

### Tests

- Unit test: parse `scope` from `credential_configurations_supported` and build the mapping
- Unit test: scope-based authorization request has correct `scope` parameter
- Unit test: preference order — when both `authorization_details` and `scope` are available, `authorization_details` is used
- Integration test: end-to-end flow with a mock AS that only supports scope-based auth

### Acceptance Criteria

- [ ] `scope` values are parsed from issuer metadata `credential_configurations_supported`
- [ ] Scope → credential_configuration_id mapping is built and used for resolution
- [ ] Authorization request uses `scope` when AS does not support `authorization_details`
- [ ] Authorization request uses `authorization_details` when AS supports it (current behavior unchanged)
- [ ] Three-tier fallback in `request_credentials` works: authorization_details → scope → offer-based
- [ ] Existing RAR-based issuance tests pass unchanged
- [ ] New scope-based test with mock AS passes

### Spec References

- [OID4VCI §5.1.2 — Scope-based Credential Configuration](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-5.1.2)
- [OID4VCI §5.1.1 — Authorization Details-based Credential Configuration](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#section-5.1.1)
- [HAIP §4.3 — Credential Offer](https://openid.net/specs/openid4vc-high-assurance-interoperability-profile-1_0.html#section-4.3)